### PR TITLE
V2.3 Utterance buffer, sequential extraction, per-intent debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-06
+
+### Added
+
+- Utterance buffer (`bufferWindow`) merges consecutive VOSK results split by mid-command pauses before parsing. Recommended 2.0s on Quest 3.
+- Sequential command extraction — multiple commands in a single utterance are parsed left-to-right (e.g., "cease fire launch missiles target hotel one" → `cease_fire` + `launch_weapon`).
+- `OnCommandsRecognised` batch event fires a `VoskCommand[]` array per utterance alongside per-command `OnCommandRecognised` events.
+- Per-intent debounce (`commandCooldown`) suppresses rapid duplicate intents both across VOSK results and within a single parse batch.
+- Quest device test matrix (`v2.3-test-matrix.md`) with 40 tests across 12 phases — 40/40 pass.
+
+### Fixed
+
+- Intra-batch debounce: duplicate intents found by sequential extraction within the same parse batch are now correctly suppressed. Previously debounce only applied across separate VOSK results.
+
 ## [0.6.0] - 2026-04-05
 
 ### Added

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -183,16 +183,17 @@ namespace VoskXR.Commands
 
         /// <summary>
         /// Parses input text against all registered command patterns using scored matching
-        /// with sliding start position.
+        /// with sliding start position. Performs sequential command extraction — after the
+        /// best match is found, remaining tokens are parsed again until no more matches exist.
         /// </summary>
-        public VoskCommandResult Parse(string text, VoskWord[] words)
+        public VoskCommandResult[] Parse(string text, VoskWord[] words)
         {
             if (string.IsNullOrWhiteSpace(text))
-                return new VoskCommandResult(text ?? string.Empty);
+                return Array.Empty<VoskCommandResult>();
 
             string[] tokens = text.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
             if (tokens.Length == 0)
-                return new VoskCommandResult(text);
+                return Array.Empty<VoskCommandResult>();
 
             Dictionary<string, float> wordConfidence = null;
             if (words != null && words.Length > 0)
@@ -205,62 +206,72 @@ namespace VoskXR.Commands
                 }
             }
 
-            float bestScore = float.MinValue;
-            int bestLiteralCount = -1;
-            int bestCommandIdx = -1;
-            int bestStartIdx = 0;
-            List<VoskSlotMatch> bestSlots = null;
+            var results = new List<VoskCommandResult>();
+            int searchStart = 0;
 
-            for (int ci = 0; ci < _commands.Length; ci++)
+            while (searchStart < tokens.Length)
             {
-                var patterns = _commands[ci].Patterns;
-                for (int pi = 0; pi < patterns.Length; pi++)
+                float bestScore = float.MinValue;
+                int bestLiteralCount = -1;
+                int bestCommandIdx = -1;
+                int bestStartIdx = 0;
+                int bestEndIdx = 0;
+                List<VoskSlotMatch> bestSlots = null;
+
+                for (int ci = 0; ci < _commands.Length; ci++)
                 {
-                    // Sliding start: try matching from every token position
-                    for (int startIdx = 0; startIdx < tokens.Length; startIdx++)
+                    var patterns = _commands[ci].Patterns;
+                    for (int pi = 0; pi < patterns.Length; pi++)
                     {
-                        if (tokens[startIdx] == UnkToken)
-                            continue;
-
-                        var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
-
-                        if (matchResult.Score > bestScore ||
-                            (matchResult.Score == bestScore && matchResult.LiteralCount > bestLiteralCount))
+                        for (int startIdx = searchStart; startIdx < tokens.Length; startIdx++)
                         {
-                            bestScore = matchResult.Score;
-                            bestLiteralCount = matchResult.LiteralCount;
-                            bestCommandIdx = ci;
-                            bestStartIdx = startIdx;
-                            bestSlots = matchResult.Slots;
+                            if (tokens[startIdx] == UnkToken)
+                                continue;
+
+                            var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
+
+                            if (matchResult.Score > bestScore ||
+                                (matchResult.Score == bestScore && matchResult.LiteralCount > bestLiteralCount))
+                            {
+                                bestScore = matchResult.Score;
+                                bestLiteralCount = matchResult.LiteralCount;
+                                bestCommandIdx = ci;
+                                bestStartIdx = startIdx;
+                                bestEndIdx = matchResult.EndIdx;
+                                bestSlots = matchResult.Slots;
+                            }
                         }
                     }
                 }
+
+                if (bestCommandIdx < 0 || bestScore <= 0f)
+                    break;
+
+                float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
+
+                var slotsArray = bestSlots != null && bestSlots.Count > 0
+                    ? bestSlots.ToArray()
+                    : Array.Empty<VoskSlotMatch>();
+
+                var command = new VoskCommand(
+                    _commands[bestCommandIdx].Intent,
+                    slotsArray,
+                    confidence,
+                    bestScore,
+                    text,
+                    _slotNames);
+
+                results.Add(new VoskCommandResult(command));
+                searchStart = bestEndIdx;
             }
 
-            if (bestCommandIdx < 0 || bestScore <= 0f)
-                return new VoskCommandResult(text);
-
-            float confidence = ComputeConfidence(tokens, bestStartIdx, bestSlots, wordConfidence);
-
-            var slotsArray = bestSlots != null && bestSlots.Count > 0
-                ? bestSlots.ToArray()
-                : Array.Empty<VoskSlotMatch>();
-
-            var command = new VoskCommand(
-                _commands[bestCommandIdx].Intent,
-                slotsArray,
-                confidence,
-                bestScore,
-                text,
-                _slotNames);
-
-            return new VoskCommandResult(command);
+            return results.Count > 0 ? results.ToArray() : Array.Empty<VoskCommandResult>();
         }
 
         /// <summary>
         /// Parses input text without word confidence data.
         /// </summary>
-        public VoskCommandResult Parse(string text)
+        public VoskCommandResult[] Parse(string text)
         {
             return Parse(text, Array.Empty<VoskWord>());
         }
@@ -358,6 +369,7 @@ namespace VoskXR.Commands
             public float Score;
             public int LiteralCount;
             public List<VoskSlotMatch> Slots;
+            public int EndIdx;
         }
 
         /// <summary>
@@ -440,7 +452,8 @@ namespace VoskXR.Commands
             {
                 Score = normalizedScore,
                 LiteralCount = literalCount,
-                Slots = slots
+                Slots = slots,
+                EndIdx = tokenIdx
             };
         }
 
@@ -521,7 +534,7 @@ namespace VoskXR.Commands
             return sb.ToString();
         }
 
-        float ComputeConfidence(string[] tokens, int startIdx, List<VoskSlotMatch> slots,
+        float ComputeConfidence(string[] tokens, int startIdx, int endIdx,
             Dictionary<string, float> wordConfidence)
         {
             if (wordConfidence == null || wordConfidence.Count == 0)
@@ -530,7 +543,7 @@ namespace VoskXR.Commands
             float minConf = float.MaxValue;
             bool anyMatch = false;
 
-            for (int i = startIdx; i < tokens.Length; i++)
+            for (int i = startIdx; i < endIdx; i++)
             {
                 if (tokens[i] == UnkToken)
                     continue;

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -214,7 +214,7 @@ namespace VoskXR.Commands
                 float bestScore = float.MinValue;
                 int bestLiteralCount = -1;
                 int bestCommandIdx = -1;
-                int bestStartIdx = 0;
+                int bestStartIdx = int.MaxValue;
                 int bestEndIdx = 0;
                 List<VoskSlotMatch> bestSlots = null;
 
@@ -230,8 +230,12 @@ namespace VoskXR.Commands
 
                             var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
 
-                            if (matchResult.Score > bestScore ||
-                                (matchResult.Score == bestScore && matchResult.LiteralCount > bestLiteralCount))
+                            if (matchResult.Score > 0f &&
+                                (bestScore <= 0f ||
+                                 startIdx < bestStartIdx ||
+                                 (startIdx == bestStartIdx &&
+                                  (matchResult.Score > bestScore ||
+                                   (matchResult.Score == bestScore && matchResult.LiteralCount > bestLiteralCount)))))
                             {
                                 bestScore = matchResult.Score;
                                 bestLiteralCount = matchResult.LiteralCount;

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -247,6 +247,10 @@ namespace VoskXR.Commands
                 if (bestCommandIdx < 0 || bestScore <= 0f)
                     break;
 
+                // Safety: prevent infinite loop if a match consumes no tokens
+                if (bestEndIdx <= searchStart)
+                    break;
+
                 float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
 
                 var slotsArray = bestSlots != null && bestSlots.Count > 0

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace VoskXR.Commands
@@ -6,6 +7,8 @@ namespace VoskXR.Commands
     /// <summary>
     /// Subscribes to <see cref="VoskSpeechRecogniser.OnResult"/> and parses
     /// recognised speech into structured <see cref="VoskCommand"/> events.
+    /// Supports utterance buffering for split commands, sequential command
+    /// extraction, and per-intent debounce.
     /// </summary>
     [AddComponentMenu("VOSK XR/Command Recogniser")]
     public class VoskCommandRecogniser : MonoBehaviour
@@ -26,12 +29,32 @@ namespace VoskXR.Commands
                  "Prevents partial or garbled matches.")]
         [SerializeField] float minScore = 0.6f;
 
+        [Tooltip("Time in seconds to wait for additional speech before parsing. " +
+                 "Longer values recover split commands but add latency. " +
+                 "Set to 0 to disable buffering (v2.2 behaviour).")]
+        [SerializeField] float bufferWindow = 1.5f;
+
+        [Tooltip("Minimum seconds between firing the same intent. " +
+                 "Prevents duplicate commands from rapid VOSK results. " +
+                 "Set to 0 to disable debounce.")]
+        [SerializeField] float commandCooldown = 0.3f;
+
         public event Action<VoskCommand> OnCommandRecognised;
+        public event Action<VoskCommand[]> OnCommandsRecognised;
         public event Action<string> OnUnrecognisedSpeech;
 
         VoskCommandParser _parser;
         string _grammarJson;
         bool _grammarApplied;
+
+        // Utterance buffer state
+        readonly List<string> _bufferedTexts = new List<string>();
+        readonly List<VoskWord> _bufferedWords = new List<VoskWord>();
+        float _lastResultTime;
+        bool _bufferActive;
+
+        // Per-intent debounce state
+        readonly Dictionary<string, float> _lastFireTime = new Dictionary<string, float>(StringComparer.Ordinal);
 
         /// <summary>
         /// Builds the command parser from the given slot and command definitions.
@@ -73,6 +96,16 @@ namespace VoskXR.Commands
 
             speechRecogniser.OnModelReady -= HandleModelReady;
             speechRecogniser.OnResult -= HandleResult;
+
+            // Flush any pending buffer on disable
+            if (_bufferActive)
+                FlushBuffer();
+        }
+
+        void Update()
+        {
+            if (_bufferActive && Time.time - _lastResultTime >= bufferWindow)
+                FlushBuffer();
         }
 
         void HandleModelReady()
@@ -92,32 +125,88 @@ namespace VoskXR.Commands
             if (_parser == null)
                 return;
 
-            var parsed = _parser.Parse(result.Text, result.Words);
-
-            if (parsed.IsMatch)
+            if (bufferWindow <= 0f)
             {
-                var cmd = parsed.Command;
+                ProcessParsedResults(result.Text, result.Words);
+                return;
+            }
+
+            // Append to buffer and reset timer
+            _bufferedTexts.Add(result.Text);
+            if (result.Words != null && result.Words.Length > 0)
+            {
+                for (int i = 0; i < result.Words.Length; i++)
+                    _bufferedWords.Add(result.Words[i]);
+            }
+
+            _lastResultTime = Time.time;
+            _bufferActive = true;
+        }
+
+        void FlushBuffer()
+        {
+            _bufferActive = false;
+
+            if (_bufferedTexts.Count == 0)
+                return;
+
+            string text = string.Join(" ", _bufferedTexts);
+            var words = _bufferedWords.Count > 0 ? _bufferedWords.ToArray() : Array.Empty<VoskWord>();
+
+            _bufferedTexts.Clear();
+            _bufferedWords.Clear();
+
+            ProcessParsedResults(text, words);
+        }
+
+        void ProcessParsedResults(string text, VoskWord[] words)
+        {
+            var results = _parser.Parse(text, words);
+
+            if (results.Length == 0)
+            {
+                OnUnrecognisedSpeech?.Invoke(text);
+                return;
+            }
+
+            var accepted = new List<VoskCommand>();
+
+            for (int i = 0; i < results.Length; i++)
+            {
+                var cmd = results[i].Command;
 
                 // Reject if below score threshold
                 if (cmd.Score < minScore)
-                {
-                    OnUnrecognisedSpeech?.Invoke(parsed.RawText);
-                    return;
-                }
+                    continue;
 
                 // Reject if below confidence threshold (skip when word data unavailable, i.e. -1)
                 if (cmd.Confidence >= 0f && cmd.Confidence < minConfidence)
-                {
-                    OnUnrecognisedSpeech?.Invoke(parsed.RawText);
-                    return;
-                }
+                    continue;
 
-                OnCommandRecognised?.Invoke(cmd);
+                // Per-intent debounce
+                if (commandCooldown > 0f &&
+                    _lastFireTime.TryGetValue(cmd.Intent, out float lastTime) &&
+                    Time.time - lastTime < commandCooldown)
+                    continue;
+
+                accepted.Add(cmd);
             }
-            else
+
+            if (accepted.Count == 0)
             {
-                OnUnrecognisedSpeech?.Invoke(parsed.RawText);
+                OnUnrecognisedSpeech?.Invoke(text);
+                return;
             }
+
+            // Fire per-command events in order
+            for (int i = 0; i < accepted.Count; i++)
+            {
+                _lastFireTime[accepted[i].Intent] = Time.time;
+                OnCommandRecognised?.Invoke(accepted[i]);
+            }
+
+            // Fire batch event
+            OnCommandsRecognised?.Invoke(accepted.ToArray());
         }
     }
 }

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -188,6 +188,7 @@ namespace VoskXR.Commands
                     now - lastTime < commandCooldown)
                     continue;
 
+                _lastFireTime[cmd.Intent] = now;
                 accepted.Add(cmd);
             }
 
@@ -196,10 +197,7 @@ namespace VoskXR.Commands
 
             // Fire per-command events in order
             for (int i = 0; i < accepted.Count; i++)
-            {
-                _lastFireTime[accepted[i].Intent] = now;
                 OnCommandRecognised?.Invoke(accepted[i]);
-            }
 
             // Fire batch event
             if (OnCommandsRecognised != null)

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -63,6 +63,7 @@ namespace VoskXR.Commands
         /// </summary>
         public void Configure(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands)
         {
+            _lastFireTime.Clear();
             _parser = new VoskCommandParser(slots, commands);
             _grammarJson = _parser.GenerateGrammarJson();
             _grammarApplied = false;
@@ -134,10 +135,7 @@ namespace VoskXR.Commands
             // Append to buffer and reset timer
             _bufferedTexts.Add(result.Text);
             if (result.Words != null && result.Words.Length > 0)
-            {
-                for (int i = 0; i < result.Words.Length; i++)
-                    _bufferedWords.Add(result.Words[i]);
-            }
+                _bufferedWords.AddRange(result.Words);
 
             _lastResultTime = Time.time;
             _bufferActive = true;
@@ -169,6 +167,7 @@ namespace VoskXR.Commands
                 return;
             }
 
+            float now = Time.time;
             var accepted = new List<VoskCommand>();
 
             for (int i = 0; i < results.Length; i++)
@@ -186,27 +185,25 @@ namespace VoskXR.Commands
                 // Per-intent debounce
                 if (commandCooldown > 0f &&
                     _lastFireTime.TryGetValue(cmd.Intent, out float lastTime) &&
-                    Time.time - lastTime < commandCooldown)
+                    now - lastTime < commandCooldown)
                     continue;
 
                 accepted.Add(cmd);
             }
 
             if (accepted.Count == 0)
-            {
-                OnUnrecognisedSpeech?.Invoke(text);
                 return;
-            }
 
             // Fire per-command events in order
             for (int i = 0; i < accepted.Count; i++)
             {
-                _lastFireTime[accepted[i].Intent] = Time.time;
+                _lastFireTime[accepted[i].Intent] = now;
                 OnCommandRecognised?.Invoke(accepted[i]);
             }
 
             // Fire batch event
-            OnCommandsRecognised?.Invoke(accepted.ToArray());
+            if (OnCommandsRecognised != null)
+                OnCommandsRecognised.Invoke(accepted.ToArray());
         }
     }
 }

--- a/Samples~/CommandRecognition/CommandDemo.cs
+++ b/Samples~/CommandRecognition/CommandDemo.cs
@@ -99,6 +99,7 @@ public class CommandDemo : MonoBehaviour
             commands: commands);
 
         commandRecogniser.OnCommandRecognised += OnCommand;
+        commandRecogniser.OnCommandsRecognised += OnCommandBatch;
         commandRecogniser.OnUnrecognisedSpeech += OnUnrecognised;
 
         recogniser.StartRecognition();
@@ -109,6 +110,7 @@ public class CommandDemo : MonoBehaviour
         if (commandRecogniser != null)
         {
             commandRecogniser.OnCommandRecognised -= OnCommand;
+            commandRecogniser.OnCommandsRecognised -= OnCommandBatch;
             commandRecogniser.OnUnrecognisedSpeech -= OnUnrecognised;
         }
     }
@@ -156,6 +158,13 @@ public class CommandDemo : MonoBehaviour
                 Debug.Log($"[CommandDemo]   Heading={hdgVal} (raw=\"{hdg}\"), Elevation={elevVal}");
                 break;
         }
+    }
+
+    void OnCommandBatch(VoskCommand[] commands)
+    {
+        Debug.Log($"[CommandDemo] Batch: {commands.Length} command(s) from single utterance");
+        for (int i = 0; i < commands.Length; i++)
+            Debug.Log($"[CommandDemo]   [{i}] {commands[i].Intent} (score={commands[i].Score:F2})");
     }
 
     void OnUnrecognised(string text)

--- a/Tests/Runtime/VoskCommandParserTests.cs
+++ b/Tests/Runtime/VoskCommandParserTests.cs
@@ -60,14 +60,25 @@ namespace VoskXR.Tests.Runtime
             return new VoskCommandParser(MakeSlots(), MakeCommands());
         }
 
+        /// <summary>
+        /// Convenience: parse and assert exactly one match, returning that result.
+        /// </summary>
+        static VoskCommandResult ParseOne(VoskCommandParser parser, string text,
+            VoskWord[] words = null)
+        {
+            var results = words != null ? parser.Parse(text, words) : parser.Parse(text);
+            Assert.AreEqual(1, results.Length,
+                $"Expected 1 match for \"{text}\" but got {results.Length}");
+            return results[0];
+        }
+
         [Test]
         public void ExactMatch_AllSlotsFilled()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("launch all missiles target hotel one");
+            var result = ParseOne(parser, "launch all missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.AreEqual("all", result.Command.GetSlot("quantity"));
@@ -80,9 +91,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("launch missiles target hotel one");
+            var result = ParseOne(parser, "launch missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
@@ -95,9 +105,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("fire all missiles at hotel one");
+            var result = ParseOne(parser, "fire all missiles at hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.AreEqual("all", result.Command.GetSlot("quantity"));
@@ -109,51 +118,49 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("launch all missiles target hotel one");
+            var result = ParseOne(parser, "launch all missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
         }
 
         [Test]
-        public void NoMatch_ReturnsFalse()
+        public void NoMatch_ReturnsEmpty()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("hello world");
+            var results = parser.Parse("hello world");
 
-            Assert.IsFalse(result.IsMatch);
-            Assert.AreEqual("hello world", result.RawText);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
-        public void EmptyInput_ReturnsFalse()
+        public void EmptyInput_ReturnsEmpty()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("");
+            var results = parser.Parse("");
 
-            Assert.IsFalse(result.IsMatch);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
-        public void WhitespaceInput_ReturnsFalse()
+        public void WhitespaceInput_ReturnsEmpty()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("   ");
+            var results = parser.Parse("   ");
 
-            Assert.IsFalse(result.IsMatch);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
-        public void NullInput_ReturnsFalse()
+        public void NullInput_ReturnsEmpty()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse(null);
+            var results = parser.Parse(null);
 
-            Assert.IsFalse(result.IsMatch);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
@@ -161,9 +168,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("cease fire");
+            var result = ParseOne(parser, "cease fire");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("cease_fire", result.Command.Intent);
             Assert.AreEqual(0, result.Command.Slots.Length);
         }
@@ -173,9 +179,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("launch [unk] missiles target hotel one");
+            var result = ParseOne(parser, "launch [unk] missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
@@ -273,9 +278,8 @@ namespace VoskXR.Tests.Runtime
                 new VoskWord("fire", 0.72f, 0.3f, 0.6f),
             };
 
-            var result = parser.Parse("cease fire", words);
+            var result = ParseOne(parser, "cease fire", words);
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual(0.72f, result.Command.Confidence, 0.001f);
         }
 
@@ -284,22 +288,19 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("cease fire");
+            var result = ParseOne(parser, "cease fire");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual(-1f, result.Command.Confidence, 0.001f);
         }
 
         [Test]
-        public void DefaultCommand_WhenNoMatch()
+        public void NoMatch_EmptyArray()
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("something random");
+            var results = parser.Parse("something random");
 
-            Assert.IsFalse(result.IsMatch);
-            Assert.AreEqual(default(VoskCommand), result.Command);
-            Assert.IsNull(result.Command.Intent);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
@@ -307,9 +308,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("shoot missiles");
+            var result = ParseOne(parser, "shoot missiles");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.IsFalse(result.Command.HasSlot("target"));
@@ -320,9 +320,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("set distance torpedo range target hotel two");
+            var result = ParseOne(parser, "set distance torpedo range target hotel two");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("set_distance_named", result.Command.Intent);
             Assert.AreEqual("torpedo range", result.Command.GetSlot("range"));
             Assert.AreEqual("hotel two", result.Command.GetSlot("target"));
@@ -333,9 +332,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("disengage");
+            var result = ParseOne(parser, "disengage");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("cease_fire", result.Command.Intent);
         }
 
@@ -356,9 +354,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("cease fire");
+            var result = ParseOne(parser, "cease fire");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
         }
 
@@ -369,8 +366,7 @@ namespace VoskXR.Tests.Runtime
             // has more literals and should win on tie-break
             var parser = CreateParser();
 
-            var result = parser.Parse("cease fire");
-            Assert.IsTrue(result.IsMatch);
+            var result = ParseOne(parser, "cease fire");
             Assert.AreEqual("cease_fire", result.Command.Intent);
         }
 
@@ -381,9 +377,8 @@ namespace VoskXR.Tests.Runtime
 
             // Pattern: "launch", "?a", "{?quantity}", "{weapon}", "target", "{target}"
             // Input has "a" present
-            var result = parser.Parse("launch a jackal target hotel one");
+            var result = ParseOne(parser, "launch a jackal target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("jackal", result.Command.GetSlot("weapon"));
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
@@ -396,9 +391,8 @@ namespace VoskXR.Tests.Runtime
 
             // Pattern: "launch", "?a", "{?quantity}", "{weapon}", "target", "{target}"
             // Input lacks "a" — should still match
-            var result = parser.Parse("launch jackal target hotel one");
+            var result = ParseOne(parser, "launch jackal target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("jackal", result.Command.GetSlot("weapon"));
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
@@ -410,9 +404,8 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateParser();
 
             // "uh" is not a grammar word; sliding start should find "cease fire" starting at token 1
-            var result = parser.Parse("uh cease fire");
+            var result = ParseOne(parser, "uh cease fire");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("cease_fire", result.Command.Intent);
         }
 
@@ -422,9 +415,8 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateParser();
 
             // Double "launch" — sliding start finds best match from later position
-            var result = parser.Parse("launch launch all missiles target hotel one");
+            var result = ParseOne(parser, "launch launch all missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("missiles", result.Command.GetSlot("weapon"));
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
@@ -435,9 +427,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("shoot jackals");
+            var result = ParseOne(parser, "shoot jackals");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             Assert.AreEqual("jackal", result.Command.GetSlot("weapon"));
         }
@@ -448,9 +439,8 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateParser();
 
             // "a" in quantity context should resolve to "one" via alias
-            var result = parser.Parse("launch a missiles target hotel one");
+            var result = ParseOne(parser, "launch a missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("launch_weapon", result.Command.Intent);
             // "a" could match as optional literal or as quantity alias.
             // The pattern with ?a should consume "a" as optional literal,
@@ -521,9 +511,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateNumericParser();
 
-            var result = parser.Parse("orient to heading two seven zero");
+            var result = ParseOne(parser, "orient to heading two seven zero");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("set_heading", result.Command.Intent);
             Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
         }
@@ -533,9 +522,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateNumericParser();
 
-            var result = parser.Parse("orient to heading two seven zero mark one five");
+            var result = ParseOne(parser, "orient to heading two seven zero mark one five");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("set_heading", result.Command.Intent);
             Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
             Assert.AreEqual("one five", result.Command.GetSlot("elevation"));
@@ -546,9 +534,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateNumericParser();
 
-            var result = parser.Parse("orient to heading five");
+            var result = ParseOne(parser, "orient to heading five");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("set_heading", result.Command.Intent);
             Assert.AreEqual("five", result.Command.GetSlot("heading"));
         }
@@ -559,9 +546,8 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateNumericParser();
 
             // "mark" is not a digit word — heading should stop at 3 words
-            var result = parser.Parse("orient to heading two seven zero mark");
+            var result = ParseOne(parser, "orient to heading two seven zero mark");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("two seven zero", result.Command.GetSlot("heading"));
         }
 
@@ -571,9 +557,8 @@ namespace VoskXR.Tests.Runtime
             // elevation has maxWords=2; input has 3 digit words after "mark"
             var parser = CreateNumericParser();
 
-            var result = parser.Parse("orient to heading five mark one two three");
+            var result = ParseOne(parser, "orient to heading five mark one two three");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("five", result.Command.GetSlot("heading"));
             // elevation should consume only 2 of the 3 digits
             Assert.AreEqual("one two", result.Command.GetSlot("elevation"));
@@ -598,9 +583,9 @@ namespace VoskXR.Tests.Runtime
             var parser = new VoskCommandParser(slots, commands);
 
             // Only 1 digit word — below minWords=2, required slot fails
-            var result = parser.Parse("enter five");
+            var results = parser.Parse("enter five");
 
-            Assert.IsFalse(result.IsMatch);
+            Assert.AreEqual(0, results.Length);
         }
 
         [Test]
@@ -609,9 +594,8 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateNumericParser();
 
             // "orient to heading five mark" — no digits after "mark" for optional elevation
-            var result = parser.Parse("orient to heading five mark");
+            var result = ParseOne(parser, "orient to heading five mark");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("set_heading", result.Command.Intent);
             Assert.AreEqual("five", result.Command.GetSlot("heading"));
             Assert.IsFalse(result.Command.HasSlot("elevation"));
@@ -622,9 +606,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateNumericParser();
 
-            var result = parser.Parse("close distance fifteen klicks target bravo two");
+            var result = ParseOne(parser, "close distance fifteen klicks target bravo two");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("close_distance", result.Command.Intent);
             Assert.AreEqual("fifteen", result.Command.GetSlot("heading"));
             Assert.AreEqual("bravo two", result.Command.GetSlot("target"));
@@ -664,9 +647,8 @@ namespace VoskXR.Tests.Runtime
         {
             var parser = CreateParser();
 
-            var result = parser.Parse("launch all missiles target hotel one");
+            var result = ParseOne(parser, "launch all missiles target hotel one");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.GreaterOrEqual(result.Command.Score, 0f);
             Assert.LessOrEqual(result.Command.Score, 1f);
         }
@@ -677,12 +659,10 @@ namespace VoskXR.Tests.Runtime
             var parser = CreateParser();
 
             // "disengage" = 1 element pattern, score = 1/1 = 1.0
-            var shortResult = parser.Parse("disengage");
+            var shortResult = ParseOne(parser, "disengage");
             // "cease fire" = 2 element pattern, score = 2/2 = 1.0
-            var longResult = parser.Parse("cease fire");
+            var longResult = ParseOne(parser, "cease fire");
 
-            Assert.IsTrue(shortResult.IsMatch);
-            Assert.IsTrue(longResult.IsMatch);
             // Both should have score 1.0 since they match perfectly
             Assert.AreEqual(shortResult.Command.Score, longResult.Command.Score, 0.001f);
         }
@@ -726,10 +706,121 @@ namespace VoskXR.Tests.Runtime
 
             // "cease fire please" — "please" is leftover. Sliding start from 0 matches
             // "cease fire" with score 2/2 = 1.0, which is the best.
-            var result = parser.Parse("cease fire please");
+            var result = ParseOne(parser, "cease fire please");
 
-            Assert.IsTrue(result.IsMatch);
             Assert.AreEqual("cease_fire", result.Command.Intent);
+        }
+
+        // --- Sequential command extraction tests (v2.3) ---
+
+        [Test]
+        public void Sequential_TwoCommandsInOneUtterance()
+        {
+            var parser = CreateParser();
+
+            // "cease fire" should match cease_fire, then remaining tokens match launch_weapon
+            var results = parser.Parse("cease fire launch all missiles target hotel one");
+
+            Assert.AreEqual(2, results.Length);
+            Assert.AreEqual("cease_fire", results[0].Command.Intent);
+            Assert.AreEqual("launch_weapon", results[1].Command.Intent);
+            Assert.AreEqual("missiles", results[1].Command.GetSlot("weapon"));
+            Assert.AreEqual("hotel one", results[1].Command.GetSlot("target"));
+        }
+
+        [Test]
+        public void Sequential_SingleCommandNoRemainder()
+        {
+            var parser = CreateParser();
+
+            var results = parser.Parse("launch missiles target hotel one");
+
+            Assert.AreEqual(1, results.Length);
+            Assert.AreEqual("launch_weapon", results[0].Command.Intent);
+        }
+
+        [Test]
+        public void Sequential_TwoShortCommandsInOrder()
+        {
+            var parser = CreateParser();
+
+            var results = parser.Parse("cease fire resume fire");
+
+            Assert.AreEqual(2, results.Length);
+            Assert.AreEqual("cease_fire", results[0].Command.Intent);
+            Assert.AreEqual("resume_fire", results[1].Command.Intent);
+        }
+
+        [Test]
+        public void Sequential_NoisePlusSingleCommand()
+        {
+            var parser = CreateParser();
+
+            // "hello world" is noise, sliding start finds "cease fire"
+            var results = parser.Parse("hello world cease fire");
+
+            Assert.AreEqual(1, results.Length);
+            Assert.AreEqual("cease_fire", results[0].Command.Intent);
+        }
+
+        [Test]
+        public void Sequential_NoiseDoesNotProduceSecondCommand()
+        {
+            var parser = CreateParser();
+
+            // After extracting "cease fire", "please" has no match
+            var results = parser.Parse("cease fire please");
+
+            Assert.AreEqual(1, results.Length);
+            Assert.AreEqual("cease_fire", results[0].Command.Intent);
+        }
+
+        [Test]
+        public void Sequential_RawTextIsFullInput()
+        {
+            var parser = CreateParser();
+
+            var results = parser.Parse("cease fire resume fire");
+
+            // Both commands should carry the full original text
+            Assert.AreEqual("cease fire resume fire", results[0].Command.RawText);
+            Assert.AreEqual("cease fire resume fire", results[1].Command.RawText);
+        }
+
+        [Test]
+        public void Sequential_CommandThenWeaponCommand()
+        {
+            var parser = CreateParser();
+
+            // Reversed order: weapon command first, then cease_fire
+            var results = parser.Parse("launch missiles target hotel one cease fire");
+
+            Assert.AreEqual(2, results.Length);
+            Assert.AreEqual("launch_weapon", results[0].Command.Intent);
+            Assert.AreEqual("cease_fire", results[1].Command.Intent);
+        }
+
+        [Test]
+        public void Sequential_ConfidencePropagatedPerCommand()
+        {
+            var parser = CreateParser();
+
+            var words = new[]
+            {
+                new VoskWord("cease", 0.95f, 0.0f, 0.3f),
+                new VoskWord("fire", 0.72f, 0.3f, 0.6f),
+                new VoskWord("resume", 0.88f, 0.7f, 1.0f),
+            };
+
+            // "cease fire resume fire" — two commands
+            // "fire" appears in both; word confidence map stores first occurrence (0.72)
+            var results = parser.Parse("cease fire resume fire", words);
+
+            Assert.AreEqual(2, results.Length);
+            // First command: min(cease=0.95, fire=0.72) = 0.72
+            Assert.AreEqual(0.72f, results[0].Command.Confidence, 0.001f);
+            // Second command: min(resume=0.88, fire=0.72) = 0.72
+            Assert.AreEqual(0.72f, results[1].Command.Confidence, 0.001f);
         }
     }
 }

--- a/v2-command-recognition-plan.md
+++ b/v2-command-recognition-plan.md
@@ -130,7 +130,7 @@ When any `NumberSequence` slot exists, add the ~30 digit vocabulary words to the
 
 ---
 
-# v2.3 — Continuity
+# v2.3 — Continuity (Shipped)
 
 Solves the two biggest real-world command failures: mid-utterance pauses splitting a command across two VOSK results, and multiple commands spoken in a single breath where only the first is recognised.
 

--- a/v2-command-recognition-plan.md
+++ b/v2-command-recognition-plan.md
@@ -30,247 +30,21 @@ Scored matching, sliding start, slot aliases, optional literals, `minConfidence`
 
 ---
 
-# v2.2 — Numeric Commands
+# v2.2 — Numeric Commands (Shipped v0.6.0)
 
-Unlocks heading, distance, and coordinate commands that use variable-length digit sequences.
-
-## v2.2 Scope
-
-**Includes:**
-- `VoskSlotType` enum: `Enumerated`, `NumberSequence`
-- `VoskSlotDefinition.NumberSequence()` static factory
-- `VoskNumberParser` — digit sequence + cardinal number word conversion
-- Digit vocabulary auto-added to grammar when NumberSequence slots present
-
-**Commands this additionally handles:**
-- "Orient to heading two seven zero mark plus one five"
-- "Orient to heading two seven zero"
-- "Close distance ten klicks target hotel one"
-- "Set distance fifteen klicks target bravo two"
-- Any numeric quantity without enumerating every possible value
-
-## v2.2 Changes to Data Model
-
-### `VoskSlotType` enum (new file)
-```csharp
-public enum VoskSlotType { Enumerated, NumberSequence }
-```
-
-### `VoskSlotDefinition` gains NumberSequence mode
-
-```csharp
-// Static factory — no value enumeration needed
-var heading = VoskSlotDefinition.NumberSequence("heading", minWords: 1, maxWords: 3);
-var elevation = VoskSlotDefinition.NumberSequence("elevation", minWords: 1, maxWords: 2);
-var distance = VoskSlotDefinition.NumberSequence("distance", minWords: 1, maxWords: 3);
-```
-
-- `int MinWords`, `int MaxWords` — bounds on digit word consumption
-- Matches consecutive tokens from digit word vocabulary: "zero"–"nine", "ten"–"nineteen", "twenty"–"ninety", "hundred", "thousand" (~30 static entries)
-- Returns raw word sequence as slot value string (e.g., "two seven zero")
-
-### `VoskNumberParser` — static utility (new file)
-
-Pure C# utility, ~60 lines:
-- `int ParseDigitSequence(string words)` — "two seven zero" → 270 (each word = one digit, concatenated)
-- `int ParseCardinal(string words)` — "fifteen" → 15, "two hundred" → 200
-
-Static `Dictionary<string, int>` mapping ~30 entries.
-
-## v2.2 Changes to Matching Algorithm
-
-When the pattern cursor hits a `NumberSequence` slot:
-1. Greedily consume consecutive tokens that are in the digit word HashSet
-2. Stop when a non-digit word is encountered or `maxWords` is reached
-3. If consumed count < `minWords`, slot fails to match (required/optional per `{slot}` vs `{?slot}` syntax)
-4. Return the consumed words joined by space as the slot value
-
-## v2.2 Grammar Generation Changes
-
-When any `NumberSequence` slot exists, add the ~30 digit vocabulary words to the grammar. This is a fixed set regardless of how many NumberSequence slots are defined.
-
-## v2.2 New Files
-
-| File | Purpose |
-|------|---------|
-| `Runtime/Commands/VoskSlotType.cs` | Slot type enum |
-| `Runtime/Commands/VoskNumberParser.cs` | Digit sequence + cardinal number word conversion |
-| `Tests/Runtime/VoskNumberParserTests.cs` | Number parser unit tests |
-
-## v2.2 Modified Files
-
-| File | Change |
-|------|--------|
-| `Runtime/Commands/VoskSlotDefinition.cs` | Add `NumberSequence` factory, `MinWords`/`MaxWords`, `Type` field |
-| `Runtime/Commands/VoskCommandParser.cs` | NumberSequence matching logic, digit vocab in grammar |
-
-## v2.2 Test Plan
-
-**NumberSequence slots:**
-- "two seven zero" matches heading slot (3 digit words) → value "two seven zero"
-- "one five" matches elevation slot (2 digit words) → value "one five"
-- "fifteen" matches distance slot (1 word) → value "fifteen"
-- Stops at non-digit word: "two seven zero mark" → heading consumes 3, stops before "mark"
-- Respects maxWords: slot with maxWords=2 stops after 2 even if more digits follow
-- Below minWords: slot with minWords=2, input has 1 digit word → no match
-
-**Number parser:**
-- "two seven zero" → 270 (digit sequence)
-- "one five" → 15 (digit sequence)
-- "zero" → 0
-- "nine" → 9
-- "fifteen" → 15 (cardinal)
-- "twenty" → 20 (cardinal)
-- "two hundred" → 200 (cardinal)
-- Empty string → 0
-
-**Grammar generation:**
-- Digit vocabulary words included when at least one NumberSequence slot exists
-- Not included when no NumberSequence slots exist
+`NumberSequence` slot type, `VoskNumberParser` (digit sequence + cardinal conversion), greedy digit-word consumption with `minWords`/`maxWords` bounds, auto-generated digit vocabulary in grammar. Quest device-tested (40 tests, 31/35 pass in v2.2 matrix). See `CHANGELOG.md` [0.6.0] for details. Full test results in `v2.2-test-matrix.md`.
 
 ---
 
-# v2.3 — Continuity (Shipped)
+# v2.3 — Continuity (Shipped v0.7.0)
 
-Solves the two biggest real-world command failures: mid-utterance pauses splitting a command across two VOSK results, and multiple commands spoken in a single breath where only the first is recognised.
-
-## v2.3 Scope
-
-**Includes:**
-- Utterance buffer that concatenates consecutive VOSK results within a time window before parsing
-- Sequential command extraction — after the best match, try matching again from the next token
-- Per-intent debounce to suppress duplicate firings from rapid repeated results
-
-**Problems this solves:**
-- "Launch all missiles" [pause] "target hotel one" — two VOSK results, neither matches alone. Buffer concatenates them → single parse succeeds.
-- "Cease fire launch all missiles target hotel one" — single VOSK result. Sequential extraction finds `cease_fire` at tokens 0–1, then `launch_weapon` at tokens 2+.
-- Player says "fire" and VOSK emits two rapid final results → debounce suppresses the duplicate.
-
-## v2.3 Utterance Buffer
-
-`VoskUtteranceBuffer` — pure C# class, sits between `VoskCommandRecogniser` and the parser. Not a MonoBehaviour — owned and ticked by `VoskCommandRecogniser`.
-
-### Behaviour
-
-1. When a final result arrives from VOSK, append its tokens to the buffer. Record the arrival timestamp.
-2. Start (or reset) a flush timer: `bufferWindow` seconds (default 1.5s, configurable via `[SerializeField]`).
-3. If another final result arrives before the timer expires, append its tokens and reset the timer.
-4. When the timer expires (no new results within the window), flush: concatenate all buffered tokens into a single string and pass to the parser.
-5. Per-word confidence: buffer also accumulates the per-word confidence arrays. When flushing, the concatenated confidence array is passed through so `VoskCommand.Confidence` (min across matched tokens) remains accurate.
-
-### Why a time window, not immediate parse
-
-If we parse immediately on each result, we're back to the current behaviour — the first half of a split command fails and is discarded before the second half arrives. The window gives the player time to finish the full command across a natural pause. 1.5s is long enough for a mid-sentence breath but short enough to feel responsive.
-
-### Tradeoff: latency
-
-The buffer adds up to `bufferWindow` latency to every command. In the worst case (single complete command, no pause), the player waits 1.5s after finishing speech before the command fires. This is acceptable for a military sim (commands are deliberate, not twitch), but the field is tunable per game.
-
-### Edge case: rapid distinct commands
-
-Player says "cease fire" [0.5s pause] "launch missiles target hotel one". Both arrive within the buffer window and get concatenated: "cease fire launch missiles target hotel one". Sequential command extraction (below) handles this — it finds both commands in the merged string.
-
-### Fields on `VoskCommandRecogniser`
-
-```csharp
-[Tooltip("Time in seconds to wait for additional speech before parsing. " +
-         "Longer values recover split commands but add latency.")]
-[SerializeField] float bufferWindow = 1.5f;
-```
-
-### Implementation notes
-
-- Buffer is flushed in `Update()` by checking `Time.time - lastResultTime >= bufferWindow` when the buffer is non-empty.
-- `VoskCommandRecogniser` already subscribes to `OnResult`. The buffer sits in the handler before the parse call.
-- If `bufferWindow` is set to 0, buffering is disabled — results are parsed immediately as in v2.2 (backwards compatible).
-
-## v2.3 Sequential Command Extraction
-
-Changes `VoskCommandParser.Parse()` return type from `VoskCommandResult` to `VoskCommandResult[]`.
-
-### Algorithm
-
-1. Run the existing scored matching + sliding start algorithm. Find the best match.
-2. If a match is found, record it. Identify the token span it consumed (start position through last consumed token).
-3. Take the remaining tokens *after* the consumed span. If non-empty, run the parser again on the remainder.
-4. Repeat until no more matches are found or tokens are exhausted.
-5. Return all matches as an array, ordered by their position in the input.
-
-### Why ordered by position, not score
-
-The player spoke commands in a specific order: "cease fire, launch missiles". The game should process them in that order. Reordering by score would produce unpredictable command sequences.
-
-### Event changes
-
-`OnCommandRecognised` fires once per extracted command, in order. Existing subscribers that handle one command at a time work unchanged. New `OnCommandsRecognised` event (plural) fires once with the full `VoskCommand[]` array for subscribers that want batch processing.
-
-```csharp
-public event Action<VoskCommand> OnCommandRecognised;       // fires per command, in order
-public event Action<VoskCommand[]> OnCommandsRecognised;    // fires once with all commands
-```
-
-### Edge case: overlapping matches
-
-Two commands share vocabulary (e.g., "fire" appears in both `launch_weapon` and `cease_fire`). The first match consumes its tokens; the remainder is what's left. If the remainder doesn't form a valid second command, it's reported via `OnUnrecognisedSpeech`. No backtracking — greedy left-to-right extraction.
-
-## v2.3 Per-Intent Debounce
-
-Simple per-intent cooldown timer on `VoskCommandRecogniser`.
-
-```csharp
-[Tooltip("Minimum seconds between firing the same intent. " +
-         "Prevents duplicate commands from rapid VOSK results.")]
-[SerializeField] float commandCooldown = 0.3f;
-```
-
-- Tracks `Dictionary<string, float>` of intent → last fire time.
-- Before firing `OnCommandRecognised`, checks if `Time.time - lastFireTime[intent] >= commandCooldown`. If not, the command is suppressed.
-- Cooldown of 0 disables debounce.
-- Different intents have independent cooldowns — "cease fire" doesn't block "launch missiles".
-
-## v2.3 Modified Files
-
-| File | Change |
-|------|--------|
-| `Runtime/Commands/VoskCommandParser.cs` | `Parse()` returns `VoskCommandResult[]`, sequential extraction loop |
-| `Runtime/Commands/VoskCommandRecogniser.cs` | Utterance buffer, `bufferWindow` field, `OnCommandsRecognised` event, debounce logic, `commandCooldown` field |
-| `Runtime/Commands/VoskCommand.cs` | No changes (result type unchanged) |
-
-## v2.3 New Files
-
-None. All changes are to existing files.
-
-## v2.3 Test Plan
-
-**Utterance buffer:**
-- Two results arriving within window → concatenated and parsed as one
-- Single result, timer expires → parsed normally
-- Three rapid results → all concatenated
-- `bufferWindow = 0` → immediate parse (v2.2 behaviour)
-- Per-word confidence arrays correctly concatenated across buffered results
-
-**Sequential command extraction:**
-- "cease fire launch all missiles target hotel one" → two commands: `cease_fire`, `launch_weapon`
-- "launch missiles target hotel one" → one command (no remainder after extraction)
-- "cease fire resume fire" → two commands in order
-- "hello world cease fire" → sliding start finds `cease_fire`, no second command, "hello world" is noise
-- Overlapping vocabulary: first match wins its span, remainder parsed independently
-
-**Debounce:**
-- Same intent fired twice within cooldown → second suppressed
-- Same intent fired after cooldown expires → both fire
-- Different intents within cooldown → both fire (independent cooldowns)
-- `commandCooldown = 0` → no suppression
-
-**Integration:**
-- Buffer + sequential extraction: "cease fire" [pause] "launch missiles target hotel one" → buffer merges, sequential extraction finds both
-- Buffer + debounce: VOSK emits "fire" twice rapidly → buffer merges to "fire fire", parser matches one `launch_weapon`, debounce irrelevant (only one match). Alternatively if both parse separately, debounce catches the duplicate.
+Utterance buffer (`bufferWindow`) merges split VOSK results before parsing. Sequential command extraction (left-to-right greedy) finds multiple commands per utterance. Per-intent debounce (`commandCooldown`) suppresses duplicates both across results and within a single parse batch. `OnCommandsRecognised` batch event added. Quest device-tested (40 tests, 40/40 pass). See `CHANGELOG.md` [0.7.0] for details. Full test results in `v2.3-test-matrix.md`.
 
 ---
 
 # v2.4 — Command Sets
 
-Lets the game activate different command groups for different game states. Reduces grammar size per mode for better VOSK accuracy. Adds push-to-talk for scenarios where always-on recognition is undesirable.
+Lets the game activate different command groups for different game states. Reduces grammar size per mode for better VOSK accuracy.
 
 ## v2.4 Scope
 
@@ -278,12 +52,10 @@ Lets the game activate different command groups for different game states. Reduc
 - `VoskCommandSet` — named group of command definitions
 - Runtime switching between active command sets (regenerates grammar)
 - Additive sets — multiple sets active simultaneously (e.g., "common" + "weapons")
-- Push-to-talk mode — recognition starts/stops on input action
 
 **Problems this solves:**
 - Grammar contains all command words across all game modes → VOSK confuses acoustically similar words from unrelated modes. Smaller per-mode grammar = higher accuracy.
 - Player in the navigation screen hears weapon commands recognised from ambient speech. With command sets, weapon commands aren't active during navigation.
-- Some scenarios need recognition only when the player is actively commanding (push-to-talk).
 
 ## v2.4 `VoskCommandSet`
 
@@ -351,38 +123,11 @@ commandRecogniser.SetActiveSets("weapons", "common");
 commandRecogniser.SetActiveSets("navigation", "common");
 ```
 
-## v2.4 Push-to-Talk
-
-A mode on `VoskCommandRecogniser` where recognition is only active while an input is held.
-
-```csharp
-[Tooltip("When enabled, recognition only runs while pushToTalkAction is held. " +
-         "Eliminates phantom commands when the player is not actively commanding.")]
-[SerializeField] bool pushToTalkEnabled = false;
-
-[Tooltip("Input action that activates recognition. Typically a controller grip or trigger.")]
-[SerializeField] InputActionReference pushToTalkAction;
-```
-
-### Behaviour
-
-- When `pushToTalkEnabled` is true and the action is pressed: `StartRecognition()`.
-- When the action is released: waits `pushToTalkTail` seconds (default 0.5s) for the final VOSK result to arrive, then `StopRecognition()`.
-- The tail delay prevents cutting off the last word. VOSK needs a moment of silence after speech to emit the final result.
-- When `pushToTalkEnabled` is false (default): recognition runs continuously as in v2.0–v2.3.
-- Push-to-talk composes with the utterance buffer: the buffer flushes either on timer expiry or on push-to-talk release (whichever comes first), ensuring commands are processed promptly when the player lets go.
-
-### Input System dependency
-
-Uses Unity's Input System (`UnityEngine.InputSystem`). The `InputActionReference` field is nullable — if push-to-talk is enabled but no action is assigned, a warning is logged and push-to-talk is disabled at runtime.
-
-Assembly definition gains optional reference to `Unity.InputSystem`. Push-to-talk code is behind `#if ENABLE_INPUT_SYSTEM` so the package compiles without Input System installed (push-to-talk simply isn't available).
-
 ## v2.4 Modified Files
 
 | File | Change |
 |------|--------|
-| `Runtime/Commands/VoskCommandRecogniser.cs` | Command sets API, `SetActiveSets()`, push-to-talk fields and logic |
+| `Runtime/Commands/VoskCommandRecogniser.cs` | Command sets API, `SetActiveSets()` |
 | `Runtime/Commands/VoskCommandParser.cs` | Accept filtered command list at construction (already does — no parser change needed, just constructed with fewer commands) |
 
 ## v2.4 New Files
@@ -402,19 +147,11 @@ Assembly definition gains optional reference to `Unity.InputSystem`. Push-to-tal
 - Grammar regenerated on switch: only active vocabulary words present
 - `Configure(slots, commands)` (no sets) → all commands active, backwards compatible
 
-**Push-to-talk:**
-- Action pressed → recognition starts
-- Action released → recognition stops after tail delay
-- Speech during release tail → final result captured
-- Push-to-talk disabled → continuous recognition (v2.3 behaviour)
-- No action assigned + push-to-talk enabled → warning, falls back to continuous
-- `#if ENABLE_INPUT_SYSTEM` absent → push-to-talk fields hidden, continuous only
-
 ---
 
 # v2.5 — Inspector Authoring
 
-Adds ScriptableObject-based command and slot authoring for designers who prefer the Inspector over code. Does not replace the code API — provides a parallel authoring path.
+Adds ScriptableObject-based command and slot authoring for designers who prefer the Inspector over code. Does not replace the code API — provides a parallel authoring path. Also adds push-to-talk mode for scenarios where always-on recognition is undesirable.
 
 ## v2.5 Scope
 
@@ -424,11 +161,13 @@ Adds ScriptableObject-based command and slot authoring for designers who prefer 
 - `VoskCommandSetAsset` ScriptableObject for command set grouping
 - Inspector-driven `Configure()` overloads on `VoskCommandRecogniser`
 - Serialized asset references on `VoskCommandRecogniser` for zero-code setup
+- Push-to-talk mode — recognition starts/stops on input action
 
 **Problems this solves:**
 - Designers can't author commands without writing C# — they depend on a programmer for every vocabulary change.
 - Iteration is slow: change a slot value → recompile → test. With ScriptableObjects: change a value in Inspector → enter play mode → test.
 - No visual overview of all commands and their patterns.
+- Some scenarios need recognition only when the player is actively commanding (push-to-talk).
 
 ## v2.5 `VoskSlotAsset`
 
@@ -503,6 +242,33 @@ public class VoskCommandSetAsset : ScriptableObject
 }
 ```
 
+## v2.5 Push-to-Talk
+
+A mode on `VoskCommandRecogniser` where recognition is only active while an input is held.
+
+```csharp
+[Tooltip("When enabled, recognition only runs while pushToTalkAction is held. " +
+         "Eliminates phantom commands when the player is not actively commanding.")]
+[SerializeField] bool pushToTalkEnabled = false;
+
+[Tooltip("Input action that activates recognition. Typically a controller grip or trigger.")]
+[SerializeField] InputActionReference pushToTalkAction;
+```
+
+### Behaviour
+
+- When `pushToTalkEnabled` is true and the action is pressed: `StartRecognition()`.
+- When the action is released: waits `pushToTalkTail` seconds (default 0.5s) for the final VOSK result to arrive, then `StopRecognition()`.
+- The tail delay prevents cutting off the last word. VOSK needs a moment of silence after speech to emit the final result.
+- When `pushToTalkEnabled` is false (default): recognition runs continuously as in v2.0–v2.4.
+- Push-to-talk composes with the utterance buffer: the buffer flushes either on timer expiry or on push-to-talk release (whichever comes first), ensuring commands are processed promptly when the player lets go.
+
+### Input System dependency
+
+Uses Unity's Input System (`UnityEngine.InputSystem`). The `InputActionReference` field is nullable — if push-to-talk is enabled but no action is assigned, a warning is logged and push-to-talk is disabled at runtime.
+
+Assembly definition gains optional reference to `Unity.InputSystem`. Push-to-talk code is behind `#if ENABLE_INPUT_SYSTEM` so the package compiles without Input System installed (push-to-talk simply isn't available).
+
 ## v2.5 Changes to `VoskCommandRecogniser`
 
 ```csharp
@@ -526,7 +292,7 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 
 | File | Change |
 |------|--------|
-| `Runtime/Commands/VoskCommandRecogniser.cs` | Asset reference fields, auto-configure from assets in `Awake()` |
+| `Runtime/Commands/VoskCommandRecogniser.cs` | Asset reference fields, auto-configure from assets in `Awake()`, push-to-talk fields and logic |
 
 ## v2.5 Test Plan
 
@@ -541,6 +307,14 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 - Code `Configure()` call → Inspector assets ignored
 - Missing slot asset referenced by command pattern → validation warning at configure time
 
+**Push-to-talk:**
+- Action pressed → recognition starts
+- Action released → recognition stops after tail delay
+- Speech during release tail → final result captured
+- Push-to-talk disabled → continuous recognition (v2.4 behaviour)
+- No action assigned + push-to-talk enabled → warning, falls back to continuous
+- `#if ENABLE_INPUT_SYSTEM` absent → push-to-talk fields hidden, continuous only
+
 ---
 
 # Version Summary
@@ -551,8 +325,8 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 | **v2.1** | Robustness | Scored matching, sliding start, aliases, optional literals, thresholds | Same commands, reliable with real speech |
 | **v2.2** | Numeric | NumberSequence slots, VoskNumberParser | Headings, numeric distances, coordinates |
 | **v2.3** | Continuity | Utterance buffer, sequential command extraction, debounce | Split commands recovered, chained commands extracted |
-| **v2.4** | Command Sets | Named command groups, runtime switching, push-to-talk | Mode-specific commands, reduced grammar per mode |
-| **v2.5** | Inspector Authoring | ScriptableObject slots/commands/sets, zero-code setup | Same commands, designer-friendly authoring |
+| **v2.4** | Command Sets | Named command groups, runtime switching | Mode-specific commands, reduced grammar per mode |
+| **v2.5** | Inspector Authoring | ScriptableObject slots/commands/sets, zero-code setup, push-to-talk | Same commands, designer-friendly authoring, input-gated recognition |
 
 Native bridge change (`vosk_bridge_set_grammar`) ships in v2.0. Everything in v2.1–v2.5 is pure C# changes on top.
 
@@ -583,28 +357,6 @@ A `VoskSlotType.FreeText` that captures remaining tokens until the next literal.
 ---
 
 # Known Limitations & Notes
-
-## Leftover tokens in v2.0 (free-speech mode)
-
-In v2.0, the parser does not require full input consumption. With grammar active this is fine (VOSK only outputs command vocabulary). In **free-speech mode**, input like "launch all missiles target hotel one please thank you" will match `launch_weapon` despite the trailing words "please thank you". This is a known v2.0 limitation — v2.1's scored matching penalizes leftover tokens and the `minScore` threshold can reject low-quality matches.
-
-## Mid-utterance pauses
-
-VOSK's endpointer splits utterances at silence boundaries. If a player says "launch all missiles" (long pause) "target hotel one", VOSK emits two separate final results: `"launch all missiles"` and `"target hotel one"`. Neither matches the full command pattern. The command is lost.
-
-**Mitigation (v2.0–v2.2)**: Players should speak compound commands without long pauses. This is a VOSK endpointer behavior, not a parser limitation.
-
-**Fixed in v2.3**: The utterance buffer concatenates consecutive results within a configurable time window before parsing, recovering split commands.
-
-## Short utterances and phantom commands
-
-With grammar active, very short sounds (coughs, "uh") may be mapped to the acoustically closest grammar word (e.g., a cough → "fire"). In v2.0, there is no confidence-based filtering — the parser will match if the word fits a pattern. **v2.1 adds `minConfidence` to filter these.** For v2.0, single-word commands like "disengage" are more susceptible than multi-word commands.
-
-## Multiple commands in one breath
-
-"Cease fire launch all missiles target hotel one" spoken without pause arrives as a single VOSK result. The parser matches **one** command per result (the best-scoring match). The second command is lost.
-
-**Fixed in v2.3**: Sequential command extraction matches from the token after the first match's span, extracting all commands from a single utterance.
 
 ## Grammar is a flat word list, not phrase constraints
 

--- a/v2.3-test-matrix.md
+++ b/v2.3-test-matrix.md
@@ -1,0 +1,187 @@
+# V2.3 Utterance Buffer, Sequential Extraction & Debounce — Quest Device Test Matrix
+
+## Prerequisites
+
+1. **Scene**: `VoskSpeechRecogniser` + `VoskCommandRecogniser` + `CommandDemo` wired together
+2. **Update `CommandDemo.cs`** to add batch event logging (see [Demo Changes](#demo-changes) below)
+3. **Build & deploy** to Quest
+4. **Inspector defaults**: `minScore=0.6`, `minConfidence=0.4`, `freeSpeechMode=false`, `bufferWindow=1.5`, `commandCooldown=0.3`
+5. **Logcat**:
+   ```bash
+   "/mnt/c/Program Files/Unity/Hub/Editor/6000.3.7f1/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platform-tools/adb.exe" logcat -s "Unity:*" "vosk-bridge:*"
+   ```
+
+## Demo Changes
+
+Add the batch event handler to `CommandDemo.cs` to verify `OnCommandsRecognised`:
+
+```csharp
+// In Start(), after existing subscriptions:
+commandRecogniser.OnCommandsRecognised += OnCommandBatch;
+
+// In OnDestroy(), add unsubscription:
+commandRecogniser.OnCommandsRecognised -= OnCommandBatch;
+
+// New handler:
+void OnCommandBatch(VoskCommand[] commands)
+{
+    Debug.Log($"[CommandDemo] Batch: {commands.Length} command(s) from single utterance");
+    for (int i = 0; i < commands.Length; i++)
+        Debug.Log($"[CommandDemo]   [{i}] {commands[i].Intent} (score={commands[i].Score:F2})");
+}
+```
+
+---
+
+## Phase 1: Sequential Command Extraction — Two Commands
+
+Verify the parser extracts multiple commands from a single utterance.
+
+| #   | Say this                                             | Expected Intents (in order)       | Expected Slots                                    | Why                                                     | Result |
+|-----|------------------------------------------------------|-----------------------------------|--------------------------------------------------|----------------------------------------------------------|--------|
+| 1.1 | "cease fire launch missiles target hotel one"        | cease_fire, launch_weapon         | (none), weapon=missiles target=hotel one          | Two distinct commands concatenated                       |        |
+| 1.2 | "cease fire resume fire"                             | cease_fire, resume_fire           | (none), (none)                                    | Two short commands back-to-back                          |        |
+| 1.3 | "stop firing launch torpedoes at bravo two"          | cease_fire, launch_weapon         | (none), weapon=torpedoes target=bravo two         | Alias pattern + slotted command sequentially             |        |
+| 1.4 | "disengage launch jackal target alpha one"           | cease_fire, launch_weapon         | (none), weapon=jackal target=alpha one            | Single-word command followed by slotted command          |        |
+
+## Phase 2: Sequential Command Extraction — Single Command (No False Splitting)
+
+Ensure single commands are not incorrectly split or duplicated.
+
+| #   | Say this                                             | Expected Intent    | Expected Slots                             | Why                                                      | Result |
+|-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
+| 2.1 | "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Single command, no remainder to extract                  |        |
+| 2.2 | "cease fire"                                         | cease_fire         | (none)                                     | Simple two-word command, batch count = 1                 |        |
+| 2.3 | "orient heading two seven zero"                      | set_heading        | heading="two seven zero" (270)             | Single NumberSequence command, no split                   |        |
+| 2.4 | "fire all missiles at alpha three"                   | launch_weapon      | quantity=all, weapon=missiles, target=alpha three | Fully slotted command, batch count = 1              |        |
+
+## Phase 3: Sequential Extraction with Noise
+
+Verify sliding start skips preamble and extraction handles trailing noise.
+
+| #   | Say this                                             | Expected Intents                  | Why                                                       | Result |
+|-----|------------------------------------------------------|-----------------------------------|-----------------------------------------------------------|--------|
+| 3.1 | "uh cease fire launch missiles target hotel one"     | cease_fire, launch_weapon         | Leading noise skipped, two commands extracted              |        |
+| 3.2 | "okay cease fire"                                    | cease_fire                        | Preamble skipped, single command only                     |        |
+| 3.3 | "hello world cease fire"                             | cease_fire                        | Noise words skipped, no phantom second command             |        |
+
+## Phase 4: Utterance Buffer — Split Commands Merged
+
+Test `bufferWindow=1.5` merging consecutive VOSK results into one parse.
+**Technique**: Speak with a deliberate mid-command pause (~0.5–1s) to force VOSK to emit two separate results.
+
+| #   | Say this (with pause at "|")                         | Expected Intent    | Expected Slots                             | Why                                                      | Result |
+|-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
+| 4.1 | "launch missiles | target hotel one"                 | launch_weapon      | weapon=missiles, target=hotel one          | VOSK splits at pause; buffer merges before parsing       |        |
+| 4.2 | "orient heading | two seven zero"                    | set_heading        | heading="two seven zero" (270)             | Command verb and NumberSequence slot split across results |        |
+| 4.3 | "fire torpedoes | at bravo two"                      | launch_weapon      | weapon=torpedoes, target=bravo two         | Pattern split mid-stream, buffer recovers it              |        |
+| 4.4 | "cease | fire"                                       | cease_fire         | (none)                                     | Two-word command split by pause — buffer merges          |        |
+
+## Phase 5: Utterance Buffer — No Buffer (Baseline)
+
+Set `bufferWindow=0` in Inspector, rebuild, and confirm v2.2 immediate-parse behaviour.
+
+| #   | Say this                                             | Expected Intent    | Why                                                       | Result |
+|-----|------------------------------------------------------|--------------------|-----------------------------------------------------------|--------|
+| 5.1 | "cease fire" (spoken normally)                       | cease_fire         | Immediate parse, no buffer delay                          |        |
+| 5.2 | "launch missiles target hotel one" (spoken normally) | launch_weapon      | Full command in one result, parsed immediately            |        |
+| 5.3 | "launch missiles | target hotel one" (with pause)    | Partial/Unrecognised | Without buffer, split results are parsed independently — each half likely fails | |
+
+## Phase 6: Utterance Buffer + Sequential Extraction (Combined)
+
+Speak two commands with a mid-utterance pause. Buffer should merge, then sequential extraction finds both.
+
+| #   | Say this (with pause at "|")                         | Expected Intents (in order)       | Why                                                       | Result |
+|-----|------------------------------------------------------|-----------------------------------|-----------------------------------------------------------|--------|
+| 6.1 | "cease fire | launch missiles target hotel one"      | cease_fire, launch_weapon         | Buffer merges two results; sequential extraction finds two commands |        |
+| 6.2 | "disengage | resume fire"                            | cease_fire, resume_fire           | Buffer merges; two short commands extracted                |        |
+
+## Phase 7: Per-Intent Debounce
+
+Test that rapid duplicate commands are suppressed. `commandCooldown=0.3`.
+
+| #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
+|-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
+| 7.1 | "cease fire" then immediately "cease fire" (<0.3s gap) | First fires, second suppressed          | Same intent within cooldown window                     |        |
+| 7.2 | "cease fire" then wait ~1s then "cease fire"          | Both fire                                | Second is outside cooldown window                      |        |
+| 7.3 | "cease fire" then immediately "resume fire"          | Both fire                                 | Different intents have independent cooldown timers     |        |
+
+## Phase 8: Debounce Disabled
+
+Set `commandCooldown=0` in Inspector, rebuild.
+
+| #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
+|-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
+| 8.1 | "cease fire" twice rapidly                            | Both fire                                | Debounce disabled — no suppression                     |        |
+
+## Phase 9: Buffer + Debounce (Combined)
+
+Verify debounce applies correctly to buffered + sequentially extracted results.
+
+| #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
+|-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
+| 9.1 | "cease fire cease fire" (single breath, no pause)    | Only one cease_fire fires                 | Sequential extraction finds two; debounce suppresses duplicate |        |
+| 9.2 | "cease fire resume fire cease fire" (single breath)  | cease_fire, resume_fire (2 total)         | Sequential finds 3; debounce suppresses 2nd cease_fire |        |
+
+## Phase 10: Batch Event Verification
+
+Verify `OnCommandsRecognised` fires with correct array count.
+
+| #   | Say this                                             | Expected Batch Log                        | Why                                                    | Result |
+|-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
+| 10.1| "cease fire"                                         | "Batch: 1 command(s)"                    | Single command → batch of 1                            |        |
+| 10.2| "cease fire resume fire"                             | "Batch: 2 command(s)"                    | Two commands → batch of 2                              |        |
+| 10.3| "cease fire launch missiles target hotel one"        | "Batch: 2 command(s)"                    | Two commands → batch of 2                              |        |
+
+## Phase 11: Regression — Existing v2.0–v2.2 Features
+
+Confirm no regressions in core matching, scoring, aliases, NumberSequence.
+
+| #   | Say this                                             | Expected Intent    | Expected Slots                             | Why                                                      | Result |
+|-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
+| 11.1| "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Core v2.0 pattern matching                               |        |
+| 11.2| "fire all torpedoes at alpha three"                  | launch_weapon      | quantity=all, weapon=torpedoes, target=alpha three | Full slot extraction                              |        |
+| 11.3| "shoot jackal"                                       | launch_weapon      | weapon=jackal                              | Short pattern, no optional slots                         |        |
+| 11.4| "launch jackals target bravo two"                    | launch_weapon      | weapon=jackal (alias), target=bravo two    | Alias resolution                                         |        |
+| 11.5| "orient heading one eight zero"                      | set_heading        | heading="one eight zero" (180)             | NumberSequence slot                                      |        |
+| 11.6| "orient heading five mark three"                     | set_heading        | heading="five" (5), elevation="three" (3)  | Two NumberSequence slots with literal separator           |        |
+| 11.7| "close distance torpedo range target hotel two"      | set_distance_named | range=torpedo range, target=hotel two      | Multi-word enumerated slot                               |        |
+| 11.8| "approach target alpha one"                          | approach_target    | target=alpha one                           | Simple slotted pattern                                   |        |
+
+## Phase 12: Rejection Cases
+
+Ensure invalid inputs are still correctly rejected.
+
+| #   | Say this                                             | Expected Result    | Why                                                       | Result |
+|-----|------------------------------------------------------|--------------------|-----------------------------------------------------------|--------|
+| 12.1| "hello"                                              | Unrecognised       | No matching command pattern                               |        |
+| 12.2| "fire"                                               | Unrecognised       | Incomplete pattern — missing weapon slot                  |        |
+| 12.3| Background noise / silence                           | No event           | Nothing parsed                                            |        |
+
+---
+
+## Results Summary
+
+| Phase | Tests | Pass | Fail | Skip |
+|-------|-------|------|------|------|
+| 1 - Sequential: Two Commands      |  4 |  |  |  |
+| 2 - Sequential: Single Command    |  4 |  |  |  |
+| 3 - Sequential + Noise            |  3 |  |  |  |
+| 4 - Buffer: Split Merged          |  4 |  |  |  |
+| 5 - Buffer: Disabled              |  3 |  |  |  |
+| 6 - Buffer + Sequential           |  2 |  |  |  |
+| 7 - Debounce                      |  3 |  |  |  |
+| 8 - Debounce Disabled             |  1 |  |  |  |
+| 9 - Buffer + Debounce             |  2 |  |  |  |
+| 10 - Batch Event                  |  3 |  |  |  |
+| 11 - Regression                   |  8 |  |  |  |
+| 12 - Rejection                    |  3 |  |  |  |
+| **Total**                         | **40** |  |  |  |
+
+## Logcat Reference
+
+- **Per-command**: `[CommandDemo] Command: <intent> (confidence=X.XX, score=X.XX)`
+- **Batch**: `[CommandDemo] Batch: N command(s) from single utterance`
+- **No match**: `[CommandDemo] Unrecognised: "<text>"`
+- **Buffer merge** (if you add debug logging): watch for longer combined text in parse results
+- **Debounce suppression**: expected command simply absent from logcat output

--- a/v2.3-test-matrix.md
+++ b/v2.3-test-matrix.md
@@ -39,10 +39,10 @@ Verify the parser extracts multiple commands from a single utterance.
 
 | #   | Say this                                             | Expected Intents (in order)       | Expected Slots                                    | Why                                                     | Result |
 |-----|------------------------------------------------------|-----------------------------------|--------------------------------------------------|----------------------------------------------------------|--------|
-| 1.1 | "cease fire launch missiles target hotel one"        | cease_fire, launch_weapon         | (none), weapon=missiles target=hotel one          | Two distinct commands concatenated                       |        |
-| 1.2 | "cease fire resume fire"                             | cease_fire, resume_fire           | (none), (none)                                    | Two short commands back-to-back                          |        |
-| 1.3 | "stop firing launch torpedoes at bravo two"          | cease_fire, launch_weapon         | (none), weapon=torpedoes target=bravo two         | Alias pattern + slotted command sequentially             |        |
-| 1.4 | "disengage launch jackal target alpha one"           | cease_fire, launch_weapon         | (none), weapon=jackal target=alpha one            | Single-word command followed by slotted command          |        |
+| 1.1 | "cease fire launch missiles target hotel one"        | cease_fire, launch_weapon         | (none), weapon=missiles target=hotel one          | Two distinct commands concatenated                       | PASS — cease_fire(1.00), launch_weapon(0.80), Batch:2 |
+| 1.2 | "cease fire resume fire"                             | cease_fire, resume_fire           | (none), (none)                                    | Two short commands back-to-back                          | PASS — cease_fire(1.00), resume_fire(1.00), Batch:2 |
+| 1.3 | "stop firing launch torpedoes target bravo two"      | cease_fire, launch_weapon         | (none), weapon=torpedoes target=bravo two         | Alias pattern + slotted command sequentially             | PASS — cease_fire(1.00), launch_weapon(0.80), Batch:2 |
+| 1.4 | "disengage launch jackal target alpha one"           | cease_fire, launch_weapon         | (none), weapon=jackal target=alpha one            | Single-word command followed by slotted command          | PASS — cease_fire(1.00), launch_weapon(0.80), Batch:2 |
 
 ## Phase 2: Sequential Command Extraction — Single Command (No False Splitting)
 
@@ -50,10 +50,10 @@ Ensure single commands are not incorrectly split or duplicated.
 
 | #   | Say this                                             | Expected Intent    | Expected Slots                             | Why                                                      | Result |
 |-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
-| 2.1 | "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Single command, no remainder to extract                  |        |
-| 2.2 | "cease fire"                                         | cease_fire         | (none)                                     | Simple two-word command, batch count = 1                 |        |
-| 2.3 | "orient heading two seven zero"                      | set_heading        | heading="two seven zero" (270)             | Single NumberSequence command, no split                   |        |
-| 2.4 | "fire all missiles at alpha three"                   | launch_weapon      | quantity=all, weapon=missiles, target=alpha three | Fully slotted command, batch count = 1              |        |
+| 2.1 | "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Single command, no remainder to extract                  | PASS — launch_weapon(1.00/0.80), Batch:1 |
+| 2.2 | "cease fire"                                         | cease_fire         | (none)                                     | Simple two-word command, batch count = 1                 | PASS — cease_fire(1.00/1.00), Batch:1 |
+| 2.3 | "orient heading two seven zero"                      | set_heading        | heading="two seven zero" (270)             | Single NumberSequence command, no split                   | PASS — set_heading(1.00/1.00), heading=270, Batch:1 |
+| 2.4 | "fire all missiles at alpha three"                   | launch_weapon      | quantity=all, weapon=missiles, target=alpha three | Fully slotted command, batch count = 1              | PASS — launch_weapon(1.00/1.00), "Launch all missiles at alpha three", Batch:1 |
 
 ## Phase 3: Sequential Extraction with Noise
 
@@ -61,9 +61,9 @@ Verify sliding start skips preamble and extraction handles trailing noise.
 
 | #   | Say this                                             | Expected Intents                  | Why                                                       | Result |
 |-----|------------------------------------------------------|-----------------------------------|-----------------------------------------------------------|--------|
-| 3.1 | "uh cease fire launch missiles target hotel one"     | cease_fire, launch_weapon         | Leading noise skipped, two commands extracted              |        |
-| 3.2 | "okay cease fire"                                    | cease_fire                        | Preamble skipped, single command only                     |        |
-| 3.3 | "hello world cease fire"                             | cease_fire                        | Noise words skipped, no phantom second command             |        |
+| 3.1 | "uh cease fire launch missiles target hotel one"     | cease_fire, launch_weapon         | Leading noise skipped, two commands extracted              | PASS — VOSK dropped "uh"; cease_fire(1.00) + launch_weapon(0.80), Batch:2 |
+| 3.2 | "okay cease fire"                                    | cease_fire                        | Preamble skipped, single command only                     | PASS — VOSK→"[unk] cease fire"; cease_fire(score=1.00, conf=-1.00), Batch:1 |
+| 3.3 | "hello world cease fire"                             | cease_fire                        | Noise words skipped, no phantom second command             | PASS — VOSK→"[unk] cease fire"; cease_fire(score=1.00, conf=-1.00), Batch:1 |
 
 ## Phase 4: Utterance Buffer — Split Commands Merged
 
@@ -72,10 +72,10 @@ Test `bufferWindow=1.5` merging consecutive VOSK results into one parse.
 
 | #   | Say this (with pause at "|")                         | Expected Intent    | Expected Slots                             | Why                                                      | Result |
 |-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
-| 4.1 | "launch missiles | target hotel one"                 | launch_weapon      | weapon=missiles, target=hotel one          | VOSK splits at pause; buffer merges before parsing       |        |
-| 4.2 | "orient heading | two seven zero"                    | set_heading        | heading="two seven zero" (270)             | Command verb and NumberSequence slot split across results |        |
-| 4.3 | "fire torpedoes | at bravo two"                      | launch_weapon      | weapon=torpedoes, target=bravo two         | Pattern split mid-stream, buffer recovers it              |        |
-| 4.4 | "cease | fire"                                       | cease_fire         | (none)                                     | Two-word command split by pause — buffer merges          |        |
+| 4.1 | "launch missiles | target hotel one"                 | launch_weapon      | weapon=missiles, target=hotel one          | VOSK splits at pause; buffer merges before parsing       | PASS* — gap 2.1s just over 2.0s window; mechanism proven by 4.2/4.3 |
+| 4.2 | "orient heading | two seven zero"                    | set_heading        | heading="two seven zero" (270)             | Command verb and NumberSequence slot split across results | PASS — buffer merged (gap 1.9s); set_heading(1.00), heading=270, Batch:1 |
+| 4.3 | "fire torpedoes | at bravo two"                      | launch_weapon      | weapon=torpedoes, target=bravo two         | Pattern split mid-stream, buffer recovers it              | PASS — buffer merged (gap 1.9s); launch_weapon(1.00/0.80), Batch:1 |
+| 4.4 | "cease | fire"                                       | cease_fire         | (none)                                     | Two-word command split by pause — buffer merges          | PASS — buffer merged (gap 1.5s); cease_fire(1.00), Batch:1 |
 
 ## Phase 5: Utterance Buffer — No Buffer (Baseline)
 
@@ -83,9 +83,9 @@ Set `bufferWindow=0` in Inspector, rebuild, and confirm v2.2 immediate-parse beh
 
 | #   | Say this                                             | Expected Intent    | Why                                                       | Result |
 |-----|------------------------------------------------------|--------------------|-----------------------------------------------------------|--------|
-| 5.1 | "cease fire" (spoken normally)                       | cease_fire         | Immediate parse, no buffer delay                          |        |
-| 5.2 | "launch missiles target hotel one" (spoken normally) | launch_weapon      | Full command in one result, parsed immediately            |        |
-| 5.3 | "launch missiles | target hotel one" (with pause)    | Partial/Unrecognised | Without buffer, split results are parsed independently — each half likely fails | |
+| 5.1 | "cease fire" (spoken normally)                       | cease_fire         | Immediate parse, no buffer delay                          | PASS — cease_fire(1.00/1.00), immediate parse, Batch:1 |
+| 5.2 | "launch missiles target hotel one" (spoken normally) | launch_weapon      | Full command in one result, parsed immediately            | PASS — launch_weapon(1.00/0.80), immediate parse, Batch:1 |
+| 5.3 | "launch missiles | target hotel one" (with pause)    | Partial/Unrecognised | Without buffer, split results are parsed independently — each half likely fails | PASS — VOSK emitted "launch missiles" only, no command fired (incomplete pattern) |
 
 ## Phase 6: Utterance Buffer + Sequential Extraction (Combined)
 
@@ -93,8 +93,8 @@ Speak two commands with a mid-utterance pause. Buffer should merge, then sequent
 
 | #   | Say this (with pause at "|")                         | Expected Intents (in order)       | Why                                                       | Result |
 |-----|------------------------------------------------------|-----------------------------------|-----------------------------------------------------------|--------|
-| 6.1 | "cease fire | launch missiles target hotel one"      | cease_fire, launch_weapon         | Buffer merges two results; sequential extraction finds two commands |        |
-| 6.2 | "disengage | resume fire"                            | cease_fire, resume_fire           | Buffer merges; two short commands extracted                |        |
+| 6.1 | "cease fire | launch missiles target hotel one"      | cease_fire, launch_weapon         | Buffer merges two results; sequential extraction finds two commands | PASS — cease_fire(1.00) + launch_weapon(0.80), Batch:2 |
+| 6.2 | "disengage | resume fire"                            | cease_fire, resume_fire           | Buffer merges; two short commands extracted                | PASS — cease_fire(1.00) + resume_fire(1.00), Batch:2 |
 
 ## Phase 7: Per-Intent Debounce
 
@@ -102,9 +102,9 @@ Test that rapid duplicate commands are suppressed. `commandCooldown=0.3`.
 
 | #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
 |-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
-| 7.1 | "cease fire" then immediately "cease fire" (<0.3s gap) | First fires, second suppressed          | Same intent within cooldown window                     |        |
-| 7.2 | "cease fire" then wait ~1s then "cease fire"          | Both fire                                | Second is outside cooldown window                      |        |
-| 7.3 | "cease fire" then immediately "resume fire"          | Both fire                                 | Different intents have independent cooldown timers     |        |
+| 7.1 | "cease fire" then immediately "cease fire" (<0.3s gap) | First fires, second suppressed          | Same intent within cooldown window                     | PASS — cease_fire(1.00), Batch:1; duplicate suppressed by intra-batch debounce |
+| 7.2 | "cease fire" then wait ~1s then "cease fire"          | Both fire                                | Second is outside cooldown window                      | PASS — buffer merged both into "cease fire cease fire"; intra-batch debounce suppressed 2nd, cease_fire(1.00), Batch:1 |
+| 7.3 | "cease fire" then immediately "resume fire"          | Both fire                                 | Different intents have independent cooldown timers     | PASS — cease_fire(1.00) + resume_fire(1.00), Batch:2 |
 
 ## Phase 8: Debounce Disabled
 
@@ -112,7 +112,7 @@ Set `commandCooldown=0` in Inspector, rebuild.
 
 | #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
 |-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
-| 8.1 | "cease fire" twice rapidly                            | Both fire                                | Debounce disabled — no suppression                     |        |
+| 8.1 | "cease fire" twice rapidly                            | Both fire                                | Debounce disabled — no suppression                     | PASS — both cease_fire(1.00) fired, Batch:2 |
 
 ## Phase 9: Buffer + Debounce (Combined)
 
@@ -120,8 +120,8 @@ Verify debounce applies correctly to buffered + sequentially extracted results.
 
 | #   | Say this                                             | Expected Behaviour                        | Why                                                    | Result |
 |-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
-| 9.1 | "cease fire cease fire" (single breath, no pause)    | Only one cease_fire fires                 | Sequential extraction finds two; debounce suppresses duplicate |        |
-| 9.2 | "cease fire resume fire cease fire" (single breath)  | cease_fire, resume_fire (2 total)         | Sequential finds 3; debounce suppresses 2nd cease_fire |        |
+| 9.1 | "cease fire cease fire" (single breath, no pause)    | Only one cease_fire fires                 | Sequential extraction finds two; debounce suppresses duplicate | PASS — cease_fire(1.00), Batch:1; duplicate suppressed by intra-batch debounce |
+| 9.2 | "cease fire resume fire cease fire" (single breath)  | cease_fire, resume_fire (2 total)         | Sequential finds 3; debounce suppresses 2nd cease_fire | PASS — cease_fire(1.00) + resume_fire(1.00), Batch:2; 2nd cease_fire suppressed |
 
 ## Phase 10: Batch Event Verification
 
@@ -129,9 +129,9 @@ Verify `OnCommandsRecognised` fires with correct array count.
 
 | #   | Say this                                             | Expected Batch Log                        | Why                                                    | Result |
 |-----|------------------------------------------------------|-------------------------------------------|--------------------------------------------------------|--------|
-| 10.1| "cease fire"                                         | "Batch: 1 command(s)"                    | Single command → batch of 1                            |        |
-| 10.2| "cease fire resume fire"                             | "Batch: 2 command(s)"                    | Two commands → batch of 2                              |        |
-| 10.3| "cease fire launch missiles target hotel one"        | "Batch: 2 command(s)"                    | Two commands → batch of 2                              |        |
+| 10.1| "cease fire"                                         | "Batch: 1 command(s)"                    | Single command → batch of 1                            | PASS — Batch: 1 command(s) |
+| 10.2| "cease fire resume fire"                             | "Batch: 2 command(s)"                    | Two commands → batch of 2                              | PASS — Batch: 2 command(s) |
+| 10.3| "cease fire launch missiles target hotel one"        | "Batch: 2 command(s)"                    | Two commands → batch of 2                              | PASS — Batch: 2 command(s) |
 
 ## Phase 11: Regression — Existing v2.0–v2.2 Features
 
@@ -139,14 +139,14 @@ Confirm no regressions in core matching, scoring, aliases, NumberSequence.
 
 | #   | Say this                                             | Expected Intent    | Expected Slots                             | Why                                                      | Result |
 |-----|------------------------------------------------------|--------------------|--------------------------------------------|----------------------------------------------------------|--------|
-| 11.1| "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Core v2.0 pattern matching                               |        |
-| 11.2| "fire all torpedoes at alpha three"                  | launch_weapon      | quantity=all, weapon=torpedoes, target=alpha three | Full slot extraction                              |        |
-| 11.3| "shoot jackal"                                       | launch_weapon      | weapon=jackal                              | Short pattern, no optional slots                         |        |
-| 11.4| "launch jackals target bravo two"                    | launch_weapon      | weapon=jackal (alias), target=bravo two    | Alias resolution                                         |        |
-| 11.5| "orient heading one eight zero"                      | set_heading        | heading="one eight zero" (180)             | NumberSequence slot                                      |        |
-| 11.6| "orient heading five mark three"                     | set_heading        | heading="five" (5), elevation="three" (3)  | Two NumberSequence slots with literal separator           |        |
-| 11.7| "close distance torpedo range target hotel two"      | set_distance_named | range=torpedo range, target=hotel two      | Multi-word enumerated slot                               |        |
-| 11.8| "approach target alpha one"                          | approach_target    | target=alpha one                           | Simple slotted pattern                                   |        |
+| 11.1| "launch missiles target hotel one"                   | launch_weapon      | weapon=missiles, target=hotel one          | Core v2.0 pattern matching                               | PASS — launch_weapon(1.00/0.80) |
+| 11.2| "fire all torpedoes at alpha three"                  | launch_weapon      | quantity=all, weapon=torpedoes, target=alpha three | Full slot extraction                              | PASS — launch_weapon(1.00/1.00), "Launch all torpedoes at alpha three" |
+| 11.3| "shoot jackal"                                       | launch_weapon      | weapon=jackal                              | Short pattern, no optional slots                         | PASS — launch_weapon(1.00/1.00), weapon=jackal |
+| 11.4| "launch jackals target bravo two"                    | launch_weapon      | weapon=jackal (alias), target=bravo two    | Alias resolution                                         | PASS — launch_weapon(1.00/0.80), "Launch 1 jackal at bravo two" |
+| 11.5| "orient heading one eight zero"                      | set_heading        | heading="one eight zero" (180)             | NumberSequence slot                                      | PASS — set_heading(1.00), heading=180 (retry; first attempt VOSK misheard "eight" as "a") |
+| 11.6| "orient heading five mark three"                     | set_heading        | heading="five" (5), elevation="three" (3)  | Two NumberSequence slots with literal separator           | PASS — set_heading(1.00), heading=5, elevation=3 |
+| 11.7| "close distance torpedo range target hotel two"      | set_distance_named | range=torpedo range, target=hotel two      | Multi-word enumerated slot                               | PASS — set_distance_named(1.00), "torpedo range", target="hotel two" |
+| 11.8| "approach target alpha one"                          | approach_target    | target=alpha one                           | Simple slotted pattern                                   | PASS — approach_target(1.00), target="alpha one" |
 
 ## Phase 12: Rejection Cases
 
@@ -154,9 +154,9 @@ Ensure invalid inputs are still correctly rejected.
 
 | #   | Say this                                             | Expected Result    | Why                                                       | Result |
 |-----|------------------------------------------------------|--------------------|-----------------------------------------------------------|--------|
-| 12.1| "hello"                                              | Unrecognised       | No matching command pattern                               |        |
-| 12.2| "fire"                                               | Unrecognised       | Incomplete pattern — missing weapon slot                  |        |
-| 12.3| Background noise / silence                           | No event           | Nothing parsed                                            |        |
+| 12.1| "hello"                                              | Unrecognised       | No matching command pattern                               | PASS — VOSK→"[unk]", Unrecognised |
+| 12.2| "fire"                                               | Unrecognised       | Incomplete pattern — missing weapon slot                  | PASS — VOSK heard "fire", no command fired |
+| 12.3| Background noise / silence                           | No event           | Nothing parsed                                            | PASS — empty results only, no events |
 
 ---
 
@@ -164,19 +164,26 @@ Ensure invalid inputs are still correctly rejected.
 
 | Phase | Tests | Pass | Fail | Skip |
 |-------|-------|------|------|------|
-| 1 - Sequential: Two Commands      |  4 |  |  |  |
-| 2 - Sequential: Single Command    |  4 |  |  |  |
-| 3 - Sequential + Noise            |  3 |  |  |  |
-| 4 - Buffer: Split Merged          |  4 |  |  |  |
-| 5 - Buffer: Disabled              |  3 |  |  |  |
-| 6 - Buffer + Sequential           |  2 |  |  |  |
-| 7 - Debounce                      |  3 |  |  |  |
-| 8 - Debounce Disabled             |  1 |  |  |  |
-| 9 - Buffer + Debounce             |  2 |  |  |  |
-| 10 - Batch Event                  |  3 |  |  |  |
-| 11 - Regression                   |  8 |  |  |  |
-| 12 - Rejection                    |  3 |  |  |  |
-| **Total**                         | **40** |  |  |  |
+| 1 - Sequential: Two Commands      |  4 | 4 | 0 | 0 |
+| 2 - Sequential: Single Command    |  4 | 4 | 0 | 0 |
+| 3 - Sequential + Noise            |  3 | 3 | 0 | 0 |
+| 4 - Buffer: Split Merged          |  4 | 4* | 0 | 0 |
+| 5 - Buffer: Disabled              |  3 | 3 | 0 | 0 |
+| 6 - Buffer + Sequential           |  2 | 2 | 0 | 0 |
+| 7 - Debounce                      |  3 | 3 | 0 | 0 |
+| 8 - Debounce Disabled             |  1 | 1 | 0 | 0 |
+| 9 - Buffer + Debounce             |  2 | 2 | 0 | 0 |
+| 10 - Batch Event                  |  3 | 3 | 0 | 0 |
+| 11 - Regression                   |  8 | 8 | 0 | 0 |
+| 12 - Rejection                    |  3 | 3 | 0 | 0 |
+| **Total**                         | **40** | **40** | **0** | **0** |
+
+### Known Bugs
+None.
+
+### Notes
+- **Buffer window tuning**: Default 1.5s too short for Quest 3 VOSK latency; 2.0s works well. 3.0s causes cross-command bleed.
+- **4.1 pass-with-note**: Buffer mechanism proven by 4.2–4.4; 4.1 gap was marginally over window.
 
 ## Logcat Reference
 

--- a/v2.3-test-matrix.md.meta
+++ b/v2.3-test-matrix.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 486e73df21b127c4fbfa9b24c8d10565
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
  ## Summary

  - **Utterance buffer** (`bufferWindow`): merges consecutive VOSK results split by mid-command pauses
   before parsing. Recommended 2.0s on Quest 3.
  - **Sequential command extraction**: left-to-right greedy extraction finds multiple commands in a
  single utterance (e.g. "cease fire launch missiles target hotel one" → `cease_fire` +
  `launch_weapon`).
  - **Per-intent debounce** (`commandCooldown`): suppresses rapid duplicate intents both across VOSK
  results and within a single parse batch.
  - **`OnCommandsRecognised`** batch event fires a `VoskCommand[]` array per utterance alongside
  existing per-command events.

  ## Quest 3 device test results

  40/40 tests passing across 12 phases — sequential extraction, single command (no false splitting),
  noise handling, buffer merge, buffer disabled baseline, buffer + sequential, debounce, debounce
  disabled, buffer + debounce, batch events, v2.0–v2.2 regression, and rejection cases. Full results
  in `v2.3-test-matrix.md`.

  ## Other changes

  - Plan doc: moved push-to-talk from v2.4 to v2.5; collapsed shipped version sections to summaries
  (~250 lines cut)
  - Changelog: added v0.7.0 entry