### PR TITLE
V2.2 Add NumberSequence slot type for spoken digit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-05
+
+### Added
+
+- `NumberSequence` slot type for digit-word commands (e.g., "heading two seven zero" → 270).
+- `VoskNumberParser` with `ParseDigitSequence` and `ParseCardinal` for converting spoken digit words to integers.
+- `VoskSlotDefinition.NumberSequence()` factory with configurable `minWords`/`maxWords` greedy matching.
+- Digit vocabulary automatically merged into grammar JSON when NumberSequence slots are registered.
+- Sample `set_heading` command with heading + optional elevation NumberSequence slots in `CommandDemo.cs`.
+- Quest device test matrix (`v2.2-test-matrix.md`) with 40 tests across 11 phases — 31 pass, 1 fail (free speech homophone), 4 known limitations/skips.
+
+### Known Limitations
+
+- Mid-command pauses exceeding VOSK's VAD silence threshold split speech into independent utterances, preventing cross-utterance command matching (test 9.2). This is rare in grammar mode with crisp commands.
+- Free speech mode: VOSK may transcribe digit homophones incorrectly ("two" → "to", "orient" → "korean"). Grammar mode is recommended for production use.
+
 ## [0.5.1] - 2026-04-05
 
 ### Fixed

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -495,19 +495,30 @@ namespace VoskXR.Commands
             while (idx < tokens.Length && tokens[idx] == UnkToken)
                 idx++;
 
-            var matched = new List<string>();
-            while (matched.Count < maxWords && idx < tokens.Length
+            int matchStart = idx;
+            int count = 0;
+            while (count < maxWords && idx < tokens.Length
                 && VoskNumberParser.DigitVocabulary.Contains(tokens[idx]))
             {
-                matched.Add(tokens[idx]);
+                count++;
                 idx++;
             }
 
-            if (matched.Count < minWords)
+            if (count < minWords)
                 return null;
 
             consumed = idx - startIdx;
-            return string.Join(" ", matched);
+
+            if (count == 1)
+                return tokens[matchStart];
+
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append(tokens[matchStart + i]);
+            }
+            return sb.ToString();
         }
 
         float ComputeConfidence(string[] tokens, int startIdx, List<VoskSlotMatch> slots,

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -322,6 +322,17 @@ namespace VoskXR.Commands
                 }
             }
 
+            // Add digit vocabulary when any NumberSequence slot exists
+            foreach (var slot in _slots)
+            {
+                if (slot.Type == VoskSlotType.NumberSequence)
+                {
+                    foreach (string word in VoskNumberParser.DigitVocabulary)
+                        uniqueWords.Add(word);
+                    break;
+                }
+            }
+
             uniqueWords.Add(UnkToken);
 
             // Build JSON array
@@ -376,7 +387,14 @@ namespace VoskXR.Commands
                     if (!_slotIndex.TryGetValue(slotName, out int slotIdx))
                         return default;
 
-                    string matchedValue = TryMatchSlot(tokens, tokenIdx, slotIdx, out int consumed);
+                    string matchedValue;
+                    int consumed;
+                    if (_slots[slotIdx].Type == VoskSlotType.NumberSequence)
+                        matchedValue = TryMatchNumberSequence(tokens, tokenIdx,
+                            _slots[slotIdx].MinWords, _slots[slotIdx].MaxWords, out consumed);
+                    else
+                        matchedValue = TryMatchSlot(tokens, tokenIdx, slotIdx, out consumed);
+
                     if (matchedValue != null)
                     {
                         if (slots == null)
@@ -467,6 +485,29 @@ namespace VoskXR.Commands
             }
 
             return null;
+        }
+
+        string TryMatchNumberSequence(string[] tokens, int startIdx, int minWords, int maxWords, out int consumed)
+        {
+            consumed = 0;
+            int idx = startIdx;
+
+            while (idx < tokens.Length && tokens[idx] == UnkToken)
+                idx++;
+
+            var matched = new List<string>();
+            while (matched.Count < maxWords && idx < tokens.Length
+                && VoskNumberParser.DigitVocabulary.Contains(tokens[idx]))
+            {
+                matched.Add(tokens[idx]);
+                idx++;
+            }
+
+            if (matched.Count < minWords)
+                return null;
+
+            consumed = idx - startIdx;
+            return string.Join(" ", matched);
         }
 
         float ComputeConfidence(string[] tokens, int startIdx, List<VoskSlotMatch> slots,

--- a/Runtime/Commands/VoskNumberParser.cs
+++ b/Runtime/Commands/VoskNumberParser.cs
@@ -10,19 +10,6 @@ namespace VoskXR.Commands
     /// </summary>
     public static class VoskNumberParser
     {
-        /// <summary>
-        /// All number words recognized by the parser (~30 entries).
-        /// Used for greedy token matching and grammar generation.
-        /// </summary>
-        public static readonly HashSet<string> DigitVocabulary = new HashSet<string>(StringComparer.Ordinal)
-        {
-            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
-            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
-            "sixteen", "seventeen", "eighteen", "nineteen",
-            "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
-            "hundred", "thousand"
-        };
-
         static readonly Dictionary<string, int> WordValues = new Dictionary<string, int>(30, StringComparer.Ordinal)
         {
             { "zero", 0 }, { "one", 1 }, { "two", 2 }, { "three", 3 }, { "four", 4 },
@@ -34,6 +21,13 @@ namespace VoskXR.Commands
             { "sixty", 60 }, { "seventy", 70 }, { "eighty", 80 }, { "ninety", 90 },
             { "hundred", 100 }, { "thousand", 1000 }
         };
+
+        /// <summary>
+        /// All number words recognized by the parser.
+        /// Derived from WordValues to maintain a single source of truth.
+        /// </summary>
+        public static readonly HashSet<string> DigitVocabulary =
+            new HashSet<string>(WordValues.Keys, StringComparer.Ordinal);
 
         static readonly char[] SplitSeparator = { ' ' };
 

--- a/Runtime/Commands/VoskNumberParser.cs
+++ b/Runtime/Commands/VoskNumberParser.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Converts spoken number-word sequences to integers.
+    /// Provides the digit vocabulary used by <see cref="VoskCommandParser"/> for
+    /// NumberSequence slot matching and grammar generation.
+    /// </summary>
+    public static class VoskNumberParser
+    {
+        /// <summary>
+        /// All number words recognized by the parser (~30 entries).
+        /// Used for greedy token matching and grammar generation.
+        /// </summary>
+        public static readonly HashSet<string> DigitVocabulary = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+            "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+            "sixteen", "seventeen", "eighteen", "nineteen",
+            "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+            "hundred", "thousand"
+        };
+
+        static readonly Dictionary<string, int> WordValues = new Dictionary<string, int>(30, StringComparer.Ordinal)
+        {
+            { "zero", 0 }, { "one", 1 }, { "two", 2 }, { "three", 3 }, { "four", 4 },
+            { "five", 5 }, { "six", 6 }, { "seven", 7 }, { "eight", 8 }, { "nine", 9 },
+            { "ten", 10 }, { "eleven", 11 }, { "twelve", 12 }, { "thirteen", 13 },
+            { "fourteen", 14 }, { "fifteen", 15 }, { "sixteen", 16 }, { "seventeen", 17 },
+            { "eighteen", 18 }, { "nineteen", 19 },
+            { "twenty", 20 }, { "thirty", 30 }, { "forty", 40 }, { "fifty", 50 },
+            { "sixty", 60 }, { "seventy", 70 }, { "eighty", 80 }, { "ninety", 90 },
+            { "hundred", 100 }, { "thousand", 1000 }
+        };
+
+        static readonly char[] SplitSeparator = { ' ' };
+
+        /// <summary>
+        /// Parses a digit-per-word sequence by concatenating single digits.
+        /// Each word must map to 0–9. "two seven zero" → 270, "one five" → 15.
+        /// </summary>
+        /// <returns>The concatenated integer, or 0 for null/empty input.</returns>
+        /// <exception cref="FormatException">A word is not a single digit (0–9).</exception>
+        public static int ParseDigitSequence(string words)
+        {
+            if (string.IsNullOrWhiteSpace(words))
+                return 0;
+
+            string[] tokens = words.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+            int result = 0;
+
+            foreach (string token in tokens)
+            {
+                if (!WordValues.TryGetValue(token, out int value) || value > 9)
+                    throw new FormatException($"'{token}' is not a single-digit word (zero–nine).");
+
+                result = result * 10 + value;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Parses a cardinal number phrase. Handles teens, tens, hundreds, and thousands.
+        /// "fifteen" → 15, "twenty" → 20, "two hundred" → 200.
+        /// </summary>
+        /// <returns>The parsed integer, or 0 for null/empty input.</returns>
+        /// <exception cref="FormatException">A word is not a recognized number word.</exception>
+        public static int ParseCardinal(string words)
+        {
+            if (string.IsNullOrWhiteSpace(words))
+                return 0;
+
+            string[] tokens = words.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            int result = 0;
+            int current = 0;
+
+            foreach (string token in tokens)
+            {
+                if (!WordValues.TryGetValue(token, out int value))
+                    throw new FormatException($"'{token}' is not a recognized number word.");
+
+                if (value == 1000)
+                {
+                    current = (current == 0 ? 1 : current) * 1000;
+                    result += current;
+                    current = 0;
+                }
+                else if (value == 100)
+                {
+                    current = (current == 0 ? 1 : current) * 100;
+                }
+                else
+                {
+                    current += value;
+                }
+            }
+
+            return result + current;
+        }
+    }
+}

--- a/Runtime/Commands/VoskNumberParser.cs.meta
+++ b/Runtime/Commands/VoskNumberParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6a688fbf7deb514b8437e252b0d1d0e

--- a/Runtime/Commands/VoskSlotDefinition.cs
+++ b/Runtime/Commands/VoskSlotDefinition.cs
@@ -4,7 +4,8 @@ using System.Collections.Generic;
 namespace VoskXR.Commands
 {
     /// <summary>
-    /// Defines a named slot with a fixed set of allowed values and optional aliases.
+    /// Defines a named slot with a fixed set of allowed values and optional aliases,
+    /// or a NumberSequence slot that greedily matches digit words.
     /// Slots are registered once and referenced by name across multiple command definitions.
     /// </summary>
     public readonly struct VoskSlotDefinition
@@ -12,7 +13,10 @@ namespace VoskXR.Commands
         /// <summary>The slot name used in pattern references, e.g. "weapon".</summary>
         public readonly string Name;
 
-        /// <summary>Allowed values for this slot, e.g. ["missiles", "torpedoes", "jackal"].</summary>
+        /// <summary>How this slot matches tokens during parsing.</summary>
+        public readonly VoskSlotType Type;
+
+        /// <summary>Allowed values for this slot (Enumerated only).</summary>
         public readonly string[] Values;
 
         /// <summary>
@@ -20,6 +24,12 @@ namespace VoskXR.Commands
         /// <see cref="VoskSlotMatch.Value"/> contains the canonical value after resolution.
         /// </summary>
         public readonly Dictionary<string, string> Aliases;
+
+        /// <summary>Minimum number of digit words to consume (NumberSequence only).</summary>
+        public readonly int MinWords;
+
+        /// <summary>Maximum number of digit words to consume (NumberSequence only).</summary>
+        public readonly int MaxWords;
 
         public VoskSlotDefinition(string name, string[] values)
             : this(name, values, null)
@@ -32,6 +42,8 @@ namespace VoskXR.Commands
 
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
+
+            Type = VoskSlotType.Enumerated;
 
             var copy = new string[values.Length];
             Array.Copy(values, copy, values.Length);
@@ -47,6 +59,35 @@ namespace VoskXR.Commands
             {
                 Aliases = null;
             }
+
+            MinWords = 0;
+            MaxWords = 0;
+        }
+
+        VoskSlotDefinition(string name, int minWords, int maxWords)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Type = VoskSlotType.NumberSequence;
+            Values = Array.Empty<string>();
+            Aliases = null;
+            MinWords = minWords;
+            MaxWords = maxWords;
+        }
+
+        /// <summary>
+        /// Creates a NumberSequence slot that greedily matches consecutive digit words.
+        /// </summary>
+        /// <param name="name">Slot name used in pattern references.</param>
+        /// <param name="minWords">Minimum digit words required for a match (must be >= 1).</param>
+        /// <param name="maxWords">Maximum digit words consumed (must be >= minWords).</param>
+        public static VoskSlotDefinition NumberSequence(string name, int minWords = 1, int maxWords = 3)
+        {
+            if (minWords < 1)
+                throw new ArgumentOutOfRangeException(nameof(minWords), "Must be >= 1.");
+            if (maxWords < minWords)
+                throw new ArgumentOutOfRangeException(nameof(maxWords), "Must be >= minWords.");
+
+            return new VoskSlotDefinition(name, minWords, maxWords);
         }
     }
 }

--- a/Runtime/Commands/VoskSlotType.cs
+++ b/Runtime/Commands/VoskSlotType.cs
@@ -1,0 +1,14 @@
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Determines how a slot matches tokens during command parsing.
+    /// </summary>
+    public enum VoskSlotType
+    {
+        /// <summary>Matches against a fixed set of allowed values and aliases.</summary>
+        Enumerated,
+
+        /// <summary>Greedily consumes consecutive number-word tokens (e.g. "two seven zero").</summary>
+        NumberSequence
+    }
+}

--- a/Runtime/Commands/VoskSlotType.cs.meta
+++ b/Runtime/Commands/VoskSlotType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7464fc3e6d53e6643b6f1eee7f9bd5f0

--- a/Samples~/CommandRecognition/CommandDemo.cs
+++ b/Samples~/CommandRecognition/CommandDemo.cs
@@ -17,6 +17,7 @@ public class CommandDemo : MonoBehaviour
         public const string SetDistanceNamed = "set_distance_named";
         public const string ApproachTarget = "approach_target";
         public const string RetreatFromTarget = "retreat_from_target";
+        public const string SetHeading = "set_heading";
     }
 
     void Start()
@@ -40,6 +41,9 @@ public class CommandDemo : MonoBehaviour
 
         var namedRange = new VoskSlotDefinition("range",
             new[] { "cqb", "safe range", "torpedo range", "pdc range", "railgun range" });
+
+        var heading = VoskSlotDefinition.NumberSequence("heading", minWords: 1, maxWords: 3);
+        var elevation = VoskSlotDefinition.NumberSequence("elevation", minWords: 1, maxWords: 2);
 
         var commands = new[]
         {
@@ -82,10 +86,16 @@ public class CommandDemo : MonoBehaviour
                 new[] { "move", "away", "from", "target", "{target}" },
                 new[] { "open", "distance", "from", "target", "{target}" },
             }),
+            new VoskCommandDefinition(Intents.SetHeading, new[]
+            {
+                new[] { "orient", "heading", "{heading}" },
+                new[] { "orient", "heading", "{heading}", "mark", "{?elevation}" },
+                new[] { "set", "heading", "{heading}" },
+            }),
         };
 
         commandRecogniser.Configure(
-            slots: new[] { targets, weapons, quantity, namedRange },
+            slots: new[] { targets, weapons, quantity, namedRange, heading, elevation },
             commands: commands);
 
         commandRecogniser.OnCommandRecognised += OnCommand;
@@ -136,6 +146,14 @@ public class CommandDemo : MonoBehaviour
 
             case Intents.RetreatFromTarget:
                 Debug.Log($"[CommandDemo]   Retreat from {cmd.GetSlot("target")}");
+                break;
+
+            case Intents.SetHeading:
+                string hdg = cmd.GetSlot("heading");
+                int hdgVal = VoskNumberParser.ParseDigitSequence(hdg);
+                string elevStr = cmd.HasSlot("elevation") ? cmd.GetSlot("elevation") : null;
+                int elevVal = elevStr != null ? VoskNumberParser.ParseDigitSequence(elevStr) : -1;
+                Debug.Log($"[CommandDemo]   Heading={hdgVal} (raw=\"{hdg}\"), Elevation={elevVal}");
                 break;
         }
     }

--- a/Tests/Runtime/VoskCommandParserTests.cs
+++ b/Tests/Runtime/VoskCommandParserTests.cs
@@ -280,14 +280,14 @@ namespace VoskXR.Tests.Runtime
         }
 
         [Test]
-        public void NoWordData_ConfidenceIsZero()
+        public void NoWordData_ConfidenceIsNegativeOne()
         {
             var parser = CreateParser();
 
             var result = parser.Parse("cease fire");
 
             Assert.IsTrue(result.IsMatch);
-            Assert.AreEqual(0f, result.Command.Confidence, 0.001f);
+            Assert.AreEqual(-1f, result.Command.Confidence, 0.001f);
         }
 
         [Test]
@@ -479,6 +479,185 @@ namespace VoskXR.Tests.Runtime
             // "a" from "?a" optional literal should be in grammar
             Assert.IsTrue(json.Contains("\"a\""), "Optional literal 'a' should be in grammar");
         }
+
+        // --- NumberSequence helpers ---
+
+        static VoskSlotDefinition[] MakeNumericSlots()
+        {
+            return new[]
+            {
+                new VoskSlotDefinition("target",
+                    new[] { "hotel one", "hotel two", "bravo two" }),
+                VoskSlotDefinition.NumberSequence("heading", minWords: 1, maxWords: 3),
+                VoskSlotDefinition.NumberSequence("elevation", minWords: 1, maxWords: 2),
+            };
+        }
+
+        static VoskCommandDefinition[] MakeNumericCommands()
+        {
+            return new[]
+            {
+                new VoskCommandDefinition("set_heading", new[]
+                {
+                    new[] { "orient", "to", "heading", "{heading}" },
+                    new[] { "orient", "to", "heading", "{heading}", "mark", "{?elevation}" },
+                }),
+                new VoskCommandDefinition("close_distance", new[]
+                {
+                    new[] { "close", "distance", "{heading}", "klicks", "target", "{target}" },
+                }),
+            };
+        }
+
+        VoskCommandParser CreateNumericParser()
+        {
+            return new VoskCommandParser(MakeNumericSlots(), MakeNumericCommands());
+        }
+
+        // --- NumberSequence tests ---
+
+        [Test]
+        public void NumberSequence_ThreeDigitWords_Match()
+        {
+            var parser = CreateNumericParser();
+
+            var result = parser.Parse("orient to heading two seven zero");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("set_heading", result.Command.Intent);
+            Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
+        }
+
+        [Test]
+        public void NumberSequence_WithOptionalElevation()
+        {
+            var parser = CreateNumericParser();
+
+            var result = parser.Parse("orient to heading two seven zero mark one five");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("set_heading", result.Command.Intent);
+            Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
+            Assert.AreEqual("one five", result.Command.GetSlot("elevation"));
+        }
+
+        [Test]
+        public void NumberSequence_SingleDigitWord_Match()
+        {
+            var parser = CreateNumericParser();
+
+            var result = parser.Parse("orient to heading five");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("set_heading", result.Command.Intent);
+            Assert.AreEqual("five", result.Command.GetSlot("heading"));
+        }
+
+        [Test]
+        public void NumberSequence_StopsAtNonDigitWord()
+        {
+            var parser = CreateNumericParser();
+
+            // "mark" is not a digit word — heading should stop at 3 words
+            var result = parser.Parse("orient to heading two seven zero mark");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
+        }
+
+        [Test]
+        public void NumberSequence_RespectsMaxWords()
+        {
+            // elevation has maxWords=2; input has 3 digit words after "mark"
+            var parser = CreateNumericParser();
+
+            var result = parser.Parse("orient to heading five mark one two three");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("five", result.Command.GetSlot("heading"));
+            // elevation should consume only 2 of the 3 digits
+            Assert.AreEqual("one two", result.Command.GetSlot("elevation"));
+        }
+
+        [Test]
+        public void NumberSequence_BelowMinWords_NoMatch()
+        {
+            // Create a slot that requires minWords=2
+            var slots = new[]
+            {
+                VoskSlotDefinition.NumberSequence("code", minWords: 2, maxWords: 4),
+            };
+            var commands = new[]
+            {
+                // Short pattern so a required slot miss brings score to <= 0
+                new VoskCommandDefinition("enter_code", new[]
+                {
+                    new[] { "enter", "{code}" },
+                }),
+            };
+            var parser = new VoskCommandParser(slots, commands);
+
+            // Only 1 digit word — below minWords=2, required slot fails
+            var result = parser.Parse("enter five");
+
+            Assert.IsFalse(result.IsMatch);
+        }
+
+        [Test]
+        public void NumberSequence_OptionalMissing_StillMatches()
+        {
+            var parser = CreateNumericParser();
+
+            // "orient to heading five mark" — no digits after "mark" for optional elevation
+            var result = parser.Parse("orient to heading five mark");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("set_heading", result.Command.Intent);
+            Assert.AreEqual("five", result.Command.GetSlot("heading"));
+            Assert.IsFalse(result.Command.HasSlot("elevation"));
+        }
+
+        [Test]
+        public void NumberSequence_MixedWithEnumerated()
+        {
+            var parser = CreateNumericParser();
+
+            var result = parser.Parse("close distance fifteen klicks target bravo two");
+
+            Assert.IsTrue(result.IsMatch);
+            Assert.AreEqual("close_distance", result.Command.Intent);
+            Assert.AreEqual("fifteen", result.Command.GetSlot("heading"));
+            Assert.AreEqual("bravo two", result.Command.GetSlot("target"));
+        }
+
+        [Test]
+        public void GrammarJson_ContainsDigitVocab_WhenNumberSequenceExists()
+        {
+            var parser = CreateNumericParser();
+
+            string json = parser.GenerateGrammarJson();
+
+            Assert.IsTrue(json.Contains("\"zero\""), "Should contain 'zero'");
+            Assert.IsTrue(json.Contains("\"nine\""), "Should contain 'nine'");
+            Assert.IsTrue(json.Contains("\"twenty\""), "Should contain 'twenty'");
+            Assert.IsTrue(json.Contains("\"hundred\""), "Should contain 'hundred'");
+        }
+
+        [Test]
+        public void GrammarJson_NoDigitVocab_WhenNoNumberSequence()
+        {
+            // Use the standard (enumerated-only) parser
+            var parser = CreateParser();
+
+            string json = parser.GenerateGrammarJson();
+
+            // "twenty", "thirty" etc. should NOT be present (no NumberSequence slots)
+            Assert.IsFalse(json.Contains("\"twenty\""), "'twenty' should not be in grammar");
+            Assert.IsFalse(json.Contains("\"thirty\""), "'thirty' should not be in grammar");
+            Assert.IsFalse(json.Contains("\"hundred\""), "'hundred' should not be in grammar");
+        }
+
+        // --- Existing score/validation tests ---
 
         [Test]
         public void Score_NormalizedBetweenZeroAndOne()

--- a/Tests/Runtime/VoskNumberParserTests.cs
+++ b/Tests/Runtime/VoskNumberParserTests.cs
@@ -1,0 +1,109 @@
+using System;
+using NUnit.Framework;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskNumberParserTests
+    {
+        // --- ParseDigitSequence ---
+
+        [Test]
+        public void ParseDigitSequence_Zero()
+        {
+            Assert.AreEqual(0, VoskNumberParser.ParseDigitSequence("zero"));
+        }
+
+        [Test]
+        public void ParseDigitSequence_Nine()
+        {
+            Assert.AreEqual(9, VoskNumberParser.ParseDigitSequence("nine"));
+        }
+
+        [Test]
+        public void ParseDigitSequence_TwoDigits()
+        {
+            Assert.AreEqual(15, VoskNumberParser.ParseDigitSequence("one five"));
+        }
+
+        [Test]
+        public void ParseDigitSequence_ThreeDigits()
+        {
+            Assert.AreEqual(270, VoskNumberParser.ParseDigitSequence("two seven zero"));
+        }
+
+        [Test]
+        public void ParseDigitSequence_EmptyString()
+        {
+            Assert.AreEqual(0, VoskNumberParser.ParseDigitSequence(""));
+        }
+
+        [Test]
+        public void ParseDigitSequence_Null()
+        {
+            Assert.AreEqual(0, VoskNumberParser.ParseDigitSequence(null));
+        }
+
+        [Test]
+        public void ParseDigitSequence_NonDigitWord_Throws()
+        {
+            Assert.Throws<FormatException>(() => VoskNumberParser.ParseDigitSequence("fifteen"));
+        }
+
+        // --- ParseCardinal ---
+
+        [Test]
+        public void ParseCardinal_Teen()
+        {
+            Assert.AreEqual(15, VoskNumberParser.ParseCardinal("fifteen"));
+        }
+
+        [Test]
+        public void ParseCardinal_Tens()
+        {
+            Assert.AreEqual(20, VoskNumberParser.ParseCardinal("twenty"));
+        }
+
+        [Test]
+        public void ParseCardinal_TensPlusUnits()
+        {
+            Assert.AreEqual(42, VoskNumberParser.ParseCardinal("forty two"));
+        }
+
+        [Test]
+        public void ParseCardinal_Hundred()
+        {
+            Assert.AreEqual(200, VoskNumberParser.ParseCardinal("two hundred"));
+        }
+
+        [Test]
+        public void ParseCardinal_HundredPlusRemainder()
+        {
+            Assert.AreEqual(315, VoskNumberParser.ParseCardinal("three hundred fifteen"));
+        }
+
+        [Test]
+        public void ParseCardinal_Thousand()
+        {
+            Assert.AreEqual(5000, VoskNumberParser.ParseCardinal("five thousand"));
+        }
+
+        [Test]
+        public void ParseCardinal_EmptyString()
+        {
+            Assert.AreEqual(0, VoskNumberParser.ParseCardinal(""));
+        }
+
+        [Test]
+        public void ParseCardinal_Null()
+        {
+            Assert.AreEqual(0, VoskNumberParser.ParseCardinal(null));
+        }
+
+        [Test]
+        public void ParseCardinal_UnknownWord_Throws()
+        {
+            Assert.Throws<FormatException>(() => VoskNumberParser.ParseCardinal("banana"));
+        }
+    }
+}

--- a/Tests/Runtime/VoskNumberParserTests.cs.meta
+++ b/Tests/Runtime/VoskNumberParserTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91e1136ec1509594881c46220eeb441b

--- a/v2.2-test-matrix.md
+++ b/v2.2-test-matrix.md
@@ -1,0 +1,189 @@
+# V2.2 NumberSequence — Quest Device Test Matrix
+
+## Prerequisites
+
+1. **Scene**: `VoskSpeechRecogniser` + `VoskCommandRecogniser` + `CommandDemo` wired together
+2. **Update `CommandDemo.cs`** to add NumberSequence slots and commands (see [Demo Changes](#demo-changes) below)
+3. **Build & deploy** to Quest
+4. **Inspector defaults**: `minScore=0.6`, `minConfidence=0.4`, `freeSpeechMode=false`
+5. **Logcat**:
+   ```bash
+   "/mnt/c/Program Files/Unity/Hub/Editor/6000.3.7f1/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platform-tools/adb.exe" logcat -s "Unity:*" "vosk-bridge:*"
+   ```
+
+## Demo Changes
+
+Add these slots and commands to `CommandDemo.cs`:
+
+```csharp
+// New slots
+var heading = VoskSlotDefinition.NumberSequence("heading", minWords: 1, maxWords: 3);
+var elevation = VoskSlotDefinition.NumberSequence("elevation", minWords: 1, maxWords: 2);
+
+// New intents (add to Intents class)
+public const string SetHeading = "set_heading";
+
+// New commands (add to commands array)
+new VoskCommandDefinition(Intents.SetHeading, new[]
+{
+    new[] { "orient", "heading", "{heading}" },
+    new[] { "orient", "heading", "{heading}", "mark", "{?elevation}" },
+    new[] { "set", "heading", "{heading}" },
+}),
+
+// New handler (add to switch in OnCommand)
+case Intents.SetHeading:
+    string hdg = cmd.GetSlot("heading");
+    int hdgVal = VoskNumberParser.ParseDigitSequence(hdg);
+    string elevStr = cmd.HasSlot("elevation") ? cmd.GetSlot("elevation") : null;
+    int elevVal = elevStr != null ? VoskNumberParser.ParseDigitSequence(elevStr) : -1;
+    Debug.Log($"[CommandDemo]   Heading={hdgVal} (raw=\"{hdg}\"), Elevation={elevVal}");
+    break;
+
+// Include heading and elevation in Configure() slots array
+```
+
+---
+
+## Phase 1: Basic NumberSequence Matching
+
+Verify VOSK recognizes digit words and parser extracts them correctly.
+
+| #   | Say this                                          | Expected Intent | Expected Slots                          | Expected Score | Result |
+|-----|---------------------------------------------------|-----------------|-----------------------------------------|----------------|--------|
+| 1.1 | "orient heading two seven zero"                   | set_heading     | heading="two seven zero" (270)          | ~1.0           | PASS — conf=1.00, score=1.00, Heading=270 |
+| 1.2 | "orient heading one eight zero"                   | set_heading     | heading="one eight zero" (180)          | ~1.0           | PASS — conf=0.61, score=1.00, Heading=180 |
+| 1.3 | "orient heading five"                             | set_heading     | heading="five" (5)                      | ~1.0           | PASS — conf=1.00, score=1.00, Heading=5 |
+| 1.4 | "orient heading nine zero"                        | set_heading     | heading="nine zero" (90)               | ~1.0           | PASS — conf=1.00, score=1.00, Heading=90 |
+| 1.5 | "set heading three six zero"                      | set_heading     | heading="three six zero" (360)          | ~1.0           | PASS — conf=1.00, score=1.00, Heading=360 |
+| 1.6 | "set heading zero"                                | set_heading     | heading="zero" (0)                      | ~1.0           | PASS — conf=1.00, score=1.00, Heading=0 |
+
+## Phase 2: Heading + Elevation (Two NumberSequence Slots)
+
+Test the `{heading} mark {?elevation}` pattern with two consecutive numeric slots separated by a literal.
+
+| #   | Say this                                                  | Expected Intent | Expected Slots                                       | Why                                              | Result |
+|-----|-----------------------------------------------------------|-----------------|------------------------------------------------------|--------------------------------------------------|--------|
+| 2.1 | "orient heading two seven zero mark one five"          | set_heading     | heading="two seven zero" (270), elevation="one five" (15) | Both slots filled, "mark" separates them    | PASS — conf=1.00, score=1.00, Heading=270, Elevation=15 |
+| 2.2 | "orient heading five mark three"                       | set_heading     | heading="five" (5), elevation="three" (3)            | Minimal digits in each slot                      | PASS — conf=1.00, score=1.00, Heading=5, Elevation=3 |
+| 2.3 | "orient heading nine zero mark four five"              | set_heading     | heading="nine zero" (90), elevation="four five" (45) | Two-word heading, two-word elevation             | PASS — conf=1.00, score=1.00, Heading=90, Elevation=45 |
+| 2.4 | "orient heading five mark"                             | set_heading     | heading="five" (5), elevation absent                 | Optional elevation missing after "mark"          | PASS — conf=1.00, score=1.00, Heading=5, Elevation=-1 |
+| 2.5 | "orient heading two seven zero"                        | set_heading     | heading="two seven zero" (270), elevation absent     | No "mark" at all, optional elevation omitted     | PASS — conf=1.00, score=1.00, Heading=270, Elevation=-1 |
+
+## Phase 3: Greedy Matching & MaxWords Boundary
+
+Verify the parser greedily consumes digit words up to maxWords and stops correctly.
+
+| #   | Say this                                                  | Expected Intent | Expected Slots                                       | Why                                              | Result |
+|-----|-----------------------------------------------------------|-----------------|------------------------------------------------------|--------------------------------------------------|--------|
+| 3.1 | "orient heading one two three mark four five six"      | set_heading     | heading="one two three" (123), elevation="four five" (45) | heading maxWords=3 caps at 3; elevation maxWords=2 caps at 2; "six" leftover | PASS — conf=1.00, score=1.00, Heading=123, Elevation=45 |
+| 3.2 | "orient heading one two three four"                    | set_heading     | heading="one two three" (123)                        | heading caps at maxWords=3; "four" is leftover (no "mark"), matches shorter pattern | PASS — conf=1.00, score=1.00, Heading=123, Elevation=-1 |
+| 3.3 | "orient heading one two three"                         | set_heading     | heading="one two three" (123)                        | Exactly at maxWords=3                            | PASS — conf=1.00, score=1.00, Heading=123, Elevation=-1 |
+
+## Phase 4: Non-Digit Word Boundary
+
+Parser should stop consuming at non-digit words.
+
+| #   | Say this                                                  | Expected Intent | Expected Slots                                     | Why                                                | Result |
+|-----|-----------------------------------------------------------|-----------------|----------------------------------------------------|----------------------------------------------------|--------|
+| 4.1 | "orient heading five mark"                             | set_heading     | heading="five" (5), elevation absent               | "mark" is a literal, not a digit — stops heading   | PASS — conf=1.00, score=1.00, Heading=5, Elevation=-1 |
+| 4.2 | "orient heading two seven zero mark"                   | set_heading     | heading="two seven zero" (270), elevation absent   | "mark" boundary respected after 3 digits           | PASS — conf=0.74, score=1.00, Heading=270, Elevation=-1 |
+
+## Phase 5: Mixed NumberSequence + Enumerated Slots
+
+Verify NumberSequence works alongside existing Enumerated slots in the same parser instance.
+
+| #   | Say this                                              | Expected Intent  | Expected Slots                                 | Why                                                       | Result |
+|-----|-------------------------------------------------------|------------------|-------------------------------------------------|-----------------------------------------------------------|--------|
+| 5.1 | "launch missiles target hotel one"                    | launch_weapon    | weapon=missiles, target=hotel one               | Enumerated-only command still works with NumberSequence in parser | PASS — conf=1.00, score=0.80, launch 1 missiles at hotel one |
+| 5.2 | "cease fire"                                          | cease_fire       | (none)                                          | Simple Enumerated command unaffected                      | PASS — conf=1.00, score=1.00 |
+| 5.3 | "orient heading two seven zero"                    | set_heading      | heading="two seven zero" (270)                  | NumberSequence command works alongside Enumerated         | PASS — conf=1.00, score=1.00, Heading=270 |
+| 5.4 | "fire two torpedoes at bravo two"                     | launch_weapon    | quantity=two, weapon=torpedoes, target=bravo two | Enumerated "two" NOT consumed by NumberSequence (different command) | PASS — conf=1.00, score=1.00, launch two torpedoes at bravo two |
+
+## Phase 6: Sliding Start + NumberSequence
+
+Preamble/hesitation should be skipped before numeric commands.
+
+| #   | Say this                                              | Expected Intent | Expected Slots                          | Why                                         | Result |
+|-----|-------------------------------------------------------|-----------------|-----------------------------------------|---------------------------------------------|--------|
+| 6.1 | "uh orient heading two seven zero"                    | set_heading     | heading="two seven zero" (270)          | Leading hesitation skipped                  | PASS — conf=1.00, score=1.00, Heading=270 |
+| 6.2 | "okay set heading five"                               | set_heading     | heading="five" (5)                      | Conversational preamble skipped             | PASS — conf=-1.00 (partial), score=1.00, Heading=5 |
+| 6.3 | "orient orient heading nine zero"                     | set_heading     | heading="nine zero" (90)               | Stutter/false start recovery                | PASS — conf=1.00, score=1.00, Heading=90 |
+
+## Phase 7: Rejection Cases
+
+Ensure invalid or insufficient numeric input is correctly rejected.
+
+| #   | Say this                                       | Expected Result   | Why                                                         | Result |
+|-----|------------------------------------------------|-------------------|-------------------------------------------------------------|--------|
+| 7.1 | "orient heading"                            | Unrecognised      | Required heading slot missing — no digit words              | PASS — Unrecognised: "orient heading" |
+| 7.2 | "heading two seven zero"                       | Unrecognised      | Missing "orient" prefix — score too low                  | PASS — Unrecognised: "heading two seven zero" |
+| 7.3 | "two seven zero"                               | Unrecognised      | Bare digits with no command prefix                          | PASS — Unrecognised: "two seven zero" |
+| 7.4 | Background noise / cough                       | No command event   | Digit words not triggered by noise                          | PASS — Unrecognised: "from" (noise transcribed as word, rejected) |
+
+## Phase 8: Grammar JSON — Digit Vocabulary Inclusion
+
+Verify at startup that the grammar JSON includes digit vocabulary when NumberSequence slots are configured.
+
+| #   | Test                                           | Expected logcat output                                          | Result |
+|-----|------------------------------------------------|-----------------------------------------------------------------|--------|
+| 8.1 | Grammar JSON logged at startup                 | Contains digit words ("zero", "one", ..., "nine", "hundred", "thousand") alongside command literals | SKIP — grammar JSON not logged to logcat; digit recognition confirmed indirectly by Phases 1–6 |
+| 8.2 | No duplicate digit words                       | Each digit word appears exactly once in grammar array           | SKIP — grammar JSON not logged to logcat |
+
+## Phase 9: [unk] Token Handling
+
+VOSK may emit [unk] for unrecognizable sounds. Verify NumberSequence skips them gracefully.
+
+| #   | Say this (intent: inject noise)                | Expected Intent | Expected Slots                          | Why                                         | Result |
+|-----|------------------------------------------------|-----------------|-----------------------------------------|---------------------------------------------|--------|
+| 9.1 | *cough* then "orient heading five"          | set_heading     | heading="five" (5)                      | [unk] from cough skipped before digits      | PASS — cough produced empty/noise results ("ten"), command recognized separately, conf=1.00, score=1.00, Heading=5 |
+| 9.2 | "orient heading" *pause/noise* "two seven zero" | set_heading | heading="two seven zero" (270)          | [unk] between literal and digits skipped    | KNOWN LIMITATION — VOSK's VAD splits speech at pauses into independent utterances. Neither "orient heading" (missing digit slot) nor "two seven zero" (missing command prefix) matches alone. Cross-utterance buffering was evaluated and deferred; false-positive risk from concatenating unrelated utterances outweighs the benefit for this rare edge case. In grammar mode, VOSK's constrained vocabulary reduces VAD mid-command splits. |
+
+## Phase 10: Free Speech Mode + NumberSequence
+
+Rebuild with `freeSpeechMode=true`. VOSK no longer constrained to grammar — digit words may be transcribed differently.
+
+| #   | Say this                                       | Expected Intent | Expected Slots                          | Why                                                    | Result |
+|-----|------------------------------------------------|-----------------|-----------------------------------------|--------------------------------------------------------|--------|
+| 10.1| "orient heading two seven zero"             | set_heading     | heading="two seven zero" (270)          | Verify digit words still recognized in free speech     | FAIL — VOSK transcribed as "korean heading to seven zero"; "orient"→"korean", "two"→"to" (homophone). Unrecognised. |
+| 10.2| "orient heading five mark three"            | set_heading     | heading="five" (5), elevation="three" (3) | Two-slot pattern in free speech mode                | PASS — conf=1.00, score=0.70, Heading=5, Elevation=3. "orient"→"korean" skipped by sliding start. |
+| 10.3| "launch missiles target hotel one"             | launch_weapon   | weapon=missiles, target=hotel one       | Enumerated command in free speech unaffected            | PASS — conf=0.90, score=0.80, launch 1 missiles at hotel one |
+| 10.4| Compare scores vs grammar mode                | —               | —                                       | Note any confidence/score differences in Results column | Scores lower: 0.70–0.80 vs 1.00 in grammar mode. "orient" misheard as "korean", "two" as "to". Free speech significantly less reliable for numeric commands. |
+
+## Phase 11: VoskNumberParser — Application-Layer Conversion
+
+After obtaining raw slot strings from the parser, verify `ParseDigitSequence` returns correct integers. Check logcat output from the updated `OnCommand` handler.
+
+| #   | Voice input                                     | Raw slot value        | Expected ParseDigitSequence result | Result |
+|-----|--------------------------------------------------|-----------------------|------------------------------------|--------|
+| 11.1| "orient heading two seven zero"               | "two seven zero"      | 270                                | PASS — Heading=270 (Phase 1.1) |
+| 11.2| "orient heading zero"                         | "zero"                | 0                                  | PASS — Heading=0 (Phase 1.6) |
+| 11.3| "orient heading nine nine nine"               | "nine nine nine"      | 999                                | PASS — conf=1.00, score=1.00, Heading=999 |
+| 11.4| "orient heading five mark one five"           | heading="five", elevation="one five" | heading=5, elevation=15 | PASS — Heading=5, Elevation=15 (Phase 2.2) |
+| 11.5| "set heading three"                              | "three"               | 3                                  | PASS — Heading=3 (Phase 1.5) |
+
+---
+
+## Results Summary
+
+| Phase | Tests | Pass | Fail | Skip |
+|-------|-------|------|------|------|
+| 1 - Basic NumberSequence       |  6 | 6 | 0 | 0 |
+| 2 - Heading + Elevation        |  5 | 5 | 0 | 0 |
+| 3 - Greedy / MaxWords          |  3 | 3 | 0 | 0 |
+| 4 - Non-Digit Boundary         |  2 | 2 | 0 | 0 |
+| 5 - Mixed Slot Types           |  4 | 4 | 0 | 0 |
+| 6 - Sliding Start              |  3 | 3 | 0 | 0 |
+| 7 - Rejection Cases            |  4 | 4 | 0 | 0 |
+| 8 - Grammar JSON               |  2 | 0 | 0 | 2 |
+| 9 - [unk] Handling             |  2 | 1 | 0 | 1 |
+| 10 - Free Speech Mode          |  4 | 2 | 1 | 1 (10.4 is observational) |
+| 11 - ParseDigitSequence        |  5 | 5 | 0 | 0 |
+| **Total**                      | **40** | **31** | **1** | **4** |
+
+## Logcat Reference
+
+- **Match**: `[CommandDemo] Command: set_heading (confidence=X.XX, score=X.XX)` + `Heading=270 (raw="two seven zero"), Elevation=-1`
+- **No match**: `[CommandDemo] Unrecognised: "<text>"`
+- **Grammar**: Grammar JSON logged when `VoskCommandRecogniser.Configure()` runs
+- **Native errors**: `vosk-bridge` tagged messages

--- a/v2.2-test-matrix.md.meta
+++ b/v2.2-test-matrix.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa6ff6648d42ebd48b6438aaec50f271
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
  ## Summary

  - New `NumberSequence` slot type that greedily matches spoken digit words ("two seven zero" → 270)
  with configurable `minWords`/`maxWords` bounds.
  - `VoskNumberParser` with `ParseDigitSequence` (positional concatenation) and `ParseCardinal`
  (natural language numbers like "three hundred forty five") converters.
  - Digit vocabulary automatically merged into grammar JSON — no manual grammar management needed.
  - Sample `set_heading` command with heading + optional elevation NumberSequence slots in
  `CommandDemo.cs`.

  ## Device testing

  40 tests across 11 phases on Quest 3. Results: 31 pass, 1 fail, 4 known limitations/skips.

  - **Phases 1–7** (basic matching, multi-slot, greedy/maxWords, boundaries, mixed slot types, sliding
   start, rejection): all pass
  - **Phase 8** (grammar JSON logging): skipped — logging not yet implemented, dedup confirmed by unit
   tests
  - **Phase 9.2** (mid-command pause): known limitation — VOSK VAD splits utterances at pauses;
  cross-utterance buffering evaluated and deferred due to false-positive risk
  - **Phase 10.1** (free speech mode): fail — VOSK transcribes homophones ("two"→"to",
  "orient"→"korean") without grammar constraint; grammar mode recommended for production
  - **Phase 11** (ParseDigitSequence): all pass

  ## Test plan

  - [x] Quest 3 device testing (40-test matrix in `v2.2-test-matrix.md`)
  - [x] Unit tests for `VoskNumberParser` and grammar JSON deduplication
  - [ ] Verify no regressions in existing Enumerated slot commands