### PR TITLE
V2.5 Inspector authoring (ScriptableObject slots/commands/sets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-06
+
+### Added
+
+- `VoskSlotAsset` ScriptableObject for Inspector-based slot definition authoring. Create via Assets > Create > VOSK XR > Slot Definition.
+- `VoskCommandAsset` ScriptableObject for command definitions with human-readable pattern strings (e.g. `"launch {?quantity} {weapon} target {target}"`).
+- `VoskCommandSetAsset` ScriptableObject for grouping commands into named sets.
+- Inspector authoring on `VoskCommandRecogniser`: assign slot and command set assets directly in the Inspector for zero-code setup. Code-based `Configure()` takes priority.
+- `initialActiveSetNames` field on `VoskCommandRecogniser` for selecting which sets activate on startup when using Inspector authoring.
+- Unit tests for all ScriptableObject-to-runtime-struct conversions.
+
 ## [0.8.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VoskCommandSetAsset` ScriptableObject for grouping commands into named sets.
 - Inspector authoring on `VoskCommandRecogniser`: assign slot and command set assets directly in the Inspector for zero-code setup. Code-based `Configure()` takes priority.
 - `initialActiveSetNames` field on `VoskCommandRecogniser` for selecting which sets activate on startup when using Inspector authoring.
+- Null-guard warnings in `VoskCommandRecogniser.Awake()` and `VoskCommandSetAsset.ToSet()` so missing references in inspector arrays are skipped with a clear warning instead of throwing.
+- 20-asset Inspector authoring set under `Samples~/CommandRecognition/AssetAuthoring/` (6 slots, 11 commands, 3 sets) covering every slot type and pattern token form.
+- `useInspectorAuthoring` toggle on `CommandDemo` to switch between code-based `Configure()` and asset-driven authoring without editing the script.
 - Unit tests for all ScriptableObject-to-runtime-struct conversions.
+- `KNOWN_LIMITATIONS.md` at the project root — single place to document VOSK acoustic, voice-recognition, and architecture limitations across all versions.
+- Quest device test matrix (`v2.5-test-matrix.md`) with 44 on-device tests across 8 phases (Phase 0 editor-only) — 42 pass, 1 known limitation (4.5: VOSK "to" → "two"), 1 skipped (6.3: script execution order edge case).
+
+### Known Limitations
+
+- VOSK misrecognises "to" as "two" in `switch to weapons`. Asset tokenization is correct; this is an acoustic-model limitation. Use the `weapons mode` alternate pattern.
+- `SetActiveSets()` triggers a grammar rebuild that briefly stops/restarts AudioCapture (~50ms gap). Speech in that window is dropped at the audio layer. Pause ~500ms after a mode switch before speaking the next command.
+- See `KNOWN_LIMITATIONS.md` for full details.
 
 ## [0.8.0] - 2026-04-06
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,0 +1,88 @@
+# Known Limitations
+
+This document collects known limitations of the VOSK Unity XR SDK that aren't
+bugs to fix but rather constraints rooted in the underlying VOSK acoustic model,
+voice recognition in general, or deliberate architectural choices. The goal is
+to give consumers (and our future selves) a single place to look when something
+"weird" happens, before assuming it's a regression.
+
+Each entry includes a short repro, the root cause, and a workaround (if any).
+
+---
+
+## VOSK Acoustic Model
+
+Limitations rooted in the small English VOSK model
+(`vosk-model-small-en-us-0.15`) we ship with. Switching to a larger model would
+mitigate some of these but at the cost of memory and download size.
+
+### "to" misrecognised as "two"
+
+- **Repro**: Say "switch to weapons". VOSK transcribes `switch two weapons`.
+- **Where seen**: v2.5 test matrix Phase 4.5.
+- **Root cause**: The small English model is acoustically biased toward "two"
+  in this context, especially when the speaker emphasises the vowel slightly
+  or says it quickly. The grammar token splitter is correct — it produces
+  `["switch", "to", "weapons"]` — but VOSK never feeds it the right phonemes
+  to match.
+- **Workaround**:
+  - Prefer alternate patterns that avoid short function words. The sample's
+    `mode_weapons` command uses both `["switch", "to", "weapons"]` and
+    `["weapons", "mode"]`; the latter recognises reliably.
+  - When designing your own commands, avoid `to`, `for`, `four`, `or`, `are`
+    and similar short homophones inside required tokens.
+
+---
+
+## Architecture and Design
+
+Limitations that come from how the SDK is structured. Most of these are
+deliberate trade-offs rather than oversights.
+
+### Active set switching has a brief audio gap
+
+- **Repro**: Trigger a `SetActiveSets()` call (e.g. via a `mode_*` command),
+  then immediately try to speak the next command. The first one or two words
+  of the second utterance are dropped.
+- **Where seen**: v2.5 test matrix Phase 5.4. After saying "navigation mode"
+  the user said "fall back from target hotel two" too quickly, and VOSK only
+  heard `target hotel two` — the leading three words were lost.
+- **Root cause**: `SetActiveSets()` calls `RebuildParserAndGrammar()` which
+  stops AudioCapture, applies the new grammar to the VOSK recogniser, and
+  restarts AudioCapture. The full sequence takes ~50ms minimum on Quest 3,
+  during which the microphone isn't being read. Any speech in that window is
+  dropped at the audio layer, before VOSK ever sees it.
+- **Workaround**:
+  - After triggering a mode switch, pause for ~500ms before speaking the next
+    command. In a game UI you can gate user input via the
+    `[CommandDemo] Switched to <X> mode` log marker (or wire a callback off
+    `OnCommandRecognised` for the `mode_*` intents).
+  - If you need seamless switching, prefer the **single-set + grammar
+    superset** approach: configure all your commands in one set and gate them
+    in your `OnCommand` handler instead of swapping active sets at runtime.
+
+### Validation warnings re-emit on every active-set switch
+
+- **Repro**: Wire any slot with a single-character alias (e.g. `a` → `one`)
+  and call `SetActiveSets()` repeatedly. The
+  `[VoskCommandParser] Slot 'quantity' has single-character alias "a"...`
+  warning fires on every switch, not just at initial Configure.
+- **Where seen**: v2.5 test matrix Phases 5–8. Visible in logcat after every
+  mode-switch command.
+- **Root cause**: `SetActiveSets()` constructs a fresh `VoskCommandParser` via
+  `RebuildParserAndGrammar()`, and the parser ctor unconditionally re-runs
+  `RunValidationWarnings()`. The warnings are correct, just noisier than they
+  should be.
+- **Workaround**: None at user level. This is a candidate for cleanup —
+  validation should run once per `Configure()` call, not per parser rebuild.
+  Filed as a low-priority follow-up.
+
+---
+
+## Notes
+
+This file is meant to grow as we discover more limitations. When adding a new
+entry, follow the existing structure: short repro, where seen (test matrix
+reference if applicable), root cause, workaround. Group entries by category —
+the categories above are a starting point but feel free to add more (e.g.
+"Hardware Audio", "Threading", "Build/Deploy") as needed.

--- a/Runtime/Commands/VoskCommandAsset.cs
+++ b/Runtime/Commands/VoskCommandAsset.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// ScriptableObject for defining a command in the Inspector.
+    /// Create via Assets > Create > VOSK XR > Command Definition.
+    /// Patterns are authored as single strings (e.g. "launch {?quantity} {weapon} target {target}")
+    /// and split on whitespace by <see cref="ToDefinition"/>.
+    /// </summary>
+    [CreateAssetMenu(menuName = "VOSK XR/Command Definition")]
+    public class VoskCommandAsset : ScriptableObject
+    {
+        static readonly char[] SplitSeparator = { ' ' };
+
+        public string intent;
+
+        [Tooltip("Each element is one pattern. Tokens separated by spaces. " +
+                 "Use {slot} for required slots, {?slot} for optional, ?word for optional literals.")]
+        public string[] patterns;
+
+        /// <summary>
+        /// Converts this asset to the runtime <see cref="VoskCommandDefinition"/> struct.
+        /// Each pattern string is split on whitespace to produce the token array the parser expects.
+        /// </summary>
+        public VoskCommandDefinition ToDefinition()
+        {
+            var patternArrays = patterns != null
+                ? new string[patterns.Length][]
+                : Array.Empty<string[]>();
+
+            for (int i = 0; i < patternArrays.Length; i++)
+            {
+                patternArrays[i] = string.IsNullOrEmpty(patterns[i])
+                    ? Array.Empty<string>()
+                    : patterns[i].Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            return new VoskCommandDefinition(intent, patternArrays);
+        }
+    }
+}

--- a/Runtime/Commands/VoskCommandAsset.cs.meta
+++ b/Runtime/Commands/VoskCommandAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 73b845a201f6bd34b8f26985094fbb31

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -39,6 +39,13 @@ namespace VoskXR.Commands
                  "Set to 0 to disable debounce.")]
         [SerializeField] float commandCooldown = 0.3f;
 
+        [Header("Inspector Authoring (optional — ignored if Configure() is called from code)")]
+        [SerializeField] VoskSlotAsset[] slotAssets;
+        [SerializeField] VoskCommandSetAsset[] commandSetAssets;
+
+        [Tooltip("Command sets to activate on startup when using Inspector authoring.")]
+        [SerializeField] string[] initialActiveSetNames;
+
         public event Action<VoskCommand> OnCommandRecognised;
         public event Action<VoskCommand[]> OnCommandsRecognised;
         public event Action<string> OnUnrecognisedSpeech;
@@ -201,6 +208,47 @@ namespace VoskXR.Commands
 
             if (wasRunning)
                 speechRecogniser.StartRecognition();
+        }
+
+        void Awake()
+        {
+            // If user code already called Configure(), _slots is non-null and inspector assets are ignored.
+            if (_slots != null)
+                return;
+
+            if (slotAssets == null || slotAssets.Length == 0)
+                return;
+
+            if (commandSetAssets == null || commandSetAssets.Length == 0)
+                return;
+
+            var slotList = new List<VoskSlotDefinition>(slotAssets.Length);
+            for (int i = 0; i < slotAssets.Length; i++)
+            {
+                if (slotAssets[i] == null)
+                {
+                    Debug.LogWarning($"[VoskCommandRecogniser] slotAssets[{i}] is null — skipping.");
+                    continue;
+                }
+                slotList.Add(slotAssets[i].ToDefinition());
+            }
+
+            var setList = new List<VoskCommandSet>(commandSetAssets.Length);
+            for (int i = 0; i < commandSetAssets.Length; i++)
+            {
+                if (commandSetAssets[i] == null)
+                {
+                    Debug.LogWarning(
+                        $"[VoskCommandRecogniser] commandSetAssets[{i}] is null — skipping.");
+                    continue;
+                }
+                setList.Add(commandSetAssets[i].ToSet());
+            }
+
+            Configure(slotList.ToArray(), setList.ToArray());
+
+            if (initialActiveSetNames != null && initialActiveSetNames.Length > 0)
+                SetActiveSets(initialActiveSetNames);
         }
 
         void OnEnable()

--- a/Runtime/Commands/VoskCommandSetAsset.cs
+++ b/Runtime/Commands/VoskCommandSetAsset.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// ScriptableObject for grouping commands into a named set.
+    /// Create via Assets > Create > VOSK XR > Command Set.
+    /// Use <see cref="ToSet"/> to convert to the runtime struct.
+    /// </summary>
+    [CreateAssetMenu(menuName = "VOSK XR/Command Set")]
+    public class VoskCommandSetAsset : ScriptableObject
+    {
+        public string setName;
+        public VoskCommandAsset[] commands;
+
+        /// <summary>
+        /// Converts this asset to the runtime <see cref="VoskCommandSet"/> struct.
+        /// Null entries in the commands array are skipped with a warning.
+        /// </summary>
+        public VoskCommandSet ToSet()
+        {
+            if (commands == null || commands.Length == 0)
+                return new VoskCommandSet(setName, Array.Empty<VoskCommandDefinition>());
+
+            var defs = new List<VoskCommandDefinition>(commands.Length);
+            for (int i = 0; i < commands.Length; i++)
+            {
+                if (commands[i] == null)
+                {
+                    Debug.LogWarning($"[VoskCommandSetAsset] '{setName}' commands[{i}] is null — skipping.");
+                    continue;
+                }
+                defs.Add(commands[i].ToDefinition());
+            }
+
+            return new VoskCommandSet(setName, defs.ToArray());
+        }
+    }
+}

--- a/Runtime/Commands/VoskCommandSetAsset.cs.meta
+++ b/Runtime/Commands/VoskCommandSetAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c3f026db4e8c16a4f927d85d19678b4f

--- a/Runtime/Commands/VoskSlotAsset.cs
+++ b/Runtime/Commands/VoskSlotAsset.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// ScriptableObject for defining a slot in the Inspector.
+    /// Create via Assets > Create > VOSK XR > Slot Definition.
+    /// Use <see cref="ToDefinition"/> to convert to the runtime struct.
+    /// </summary>
+    [CreateAssetMenu(menuName = "VOSK XR/Slot Definition")]
+    public class VoskSlotAsset : ScriptableObject
+    {
+        [Tooltip("Slot name used in pattern references {slotName}")]
+        public string slotName;
+
+        public VoskSlotType slotType = VoskSlotType.Enumerated;
+
+        [Tooltip("Allowed values (Enumerated slots only)")]
+        public string[] values;
+
+        [Tooltip("Variant → canonical mappings")]
+        public AliasEntry[] aliases;
+
+        [Header("NumberSequence Settings")]
+        public int minWords = 1;
+        public int maxWords = 3;
+
+        [Serializable]
+        public struct AliasEntry
+        {
+            public string variant;
+            public string canonical;
+        }
+
+        /// <summary>
+        /// Converts this asset to the runtime <see cref="VoskSlotDefinition"/> struct.
+        /// </summary>
+        public VoskSlotDefinition ToDefinition()
+        {
+            if (slotType == VoskSlotType.NumberSequence)
+                return VoskSlotDefinition.NumberSequence(slotName, minWords, maxWords);
+
+            Dictionary<string, string> aliasDict = null;
+            if (aliases != null && aliases.Length > 0)
+            {
+                aliasDict = new Dictionary<string, string>(aliases.Length, StringComparer.Ordinal);
+                for (int i = 0; i < aliases.Length; i++)
+                    aliasDict[aliases[i].variant] = aliases[i].canonical;
+            }
+
+            return new VoskSlotDefinition(
+                slotName,
+                values ?? Array.Empty<string>(),
+                aliasDict);
+        }
+    }
+}

--- a/Runtime/Commands/VoskSlotAsset.cs.meta
+++ b/Runtime/Commands/VoskSlotAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ccc96065bc235ec4eabd6d8d0e7ace9c

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ApproachTarget.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ApproachTarget.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ApproachTarget
+  m_EditorClassIdentifier:
+  intent: approach_target
+  patterns:
+  - 'close on target {target}'
+  - 'close in on target {target}'
+  - 'approach target {target}'

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ApproachTarget.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ApproachTarget.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82660e15997441e4b0d2112f821ae199
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_CeaseFire.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_CeaseFire.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_CeaseFire
+  m_EditorClassIdentifier:
+  intent: cease_fire
+  patterns:
+  - cease fire
+  - stop firing
+  - disengage

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_CeaseFire.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_CeaseFire.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f21209591ac4062b7a674db78ff7c3b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_LaunchWeapon.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_LaunchWeapon.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_LaunchWeapon
+  m_EditorClassIdentifier:
+  intent: launch_weapon
+  patterns:
+  - 'launch {?quantity} {weapon} target {target}'
+  - 'fire {?quantity} {weapon} at {target}'
+  - 'shoot {weapon}'

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_LaunchWeapon.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_LaunchWeapon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f5859ea77dc4f6fad4ad0f7139a7870
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeAll.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeAll.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ModeAll
+  m_EditorClassIdentifier:
+  intent: mode_all
+  patterns:
+  - all modes
+  - enable all

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeAll.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeAll.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 968eea98056a4f3e9d77a08409a65e61
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeDisable.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeDisable.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ModeDisable
+  m_EditorClassIdentifier:
+  intent: mode_disable
+  patterns:
+  - disable all
+  - disable commands

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeDisable.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeDisable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ea144840dd14157bc2b42f80915f9cf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeNavigation.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeNavigation.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ModeNavigation
+  m_EditorClassIdentifier:
+  intent: mode_navigation
+  patterns:
+  - navigation mode
+  - switch to navigation

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeNavigation.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeNavigation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d011570a460a45f59e761007efe30323
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeWeapons.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeWeapons.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ModeWeapons
+  m_EditorClassIdentifier:
+  intent: mode_weapons
+  patterns:
+  - weapons mode
+  - switch to weapons

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeWeapons.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ModeWeapons.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ba1937b1f9b4ee6ad1959605b7ca54e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ResumeFire.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ResumeFire.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_ResumeFire
+  m_EditorClassIdentifier:
+  intent: resume_fire
+  patterns:
+  - resume fire
+  - resume firing
+  - reengage

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ResumeFire.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_ResumeFire.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad77bf8a3d754aa799708bcf4b7477a2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_RetreatFromTarget.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_RetreatFromTarget.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_RetreatFromTarget
+  m_EditorClassIdentifier:
+  intent: retreat_from_target
+  patterns:
+  - 'fall back from target {target}'
+  - 'pull back from target {target}'
+  - 'get away from target {target}'
+  - 'move away from target {target}'
+  - 'open distance from target {target}'

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_RetreatFromTarget.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_RetreatFromTarget.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c66aa3f083a34567b57d19cee56fcd6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetDistanceNamed.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetDistanceNamed.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_SetDistanceNamed
+  m_EditorClassIdentifier:
+  intent: set_distance_named
+  patterns:
+  - 'close distance {range} target {target}'
+  - 'set distance {range} target {target}'
+  - 'make distance {range} target {target}'
+  - 'open distance {range} target {target}'

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetDistanceNamed.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetDistanceNamed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4febac755ac54784bfc9362bc2a10d9f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetHeading.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetHeading.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73b845a201f6bd34b8f26985094fbb31, type: 3}
+  m_Name: Cmd_SetHeading
+  m_EditorClassIdentifier:
+  intent: set_heading
+  patterns:
+  - 'orient heading {heading}'
+  - 'orient heading {heading} mark {?elevation}'
+  - 'set heading {heading}'

--- a/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetHeading.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Commands/Cmd_SetHeading.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53ad75bec10c49d092d87a71f1f21122
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/README.md
+++ b/Samples~/CommandRecognition/AssetAuthoring/README.md
@@ -1,0 +1,35 @@
+# Inspector Authoring (v2.5)
+
+ScriptableObject equivalents of the slots, commands, and command sets defined
+in `CommandDemo.cs`. Used to verify that v2.5 Inspector authoring produces the
+same recognition behaviour as the code path.
+
+## Contents
+
+- `Slots/` — 6 `VoskSlotAsset` files (target, weapon, quantity, range, heading, elevation)
+- `Commands/` — 11 `VoskCommandAsset` files (one per intent in `CommandDemo.cs`)
+- `Sets/` — 3 `VoskCommandSetAsset` files (weapons, navigation, common)
+
+## How to wire
+
+1. On the GameObject hosting `VoskCommandRecogniser`, expand **Inspector
+   Authoring**:
+   - **Slot Assets** → drag in all 6 assets from `Slots/`
+   - **Command Set Assets** → drag in `Set_Weapons`, `Set_Navigation`, `Set_Common`
+   - **Initial Active Set Names** → `weapons`, `navigation`, `common`
+2. On the `CommandDemo` component, enable **Use Inspector Authoring**.
+3. Enter Play mode (or build to Quest). `VoskCommandRecogniser.Awake()` will
+   call `Configure()` from the assets and `SetActiveSets(initialActiveSetNames)`
+   before `CommandDemo.Start()` runs.
+
+When **Use Inspector Authoring** is disabled, `CommandDemo` falls back to the
+v2.4 code path: it constructs slots/sets in `Start()` and calls `Configure()`
+directly, overriding any asset-driven setup. This is the path tested in
+Phase 6 of `v2.5-test-matrix.md`.
+
+## Equivalence with code path
+
+These assets are intentional 1:1 copies of the definitions in
+`CommandDemo.Start()`. Any divergence is a bug in either the assets or the
+code path — both should produce identical grammar JSON and identical
+recognition results for the same input.

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Common.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Common.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3f026db4e8c16a4f927d85d19678b4f, type: 3}
+  m_Name: Set_Common
+  m_EditorClassIdentifier:
+  setName: common
+  commands:
+  - {fileID: 11400000, guid: 0ba1937b1f9b4ee6ad1959605b7ca54e, type: 2}
+  - {fileID: 11400000, guid: d011570a460a45f59e761007efe30323, type: 2}
+  - {fileID: 11400000, guid: 968eea98056a4f3e9d77a08409a65e61, type: 2}
+  - {fileID: 11400000, guid: 3ea144840dd14157bc2b42f80915f9cf, type: 2}

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Common.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Common.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d5fb17afb344c45ba437f38afe7124a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Navigation.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Navigation.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3f026db4e8c16a4f927d85d19678b4f, type: 3}
+  m_Name: Set_Navigation
+  m_EditorClassIdentifier:
+  setName: navigation
+  commands:
+  - {fileID: 11400000, guid: 4febac755ac54784bfc9362bc2a10d9f, type: 2}
+  - {fileID: 11400000, guid: 82660e15997441e4b0d2112f821ae199, type: 2}
+  - {fileID: 11400000, guid: c66aa3f083a34567b57d19cee56fcd6d, type: 2}
+  - {fileID: 11400000, guid: 53ad75bec10c49d092d87a71f1f21122, type: 2}

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Navigation.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Navigation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f19fc680f72f4dfda27a45af6430a492
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Weapons.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Weapons.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3f026db4e8c16a4f927d85d19678b4f, type: 3}
+  m_Name: Set_Weapons
+  m_EditorClassIdentifier:
+  setName: weapons
+  commands:
+  - {fileID: 11400000, guid: 3f5859ea77dc4f6fad4ad0f7139a7870, type: 2}
+  - {fileID: 11400000, guid: 9f21209591ac4062b7a674db78ff7c3b, type: 2}
+  - {fileID: 11400000, guid: ad77bf8a3d754aa799708bcf4b7477a2, type: 2}

--- a/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Weapons.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Sets/Set_Weapons.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90c1ce141884426491c912f01a9dafa9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Elevation.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Elevation.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Elevation
+  m_EditorClassIdentifier:
+  slotName: elevation
+  slotType: 1
+  values: []
+  aliases: []
+  minWords: 1
+  maxWords: 2

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Elevation.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Elevation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5685f30f8e3e4be6bcf7e5e7f1eeb4fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Heading.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Heading.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Heading
+  m_EditorClassIdentifier:
+  slotName: heading
+  slotType: 1
+  values: []
+  aliases: []
+  minWords: 1
+  maxWords: 3

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Heading.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Heading.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e75acfd2373748caa196d83a031d217a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Quantity.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Quantity.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Quantity
+  m_EditorClassIdentifier:
+  slotName: quantity
+  slotType: 0
+  values:
+  - all
+  - one
+  - two
+  - three
+  aliases:
+  - variant: a
+    canonical: one
+  minWords: 1
+  maxWords: 3

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Quantity.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Quantity.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beb76d2c57ae4052b302e5617d86fd69
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Range.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Range.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Range
+  m_EditorClassIdentifier:
+  slotName: range
+  slotType: 0
+  values:
+  - cqb
+  - safe range
+  - torpedo range
+  - pdc range
+  - railgun range
+  aliases: []
+  minWords: 1
+  maxWords: 3

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Range.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Range.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b739968093246cd85097b9772167c6f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Target.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Target.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Target
+  m_EditorClassIdentifier:
+  slotName: target
+  slotType: 0
+  values:
+  - hotel one
+  - hotel two
+  - alpha one
+  - alpha three
+  - bravo two
+  aliases: []
+  minWords: 1
+  maxWords: 3

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Target.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Target.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84c4131700cd4b40aa1d070e4768805f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Weapon.asset
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Weapon.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccc96065bc235ec4eabd6d8d0e7ace9c, type: 3}
+  m_Name: Slot_Weapon
+  m_EditorClassIdentifier:
+  slotName: weapon
+  slotType: 0
+  values:
+  - missiles
+  - torpedoes
+  - jackal
+  aliases:
+  - variant: jackals
+    canonical: jackal
+  minWords: 1
+  maxWords: 3

--- a/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Weapon.asset.meta
+++ b/Samples~/CommandRecognition/AssetAuthoring/Slots/Slot_Weapon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35372aa7885c44c289d2b8ebfade2982
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/CommandRecognition/CommandDemo.cs
+++ b/Samples~/CommandRecognition/CommandDemo.cs
@@ -9,6 +9,11 @@ public class CommandDemo : MonoBehaviour
     [SerializeField] VoskSpeechRecogniser recogniser;
     [SerializeField] VoskCommandRecogniser commandRecogniser;
 
+    [Tooltip("When enabled, skip the code-based Configure() call and rely on " +
+             "ScriptableObject assets wired on VoskCommandRecogniser instead. " +
+             "Used for v2.5 Inspector authoring tests.")]
+    [SerializeField] bool useInspectorAuthoring = false;
+
     // Define intent names as constants to avoid typos.
     static class Intents
     {
@@ -27,6 +32,18 @@ public class CommandDemo : MonoBehaviour
 
     void Start()
     {
+        if (useInspectorAuthoring)
+        {
+            // Slots/commands/sets came from ScriptableObject assets in Awake().
+            // Just wire events and start recognition.
+            LogActiveSets();
+            commandRecogniser.OnCommandRecognised += OnCommand;
+            commandRecogniser.OnCommandsRecognised += OnCommandBatch;
+            commandRecogniser.OnUnrecognisedSpeech += OnUnrecognised;
+            recogniser.StartRecognition();
+            return;
+        }
+
         var targets = new VoskSlotDefinition("target",
             new[] { "hotel one", "hotel two", "alpha one", "alpha three", "bravo two" });
 

--- a/Tests/Runtime/VoskAssetConversionTests.cs
+++ b/Tests/Runtime/VoskAssetConversionTests.cs
@@ -1,0 +1,290 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskAssetConversionTests
+    {
+        // --- VoskSlotAsset ---
+
+        [Test]
+        public void SlotAsset_Enumerated_ProducesCorrectDefinition()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            asset.slotName = "weapon";
+            asset.slotType = VoskSlotType.Enumerated;
+            asset.values = new[] { "missiles", "torpedoes" };
+            asset.aliases = new[]
+            {
+                new VoskSlotAsset.AliasEntry { variant = "jackals", canonical = "jackal" },
+            };
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual("weapon", def.Name);
+            Assert.AreEqual(VoskSlotType.Enumerated, def.Type);
+            Assert.AreEqual(2, def.Values.Length);
+            Assert.AreEqual("missiles", def.Values[0]);
+            Assert.AreEqual("torpedoes", def.Values[1]);
+            Assert.IsNotNull(def.Aliases);
+            Assert.AreEqual("jackal", def.Aliases["jackals"]);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void SlotAsset_NumberSequence_ProducesCorrectDefinition()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            asset.slotName = "heading";
+            asset.slotType = VoskSlotType.NumberSequence;
+            asset.minWords = 1;
+            asset.maxWords = 3;
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual("heading", def.Name);
+            Assert.AreEqual(VoskSlotType.NumberSequence, def.Type);
+            Assert.AreEqual(1, def.MinWords);
+            Assert.AreEqual(3, def.MaxWords);
+            Assert.AreEqual(0, def.Values.Length);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void SlotAsset_EmptyAliases_ProducesNullAliasDict()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            asset.slotName = "target";
+            asset.slotType = VoskSlotType.Enumerated;
+            asset.values = new[] { "hotel one" };
+            asset.aliases = Array.Empty<VoskSlotAsset.AliasEntry>();
+
+            var def = asset.ToDefinition();
+
+            Assert.IsNull(def.Aliases);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void SlotAsset_NullAliases_ProducesNullAliasDict()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            asset.slotName = "target";
+            asset.slotType = VoskSlotType.Enumerated;
+            asset.values = new[] { "alpha one" };
+            asset.aliases = null;
+
+            var def = asset.ToDefinition();
+
+            Assert.IsNull(def.Aliases);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void SlotAsset_NullValues_ProducesEmptyArray()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            asset.slotName = "empty";
+            asset.slotType = VoskSlotType.Enumerated;
+            asset.values = null;
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual(0, def.Values.Length);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        // --- VoskCommandAsset ---
+
+        [Test]
+        public void CommandAsset_SinglePattern_SplitsCorrectly()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "fire";
+            asset.patterns = new[] { "fire weapons" };
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual("fire", def.Intent);
+            Assert.AreEqual(1, def.Patterns.Length);
+            Assert.AreEqual(new[] { "fire", "weapons" }, def.Patterns[0]);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void CommandAsset_MultiplePatterns_SplitIndependently()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "launch";
+            asset.patterns = new[]
+            {
+                "launch {weapon} target {target}",
+                "fire {weapon} at {target}",
+            };
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual(2, def.Patterns.Length);
+            Assert.AreEqual(new[] { "launch", "{weapon}", "target", "{target}" }, def.Patterns[0]);
+            Assert.AreEqual(new[] { "fire", "{weapon}", "at", "{target}" }, def.Patterns[1]);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void CommandAsset_SlotTokens_PreservedAfterSplit()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "test";
+            asset.patterns = new[] { "launch {?quantity} {weapon} ?a target" };
+
+            var def = asset.ToDefinition();
+            var tokens = def.Patterns[0];
+
+            Assert.AreEqual("launch", tokens[0]);
+            Assert.AreEqual("{?quantity}", tokens[1]);
+            Assert.AreEqual("{weapon}", tokens[2]);
+            Assert.AreEqual("?a", tokens[3]);
+            Assert.AreEqual("target", tokens[4]);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void CommandAsset_ExtraWhitespace_HandledCorrectly()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "test";
+            asset.patterns = new[] { "  fire   weapons  " };
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual(new[] { "fire", "weapons" }, def.Patterns[0]);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void CommandAsset_EmptyPattern_ProducesEmptyTokenArray()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "test";
+            asset.patterns = new[] { "" };
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual(1, def.Patterns.Length);
+            Assert.AreEqual(0, def.Patterns[0].Length);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        [Test]
+        public void CommandAsset_NullPatterns_ProducesEmptyArray()
+        {
+            var asset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            asset.intent = "test";
+            asset.patterns = null;
+
+            var def = asset.ToDefinition();
+
+            Assert.AreEqual(0, def.Patterns.Length);
+
+            UnityEngine.Object.DestroyImmediate(asset);
+        }
+
+        // --- VoskCommandSetAsset ---
+
+        [Test]
+        public void CommandSetAsset_ConvertsNameAndCommands()
+        {
+            var cmdAsset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            cmdAsset.intent = "cease_fire";
+            cmdAsset.patterns = new[] { "cease fire" };
+
+            var setAsset = ScriptableObject.CreateInstance<VoskCommandSetAsset>();
+            setAsset.setName = "weapons";
+            setAsset.commands = new[] { cmdAsset };
+
+            var set = setAsset.ToSet();
+
+            Assert.AreEqual("weapons", set.Name);
+            Assert.AreEqual(1, set.Commands.Length);
+            Assert.AreEqual("cease_fire", set.Commands[0].Intent);
+
+            UnityEngine.Object.DestroyImmediate(cmdAsset);
+            UnityEngine.Object.DestroyImmediate(setAsset);
+        }
+
+        [Test]
+        public void CommandSetAsset_NullCommandEntry_SkippedWithWarning()
+        {
+            var cmdAsset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            cmdAsset.intent = "test";
+            cmdAsset.patterns = new[] { "hello" };
+
+            var setAsset = ScriptableObject.CreateInstance<VoskCommandSetAsset>();
+            setAsset.setName = "mixed";
+            setAsset.commands = new VoskCommandAsset[] { cmdAsset, null };
+
+            var set = setAsset.ToSet();
+
+            Assert.AreEqual(1, set.Commands.Length);
+            Assert.AreEqual("test", set.Commands[0].Intent);
+
+            UnityEngine.Object.DestroyImmediate(cmdAsset);
+            UnityEngine.Object.DestroyImmediate(setAsset);
+        }
+
+        [Test]
+        public void CommandSetAsset_EmptyCommands_ProducesEmptySet()
+        {
+            var setAsset = ScriptableObject.CreateInstance<VoskCommandSetAsset>();
+            setAsset.setName = "empty";
+            setAsset.commands = Array.Empty<VoskCommandAsset>();
+
+            var set = setAsset.ToSet();
+
+            Assert.AreEqual("empty", set.Name);
+            Assert.AreEqual(0, set.Commands.Length);
+
+            UnityEngine.Object.DestroyImmediate(setAsset);
+        }
+
+        // --- Round-trip ---
+
+        [Test]
+        public void RoundTrip_AssetToDefinitionToParser_MatchesCommand()
+        {
+            var slotAsset = ScriptableObject.CreateInstance<VoskSlotAsset>();
+            slotAsset.slotName = "weapon";
+            slotAsset.slotType = VoskSlotType.Enumerated;
+            slotAsset.values = new[] { "missiles", "torpedoes" };
+
+            var cmdAsset = ScriptableObject.CreateInstance<VoskCommandAsset>();
+            cmdAsset.intent = "fire";
+            cmdAsset.patterns = new[] { "fire {weapon}" };
+
+            var slots = new[] { slotAsset.ToDefinition() };
+            var commands = new[] { cmdAsset.ToDefinition() };
+
+            var parser = new VoskCommandParser(slots, commands);
+            var results = parser.Parse("fire missiles", Array.Empty<VoskWord>());
+
+            Assert.AreEqual(1, results.Length);
+            Assert.AreEqual("fire", results[0].Command.Intent);
+            Assert.AreEqual("missiles", results[0].Command.GetSlot("weapon"));
+
+            UnityEngine.Object.DestroyImmediate(slotAsset);
+            UnityEngine.Object.DestroyImmediate(cmdAsset);
+        }
+    }
+}

--- a/Tests/Runtime/VoskAssetConversionTests.cs.meta
+++ b/Tests/Runtime/VoskAssetConversionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30d9d86899351a843be5471dde0150c0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AAudio on Android arm64.",
   "unity": "6000.0",

--- a/v2-command-recognition-plan.md
+++ b/v2-command-recognition-plan.md
@@ -50,7 +50,7 @@ Utterance buffer (`bufferWindow`) merges split VOSK results before parsing. Sequ
 
 # v2.5 — Inspector Authoring
 
-Adds ScriptableObject-based command and slot authoring for designers who prefer the Inspector over code. Does not replace the code API — provides a parallel authoring path. Also adds push-to-talk mode for scenarios where always-on recognition is undesirable.
+Adds ScriptableObject-based command and slot authoring for designers who prefer the Inspector over code. Does not replace the code API — provides a parallel authoring path.
 
 ## v2.5 Scope
 
@@ -60,13 +60,11 @@ Adds ScriptableObject-based command and slot authoring for designers who prefer 
 - `VoskCommandSetAsset` ScriptableObject for command set grouping
 - Inspector-driven `Configure()` overloads on `VoskCommandRecogniser`
 - Serialized asset references on `VoskCommandRecogniser` for zero-code setup
-- Push-to-talk mode — recognition starts/stops on input action
 
 **Problems this solves:**
 - Designers can't author commands without writing C# — they depend on a programmer for every vocabulary change.
 - Iteration is slow: change a slot value → recompile → test. With ScriptableObjects: change a value in Inspector → enter play mode → test.
 - No visual overview of all commands and their patterns.
-- Some scenarios need recognition only when the player is actively commanding (push-to-talk).
 
 ## v2.5 `VoskSlotAsset`
 
@@ -141,33 +139,6 @@ public class VoskCommandSetAsset : ScriptableObject
 }
 ```
 
-## v2.5 Push-to-Talk
-
-A mode on `VoskCommandRecogniser` where recognition is only active while an input is held.
-
-```csharp
-[Tooltip("When enabled, recognition only runs while pushToTalkAction is held. " +
-         "Eliminates phantom commands when the player is not actively commanding.")]
-[SerializeField] bool pushToTalkEnabled = false;
-
-[Tooltip("Input action that activates recognition. Typically a controller grip or trigger.")]
-[SerializeField] InputActionReference pushToTalkAction;
-```
-
-### Behaviour
-
-- When `pushToTalkEnabled` is true and the action is pressed: `StartRecognition()`.
-- When the action is released: waits `pushToTalkTail` seconds (default 0.5s) for the final VOSK result to arrive, then `StopRecognition()`.
-- The tail delay prevents cutting off the last word. VOSK needs a moment of silence after speech to emit the final result.
-- When `pushToTalkEnabled` is false (default): recognition runs continuously as in v2.0–v2.4.
-- Push-to-talk composes with the utterance buffer: the buffer flushes either on timer expiry or on push-to-talk release (whichever comes first), ensuring commands are processed promptly when the player lets go.
-
-### Input System dependency
-
-Uses Unity's Input System (`UnityEngine.InputSystem`). The `InputActionReference` field is nullable — if push-to-talk is enabled but no action is assigned, a warning is logged and push-to-talk is disabled at runtime.
-
-Assembly definition gains optional reference to `Unity.InputSystem`. Push-to-talk code is behind `#if ENABLE_INPUT_SYSTEM` so the package compiles without Input System installed (push-to-talk simply isn't available).
-
 ## v2.5 Changes to `VoskCommandRecogniser`
 
 ```csharp
@@ -191,7 +162,7 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 
 | File | Change |
 |------|--------|
-| `Runtime/Commands/VoskCommandRecogniser.cs` | Asset reference fields, auto-configure from assets in `Awake()`, push-to-talk fields and logic |
+| `Runtime/Commands/VoskCommandRecogniser.cs` | Asset reference fields, auto-configure from assets in `Awake()` |
 
 ## v2.5 Test Plan
 
@@ -206,14 +177,6 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 - Code `Configure()` call → Inspector assets ignored
 - Missing slot asset referenced by command pattern → validation warning at configure time
 
-**Push-to-talk:**
-- Action pressed → recognition starts
-- Action released → recognition stops after tail delay
-- Speech during release tail → final result captured
-- Push-to-talk disabled → continuous recognition (v2.4 behaviour)
-- No action assigned + push-to-talk enabled → warning, falls back to continuous
-- `#if ENABLE_INPUT_SYSTEM` absent → push-to-talk fields hidden, continuous only
-
 ---
 
 # Version Summary
@@ -225,13 +188,17 @@ On `Awake()`, if `slotAssets` is non-empty and `Configure()` has not been called
 | **v2.2** | Numeric | NumberSequence slots, VoskNumberParser | Headings, numeric distances, coordinates |
 | **v2.3** | Continuity | Utterance buffer, sequential command extraction, debounce | Split commands recovered, chained commands extracted |
 | **v2.4** | Command Sets | Named command groups, runtime switching | Mode-specific commands, reduced grammar per mode |
-| **v2.5** | Inspector Authoring | ScriptableObject slots/commands/sets, zero-code setup, push-to-talk | Same commands, designer-friendly authoring, input-gated recognition |
+| **v2.5** | Inspector Authoring | ScriptableObject slots/commands/sets, zero-code setup | Same commands, designer-friendly authoring |
 
 Native bridge change (`vosk_bridge_set_grammar`) ships in v2.0. Everything in v2.1–v2.5 is pure C# changes on top.
 
 ---
 
 # Future Ideas (Out of Scope for v2.x)
+
+## Push-to-talk mode
+
+Recognition starts/stops on input action press/release. Eliminates phantom commands when the player is not actively commanding. Requires Unity Input System (`InputActionReference`). Tail delay (e.g. 0.5s) after release prevents cutting off the last word — VOSK needs a moment of silence to emit the final result. Composes with the utterance buffer: buffer flushes on timer expiry or push-to-talk release, whichever comes first. Assembly definition gains optional reference to `Unity.InputSystem` behind `#if` so the package compiles without it.
 
 ## Pattern prefix routing (wake words)
 

--- a/v2.5-test-matrix.md
+++ b/v2.5-test-matrix.md
@@ -1,0 +1,264 @@
+# V2.5 Inspector Authoring — Quest Device Test Matrix
+
+v2.5 adds ScriptableObject-based command authoring (`VoskSlotAsset`,
+`VoskCommandAsset`, `VoskCommandSetAsset`) plus auto-configure on `Awake()`
+in `VoskCommandRecogniser`. The on-device test goal is to confirm that the
+asset path produces the **same recognition behaviour** as the v2.4 code path
+across every slot type, pattern token form, and runtime set switch.
+
+The asset → definition conversion is already covered by `VoskAssetConversionTests`
+(13 tests). This matrix focuses on **integration**: assets actually drive a
+working `VoskCommandRecogniser` on Quest hardware.
+
+## Prerequisites
+
+1. **Scene**: `VoskSpeechRecogniser` + `VoskCommandRecogniser` + a demo behaviour
+   that subscribes to events for logging (see "Demo Variant" below)
+2. **Build & deploy** to Quest
+3. **Inspector defaults**: `minScore=0.6`, `minConfidence=0.4`, `freeSpeechMode=false`,
+   `bufferWindow=1.5`, `commandCooldown=0.3`
+4. **Logcat**:
+   ```bash
+   "/mnt/c/Program Files/Unity/Hub/Editor/6000.3.7f1/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/platform-tools/adb.exe" logcat -s "Unity:*" "vosk-bridge:*"
+   ```
+
+## Demo Variant
+
+`CommandDemo.cs` has a `useInspectorAuthoring` flag that gates the code-based
+`Configure()` call. When enabled, `Start()` skips slot/command construction
+and only wires events + starts recognition — letting the assets configured in
+`Awake()` drive everything. When disabled (default), `CommandDemo` runs the
+v2.4 code path. For Phase 6 (code priority) the flag is toggled back to
+`false`.
+
+## Asset Setup
+
+The 20 assets needed for these tests ship with the Command Recognition sample
+under `Samples~/CommandRecognition/AssetAuthoring/` (Slots/, Commands/, Sets/).
+After importing the sample via Package Manager, they appear in
+`Assets/Samples/VOSK XR Speech Recognition/<version>/Command Recognition/AssetAuthoring/`.
+The asset definitions below match the runtime values in `CommandDemo.cs`
+exactly so existing voice phrases transfer between code and asset paths.
+
+### Slot Assets (Assets → Create → VOSK XR → Slot Definition)
+
+| Asset file              | slotName    | slotType        | values / settings                                                                          | aliases               |
+|-------------------------|-------------|-----------------|--------------------------------------------------------------------------------------------|-----------------------|
+| `Slot_Target.asset`     | `target`    | Enumerated      | `hotel one`, `hotel two`, `alpha one`, `alpha three`, `bravo two`                          | (none)                |
+| `Slot_Weapon.asset`     | `weapon`    | Enumerated      | `missiles`, `torpedoes`, `jackal`                                                          | `jackals` → `jackal`  |
+| `Slot_Quantity.asset`   | `quantity`  | Enumerated      | `all`, `one`, `two`, `three`                                                               | `a` → `one`           |
+| `Slot_Range.asset`      | `range`     | Enumerated      | `cqb`, `safe range`, `torpedo range`, `pdc range`, `railgun range`                         | (none)                |
+| `Slot_Heading.asset`    | `heading`   | NumberSequence  | `minWords=1`, `maxWords=3`                                                                 | (none)                |
+| `Slot_Elevation.asset`  | `elevation` | NumberSequence  | `minWords=1`, `maxWords=2`                                                                 | (none)                |
+
+### Command Assets (Assets → Create → VOSK XR → Command Definition)
+
+Each pattern is a single string; whitespace splits into tokens.
+
+| Asset file                  | intent              | patterns (one per array element)                                                                                                                                           |
+|-----------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Cmd_LaunchWeapon.asset`    | `launch_weapon`     | `launch {?quantity} {weapon} target {target}` <br> `fire {?quantity} {weapon} at {target}` <br> `shoot {weapon}`                                                            |
+| `Cmd_CeaseFire.asset`       | `cease_fire`        | `cease fire` <br> `stop firing` <br> `disengage`                                                                                                                            |
+| `Cmd_ResumeFire.asset`      | `resume_fire`       | `resume fire` <br> `resume firing` <br> `reengage`                                                                                                                          |
+| `Cmd_SetDistanceNamed.asset`| `set_distance_named`| `close distance {range} target {target}` <br> `set distance {range} target {target}` <br> `make distance {range} target {target}` <br> `open distance {range} target {target}` |
+| `Cmd_ApproachTarget.asset`  | `approach_target`   | `close on target {target}` <br> `close in on target {target}` <br> `approach target {target}`                                                                               |
+| `Cmd_RetreatFromTarget.asset`| `retreat_from_target` | `fall back from target {target}` <br> `pull back from target {target}` <br> `get away from target {target}` <br> `move away from target {target}` <br> `open distance from target {target}` |
+| `Cmd_SetHeading.asset`      | `set_heading`       | `orient heading {heading}` <br> `orient heading {heading} mark {?elevation}` <br> `set heading {heading}`                                                                   |
+| `Cmd_ModeWeapons.asset`     | `mode_weapons`      | `weapons mode` <br> `switch to weapons`                                                                                                                                     |
+| `Cmd_ModeNavigation.asset`  | `mode_navigation`   | `navigation mode` <br> `switch to navigation`                                                                                                                               |
+| `Cmd_ModeAll.asset`         | `mode_all`          | `all modes` <br> `enable all`                                                                                                                                               |
+| `Cmd_ModeDisable.asset`     | `mode_disable`      | `disable all` <br> `disable commands`                                                                                                                                       |
+
+### Command Set Assets (Assets → Create → VOSK XR → Command Set)
+
+| Asset file              | setName      | commands                                                                                                          |
+|-------------------------|--------------|-------------------------------------------------------------------------------------------------------------------|
+| `Set_Weapons.asset`     | `weapons`    | `Cmd_LaunchWeapon`, `Cmd_CeaseFire`, `Cmd_ResumeFire`                                                             |
+| `Set_Navigation.asset`  | `navigation` | `Cmd_SetDistanceNamed`, `Cmd_ApproachTarget`, `Cmd_RetreatFromTarget`, `Cmd_SetHeading`                           |
+| `Set_Common.asset`      | `common`     | `Cmd_ModeWeapons`, `Cmd_ModeNavigation`, `Cmd_ModeAll`, `Cmd_ModeDisable`                                         |
+
+### Wire on `VoskCommandRecogniser`
+
+In the Inspector, under **Inspector Authoring**:
+- `Slot Assets` → drag in all 6 slot assets
+- `Command Set Assets` → drag in `Set_Weapons`, `Set_Navigation`, `Set_Common`
+- `Initial Active Set Names` → `["weapons", "navigation", "common"]`
+
+Set `useInspectorAuthoring = true` on `CommandDemo` (Option A above).
+
+---
+
+## Phase 0: Editor Setup Verification
+
+Pre-build sanity checks before deploying to Quest.
+
+| #   | Check                                                                                                              | Expected                                                                          | Result |
+|-----|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|--------|
+| 0.1 | Import the **Command Recognition** sample via Package Manager                                                      | `AssetAuthoring/Slots`, `Commands`, `Sets` folders appear under `Assets/Samples/...` |     |
+| 0.2 | Open `Slot_Weapon.asset` — Inspector shows slotName=weapon, values=missiles/torpedoes/jackal, alias jackals→jackal| All fields populated correctly (script reference resolved, no `(missing)`)        |        |
+| 0.3 | Open `Set_Weapons.asset` — Inspector shows setName=weapons, 3 command refs (LaunchWeapon, CeaseFire, ResumeFire)   | All 3 references resolved (no `Missing (Mono Script)` placeholders)               |        |
+| 0.4 | On `VoskCommandRecogniser`: drag in 6 slots, 3 sets, set `initialActiveSetNames = [weapons, navigation, common]`   | Lists populated, no `(missing)` entries                                           |        |
+| 0.5 | On `CommandDemo`: enable `useInspectorAuthoring`                                                                   | Tooltip visible; flag persists in scene                                           |        |
+| 0.6 | Editor Play mode: enter play, check console                                                                        | No exceptions; `Active sets: [weapons, navigation, common]` logged                |        |
+| 0.7 | `VoskAssetConversionTests` (Test Runner)                                                                           | 13/13 pass                                                                        |        |
+
+---
+
+## Phase 1: Auto-Configure on Awake — Baseline Recognition
+
+Verify that `VoskCommandRecogniser.Awake()` populates slots/sets from assets
+and recognition starts working with no code `Configure()` call.
+
+| #   | Say this                                       | Expected Intent    | Expected Slots                             | Why                                                    | Result |
+|-----|------------------------------------------------|--------------------|--------------------------------------------|--------------------------------------------------------|--------|
+| 1.1 | (startup, no speech)                           | —                  | —                                          | Logcat shows `Active sets: [weapons, navigation, common]` from `initialActiveSetNames` | PASS |
+| 1.2 | "cease fire"                                   | cease_fire         | (none)                                     | Asset-driven weapons command works                     | PASS |
+| 1.3 | "launch missiles target hotel one"             | launch_weapon      | weapon=missiles, target=hotel one          | Asset-driven slotted command works                     | PASS |
+| 1.4 | "approach target alpha one"                    | approach_target    | target=alpha one                           | Asset-driven navigation command works                  | PASS |
+| 1.5 | "orient heading two seven zero"                | set_heading        | heading="two seven zero" (270)             | Asset-driven NumberSequence works                      | PASS |
+
+---
+
+## Phase 2: Slot Conversion via Assets — Enumerated + Aliases
+
+Verify all enumerated slot values + aliases survive the asset → definition conversion.
+
+| #   | Say this                                       | Expected Intent    | Expected Slots                                       | Why                                                | Result |
+|-----|------------------------------------------------|--------------------|------------------------------------------------------|----------------------------------------------------|--------|
+| 2.1 | "fire torpedoes at bravo two"                  | launch_weapon      | weapon=torpedoes, target=bravo two                   | Multi-value enumerated slot + multi-word target    | PASS   |
+| 2.2 | "shoot jackals"                                | launch_weapon      | weapon=jackal (alias resolved)                       | Asset-defined alias `jackals` → `jackal`           | PASS   |
+| 2.3 | "fire a torpedoes at alpha three"              | launch_weapon      | quantity=one (alias), weapon=torpedoes, target=alpha three | Asset-defined alias `a` → `one` on quantity slot | PASS |
+| 2.4 | "close distance torpedo range target hotel two"| set_distance_named | range=torpedo range, target=hotel two                | Multi-word enumerated value (`torpedo range`)      | PASS   |
+| 2.5 | "fire all missiles at alpha three"             | launch_weapon      | quantity=all, weapon=missiles, target=alpha three    | All slot positions populated from asset definitions| PASS   |
+
+---
+
+## Phase 3: Slot Conversion via Assets — NumberSequence
+
+Verify `VoskSlotType.NumberSequence` with `minWords` / `maxWords` survives conversion.
+
+| #   | Say this                                       | Expected Intent | Expected Slots                                       | Why                                                  | Result |
+|-----|------------------------------------------------|-----------------|------------------------------------------------------|------------------------------------------------------|--------|
+| 3.1 | "orient heading one eight zero"                | set_heading     | heading="one eight zero" (180)                       | 3-word number sequence (maxWords)                    | PASS   |
+| 3.2 | "orient heading nine"                          | set_heading     | heading="nine" (9)                                   | 1-word number sequence (minWords)                    | PASS   |
+| 3.3 | "orient heading three five mark two"           | set_heading     | heading=35, elevation=2                              | Two NumberSequence slots in one pattern              | PASS   |
+| 3.4 | "set heading two seven zero"                   | set_heading     | heading=270                                          | Alternate pattern using same NumberSequence slot     | PASS   |
+
+---
+
+## Phase 4: Pattern Token Splitting
+
+Verify that whitespace-delimited pattern strings produce correct token arrays
+for `{slot}`, `{?slot}`, `?word`, and multi-word literals.
+
+| #   | Say this                                       | Expected Intent | Expected Slots                                       | Pattern feature exercised                            | Result |
+|-----|------------------------------------------------|-----------------|------------------------------------------------------|------------------------------------------------------|--------|
+| 4.1 | "launch missiles target hotel one"             | launch_weapon   | weapon=missiles, target=hotel one (no quantity)      | `{?quantity}` optional slot omitted                  | PASS   |
+| 4.2 | "launch all missiles target hotel one"         | launch_weapon   | quantity=all, weapon=missiles, target=hotel one      | `{?quantity}` optional slot present                  | PASS   |
+| 4.3 | "shoot missiles"                               | launch_weapon   | weapon=missiles                                      | Short 2-token pattern                                | PASS   |
+| 4.4 | "orient heading two seven zero mark five"      | set_heading     | heading=270, elevation=5                             | Optional NumberSequence slot via `{?elevation}`      | PASS   |
+| 4.5 | "switch to weapons"                            | mode_weapons    | (none)                                               | Multi-token literal pattern, no slots                | KNOWN ISSUE — VOSK misrecognises "to" as "two", pattern never matches. Asset tokenization is correct; acoustic-model limitation. |
+| 4.6 | "stop firing"                                  | cease_fire      | (none)                                               | Alternate pattern (asset's 2nd patterns[] entry)     | PASS   |
+
+---
+
+## Phase 5: Runtime Set Switching via Asset Path
+
+Confirm `SetActiveSets()` still works when sets came from assets — i.e. v2.4
+behaviour is preserved through the asset configure path.
+
+| #   | Action                                              | Then say                              | Expected Result       | Result |
+|-----|-----------------------------------------------------|---------------------------------------|-----------------------|--------|
+| 5.1 | (startup, all 3 sets active from `initialActiveSetNames`) | "weapons mode"                  | mode_weapons + `Active sets: [weapons, common]` | PASS |
+| 5.2 | (still in weapons mode)                             | "approach target alpha one"           | Unrecognised — navigation set inactive | PASS — bonus: "approach" filtered at acoustic level (`[unk]`) since not in active grammar |
+| 5.3 | (still in weapons mode)                             | "cease fire"                          | cease_fire            | PASS   |
+| 5.4 | Say "navigation mode"                               | "fall back from target hotel two"     | retreat_from_target, target=hotel two | PASS (2nd attempt) — first attempt dropped "fall back from" because audio capture was restarting after grammar rebuild. See Known Issues. |
+| 5.5 | (still in navigation mode)                          | "cease fire"                          | Unrecognised — weapons set inactive | PASS — both words filtered to `[unk]` |
+| 5.6 | Say "all modes"                                     | "cease fire"                          | cease_fire — all sets restored        | PASS   |
+| 5.7 | Say "disable all"                                   | "cease fire"                          | No event — all sets cleared           | PASS — zero command events fired during 5s disabled window |
+| 5.8 | Wait 5s for auto-restore, then "approach target alpha one" | approach_target              | Coroutine restore works through asset path | PASS — navigation set restored, approach_target fired (score=1.00) |
+
+---
+
+## Phase 6: Code `Configure()` Priority
+
+Verify that calling `Configure()` from code overrides the inspector asset path.
+
+| #   | Setup                                                                 | Say this                          | Expected                                        | Result |
+|-----|-----------------------------------------------------------------------|-----------------------------------|-------------------------------------------------|--------|
+| 6.1 | `useInspectorAuthoring = false` (CommandDemo Start() rebuilds via code)| "cease fire"                     | cease_fire — code path wins                     | PASS — two `Grammar applied` log lines (asset Awake then code Start), code wins |
+| 6.2 | (same)                                                                | "approach target alpha one"       | approach_target — code-defined commands active  | PASS   |
+| 6.3 | Move `Configure()` to a script with **higher** Script Execution Order than `VoskCommandRecogniser`, so its `Awake()` calls `Configure()` before recogniser's `Awake()` runs | "cease fire" | cease_fire — code wins via early Awake too | SKIP — edge case; common case (Configure in Start) covered by 6.1/6.2 |
+| 6.4 | (Phase 6 cleanup) Restore `useInspectorAuthoring = true`              | "cease fire"                      | cease_fire — back on asset path                 | PASS — only ONE `Grammar applied` (asset only), code path correctly skipped |
+
+---
+
+## Phase 7: Null Guards
+
+Verify the `Awake()` null-skip warnings don't crash and the remaining valid
+assets still produce a working configuration.
+
+| #   | Setup                                                                                | Say this              | Expected                                                          | Result |
+|-----|--------------------------------------------------------------------------------------|-----------------------|-------------------------------------------------------------------|--------|
+| 7.1 | Insert one `null` entry in `slotAssets` array on the recogniser                      | "cease fire"          | Warning `slotAssets[N] is null — skipping`; cease_fire still fires | PASS — `slotAssets[6] is null — skipping`, then cease_fire fired (score=1.00) |
+| 7.2 | Insert one `null` entry in `commandSetAssets` array                                  | "cease fire"          | Warning `commandSetAssets[N] is null — skipping`; cease_fire still fires | PASS — `commandSetAssets[3] is null — skipping`, then cease_fire fired (score=1.00) |
+| 7.3 | Insert one `null` entry inside a `VoskCommandSetAsset.commands` array (e.g. Set_Weapons) | "cease fire"      | Warning `commands[N] is null — skipping`; cease_fire still fires (other commands in set still loaded) | PASS — `[VoskCommandSetAsset] 'weapons' commands[3] is null — skipping`, cease_fire fired (score=1.00). First attempt failed due to stray empty entry in `Initial Active Set Names` (separate user error). |
+| 7.4 | Empty `slotAssets` array (length 0)                                                  | "cease fire"          | No exception; `Awake()` returns early; no recognition (no commands configured) | PASS — `Active sets: []`, no exception, no command event when "cease fire" said |
+| 7.5 | (Phase 7 cleanup) Restore all asset references                                       | "cease fire"          | cease_fire — back to baseline                                     | PASS — only the expected 'a' alias validation warning, cease_fire fired (score=1.00) |
+
+---
+
+## Phase 8: Regression — Full v2.0–v2.4 Stack via Asset Path
+
+Spot-check that every core feature from prior versions still works when
+configured via assets.
+
+| #   | Say this                                         | Expected Intent                | Expected Slots                                       | Feature (version)                        | Result |
+|-----|--------------------------------------------------|--------------------------------|------------------------------------------------------|------------------------------------------|--------|
+| 8.1 | "fire all torpedoes at alpha three"              | launch_weapon                  | quantity=all, weapon=torpedoes, target=alpha three   | Full slot extraction (v2.0)              | PASS   |
+| 8.2 | "launch jackals target bravo two"                | launch_weapon                  | weapon=jackal (alias), target=bravo two              | Alias resolution (v2.1)                  | PASS   |
+| 8.3 | "orient heading one eight zero"                  | set_heading                    | heading=180                                          | NumberSequence slot (v2.2)               | PASS   |
+| 8.4 | "cease fire launch missiles target hotel one"    | cease_fire, launch_weapon      | —, weapon=missiles target=hotel one                  | Sequential extraction (v2.3)             | PASS — Batch: 2 commands from single utterance |
+| 8.5 | "fire torpedoes \| at bravo two" (with pause)    | launch_weapon                  | weapon=torpedoes, target=bravo two                   | Utterance buffer merge (v2.3)            | PASS — VOSK merged into single Final, parsed cleanly |
+| 8.6 | "cease fire" twice rapidly (<0.3s)               | First fires, second suppressed | (none)                                               | Per-intent debounce (v2.3)               | PASS — VOSK heard as one Final "cease fire cease fire", only 1 cease_fire event fired (Batch: 1) |
+| 8.7 | (in weapons mode) "approach target alpha one"    | Unrecognised                   | —                                                    | Set restriction blocks navigation (v2.4) | PASS — "approach" filtered acoustically (`[unk]`), no command event fired |
+
+---
+
+## Results Summary
+
+| Phase | Tests | Pass | Fail | Skip |
+|-------|-------|------|------|------|
+| 0 - Editor Setup Verification         |  7 | — | — | 7 (editor-only, not run this pass) |
+| 1 - Auto-Configure on Awake           |  5 | 5 | 0 | 0 |
+| 2 - Slot Conversion: Enumerated       |  5 | 5 | 0 | 0 |
+| 3 - Slot Conversion: NumberSequence   |  4 | 4 | 0 | 0 |
+| 4 - Pattern Token Splitting           |  6 | 5 | 0 | 1 (4.5 known issue) |
+| 5 - Runtime Set Switching             |  8 | 8 | 0 | 0 |
+| 6 - Code Configure() Priority         |  4 | 3 | 0 | 1 (6.3 skipped) |
+| 7 - Null Guards                       |  5 | 5 | 0 | 0 |
+| 8 - Regression: v2.0–v2.4             |  7 | 7 | 0 | 0 |
+| **Quest run (Phases 1–8)**            | **44** | **42** | **0** | **2** (1 known issue, 1 skipped) |
+| **Including Phase 0**                 | **51** | **42** | **0** | **9** |
+
+### Notes
+
+- Phase 0 is editor-only (Test Runner + Inspector wiring); Phases 1–8 run on Quest.
+- Phases 1–5 and 8 reuse the v2.4 phrase set so any failure indicates the asset
+  conversion path differs from the code path (rather than a phrase that always
+  misrecognises). Cross-reference v2.4 results when triaging.
+- Phase 6.3 requires editing **Edit → Project Settings → Script Execution Order**
+  to push the Configure-from-code script ahead of `VoskCommandRecogniser`. Skip
+  this row if execution-order ordering proves fiddly — Phase 6.1/6.2 already
+  cover the common case (Configure called in Start()).
+
+## Logcat Reference
+
+- **Per-command**: `[CommandDemo] Command: <intent> (confidence=X.XX, score=X.XX)`
+- **Batch**: `[CommandDemo] Batch: N command(s) from single utterance`
+- **No match**: `[CommandDemo] Unrecognised: "<text>"`
+- **Active sets**: `[CommandDemo] Active sets: [set1, set2, ...]`
+- **Mode switch**: `[CommandDemo] Switched to WEAPONS/NAVIGATION/ALL mode`
+- **Null asset warning**: `[VoskCommandRecogniser] slotAssets[N] is null — skipping`
+- **Null command set warning**: `[VoskCommandRecogniser] commandSetAssets[N] is null — skipping`
+- **Null command in set warning**: `[VoskCommandSetAsset] '<setName>' commands[N] is null — skipping`

--- a/v2.5-test-matrix.md.meta
+++ b/v2.5-test-matrix.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 33ff8292eefffa04cade6e9824ee076d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
  ## Summary

  - Adds Inspector-based command authoring via three new ScriptableObjects: `VoskSlotAsset`,
  `VoskCommandAsset`, `VoskCommandSetAsset`. Wire slot and command set assets directly on
  `VoskCommandRecogniser` for zero-code setup; code-based `Configure()` still takes priority when both
   are present.
  - Adds `initialActiveSetNames` on `VoskCommandRecogniser` to select which sets activate on `Awake()`
   when using the asset path, plus null-guard warnings so missing inspector references are skipped
  with a clear log line instead of throwing.
  - Ships a 20-asset sample set under `Samples~/CommandRecognition/AssetAuthoring/` (6 slots, 11
  commands, 3 sets) covering every slot type and pattern token form, plus a `useInspectorAuthoring`
  toggle on `CommandDemo` to flip between code and asset paths without editing the script.
  - Adds project-wide `KNOWN_LIMITATIONS.md` collecting VOSK acoustic, voice-recognition, and
  architectural limitations as we find them.

  ## Test plan

  - [x] Editor unit tests: 13/13 `VoskAssetConversionTests` pass
  - [x] Quest device test matrix (`v2.5-test-matrix.md`): **42/44 on-device tests pass**, 0 fail
    - Phase 1 — Auto-Configure on Awake: 5/5
    - Phase 2 — Slot Conversion (Enumerated + Aliases): 5/5
    - Phase 3 — Slot Conversion (NumberSequence): 4/4
    - Phase 4 — Pattern Token Splitting: 5/6 (4.5 known issue: VOSK "to" → "two")
    - Phase 5 — Runtime Set Switching: 8/8
    - Phase 6 — Code `Configure()` Priority: 3/4 (6.3 skipped: script execution order edge case)
    - Phase 7 — Null Guards: 5/5
    - Phase 8 — Regression v2.0–v2.4: 7/7
  - [x] Two known limitations documented in `KNOWN_LIMITATIONS.md`:
    - VOSK "to" → "two" misrecognition (acoustic, workaround: `weapons mode` alternate pattern)
    - Set switch latency: ~50ms audio gap during grammar rebuild can drop leading words of next
  utterance (workaround: pause ~500ms after a mode switch)