### PR TITLE
V3 text injection API for Editor testing without native bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VoskCommandRecogniser.InjectText(text, words)` — injects text into the full command pipeline (parser, threshold filter, buffer, debounce) as if it had arrived from VOSK.
 - `VoskCommandRecogniser.FlushPendingBuffer()` — immediately flushes any speech held in the utterance buffer. Useful for push-to-talk release, scene transitions, and synchronous test injection.
 - Play Mode tests covering injection, threshold filtering, debounce, buffered-path flushing, and end-to-end speech-to-command wiring.
+- Editor test matrix (`v3-test-matrix.md`) with 9 automated suites (145 tests) and 36 manual injection rows across 8 phases — 45/45 pass, no Quest device, native bridge, or model required. Verifies every v2.0–v2.5 feature category (literals, aliases, optional slots, NumberSequence, utterance buffer, sequential extraction, debounce, threshold filtering, command sets, asset authoring) is reachable via injection.
 
 ## [0.9.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-07
+
+### Added
+
+- `VoskSpeechRecogniser.InjectResult(text, words, alternatives)` — fires `OnFinalResult` and `OnResult` events as if VOSK had recognised the text. Bypasses native bridge state for Editor testing, replay, and CI.
+- `VoskSpeechRecogniser.InjectPartialResult(text)` — fires `OnPartialResult`.
+- `VoskSpeechRecogniser.CreateSimulatedWords(text, confidence)` — generates `VoskWord[]` with uniform confidence and sequential timing for threshold testing.
+- `VoskCommandRecogniser.InjectText(text, words)` — injects text into the full command pipeline (parser, threshold filter, buffer, debounce) as if it had arrived from VOSK.
+- `VoskCommandRecogniser.FlushPendingBuffer()` — immediately flushes any speech held in the utterance buffer. Useful for push-to-talk release, scene transitions, and synchronous test injection.
+- Play Mode tests covering injection, threshold filtering, debounce, buffered-path flushing, and end-to-end speech-to-command wiring.
+
 ## [0.9.0] - 2026-04-06
 
 ### Added

--- a/KNOWN_LIMITATIONS.md.meta
+++ b/KNOWN_LIMITATIONS.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9fdacc0fbf7711f49bde337c438da2c9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -181,6 +181,53 @@ namespace VoskXR.Commands
             SetActiveSets(setName);
         }
 
+        /// <summary>
+        /// Injects text directly into the command pipeline as if it had arrived from VOSK.
+        /// Goes through the full <see cref="HandleResult"/> path including the utterance
+        /// buffer, so injection tests exercise the same code path as real audio. Fires
+        /// <see cref="OnCommandRecognised"/>/<see cref="OnCommandsRecognised"/> or
+        /// <see cref="OnUnrecognisedSpeech"/>.
+        /// <para>If <c>bufferWindow &gt; 0</c> the result is queued and events fire later from
+        /// <see cref="Update"/>. Call <see cref="FlushPendingBuffer"/> immediately after
+        /// injection to force synchronous events.</para>
+        /// <para>Requires <see cref="Configure(VoskSlotDefinition[], VoskCommandDefinition[])"/>
+        /// or <see cref="Configure(VoskSlotDefinition[], VoskCommandSet[])"/> followed by
+        /// <see cref="SetActiveSets"/> to have been called first. Must be called from the
+        /// main thread.</para>
+        /// </summary>
+        public void InjectText(string text, VoskWord[] words = null)
+        {
+            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
+                "InjectText must be called from the Unity main thread.");
+
+            if (_parser == null)
+            {
+                Debug.LogWarning("[VoskCommandRecogniser] InjectText called before parser is ready. " +
+                    "Call Configure(slots, commands) or Configure(slots, sets) followed by SetActiveSets(...) first.");
+                return;
+            }
+
+            HandleResult(new VoskResult(
+                text,
+                words ?? Array.Empty<VoskWord>(),
+                Array.Empty<VoskAlternative>()));
+        }
+
+        /// <summary>
+        /// Immediately flushes any speech currently held in the utterance buffer, firing
+        /// command/unrecognised events synchronously on the calling thread. Useful for
+        /// push-to-talk release, scene transitions, and synchronous test injection.
+        /// No-op if no buffered speech is pending. Must be called from the main thread.
+        /// </summary>
+        public void FlushPendingBuffer()
+        {
+            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
+                "FlushPendingBuffer must be called from the Unity main thread.");
+
+            if (_bufferActive)
+                FlushBuffer();
+        }
+
         void RebuildParserAndGrammar(VoskCommandDefinition[] commands)
         {
             // Discard stale buffered speech from the previous grammar

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -182,23 +182,21 @@ namespace VoskXR.Commands
         }
 
         /// <summary>
-        /// Injects text directly into the command pipeline as if it had arrived from VOSK.
-        /// Goes through the full <see cref="HandleResult"/> path including the utterance
-        /// buffer, so injection tests exercise the same code path as real audio. Fires
-        /// <see cref="OnCommandRecognised"/>/<see cref="OnCommandsRecognised"/> or
-        /// <see cref="OnUnrecognisedSpeech"/>.
-        /// <para>If <c>bufferWindow &gt; 0</c> the result is queued and events fire later from
-        /// <see cref="Update"/>. Call <see cref="FlushPendingBuffer"/> immediately after
-        /// injection to force synchronous events.</para>
-        /// <para>Requires <see cref="Configure(VoskSlotDefinition[], VoskCommandDefinition[])"/>
-        /// or <see cref="Configure(VoskSlotDefinition[], VoskCommandSet[])"/> followed by
-        /// <see cref="SetActiveSets"/> to have been called first. Must be called from the
-        /// main thread.</para>
+        /// Injects text into the command pipeline as if it had arrived from VOSK, exercising
+        /// the same <see cref="HandleResult"/> path (parser, threshold filter, buffer, debounce)
+        /// as real audio.
+        /// When <c>bufferWindow &gt; 0</c> the result is queued and events fire later from
+        /// <see cref="Update"/>; call <see cref="FlushPendingBuffer"/> for synchronous events.
+        /// Requires one of the <c>Configure</c> overloads (and <see cref="SetActiveSets"/> when
+        /// using command sets) to have been called first. Main thread only.
         /// </summary>
         public void InjectText(string text, VoskWord[] words = null)
         {
             Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
                 "InjectText must be called from the Unity main thread.");
+
+            if (string.IsNullOrWhiteSpace(text))
+                return;
 
             if (_parser == null)
             {
@@ -214,10 +212,9 @@ namespace VoskXR.Commands
         }
 
         /// <summary>
-        /// Immediately flushes any speech currently held in the utterance buffer, firing
-        /// command/unrecognised events synchronously on the calling thread. Useful for
-        /// push-to-talk release, scene transitions, and synchronous test injection.
-        /// No-op if no buffered speech is pending. Must be called from the main thread.
+        /// Flushes any speech currently held in the utterance buffer, firing command events
+        /// synchronously. Useful for push-to-talk release and scene transitions. No-op when
+        /// the buffer is empty. Main thread only.
         /// </summary>
         public void FlushPendingBuffer()
         {
@@ -227,6 +224,11 @@ namespace VoskXR.Commands
             if (_bufferActive)
                 FlushBuffer();
         }
+
+        // Test-only setters. Production callers configure via the Inspector.
+        internal float BufferWindow { set => bufferWindow = value; }
+        internal float CommandCooldown { set => commandCooldown = value; }
+        internal VoskSpeechRecogniser SpeechRecogniser { set => speechRecogniser = value; }
 
         void RebuildParserAndGrammar(VoskCommandDefinition[] commands)
         {

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -236,54 +236,39 @@ namespace VoskXR
         }
 
         /// <summary>
-        /// Injects a final result as if VOSK had recognised it. Fires <see cref="OnFinalResult"/>
-        /// then <see cref="OnResult"/>, in the same order as the real audio path.
-        /// Use for Editor testing, replay, and CI without a microphone or native bridge.
-        /// <para>Mirrors real VOSK behaviour: empty or null <paramref name="text"/> is passed
-        /// through to subscribers — the real audio path does not short-circuit on empty either,
-        /// so subscribers should handle it. Filter upstream if your test scenario should not
-        /// fire those.</para>
-        /// <para>Bypasses <c>_bridgeAvailable</c>, <see cref="IsModelReady"/>, and
-        /// <see cref="IsRecognising"/>. Subscribers receive events even when no recognition
-        /// session is active — gate them yourself if they assume an active session.</para>
-        /// <para>Must be called from the main thread.</para>
+        /// Injects a final result as if VOSK had recognised it.
+        /// Bypasses bridge/model/session state, so events fire even when no recognition
+        /// session is active — gate downstream code that assumes an active session.
+        /// Empty or null text is passed through to match the real audio path. Must be
+        /// called from the main thread.
         /// </summary>
         public void InjectResult(string text, VoskWord[] words = null, VoskAlternative[] alternatives = null)
         {
-            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
-                "InjectResult must be called from the Unity main thread.");
-
-            OnFinalResult?.Invoke(text);
-
-            if (OnResult != null)
-            {
-                var result = new VoskResult(
-                    text,
-                    words ?? Array.Empty<VoskWord>(),
-                    alternatives ?? Array.Empty<VoskAlternative>());
-                OnResult.Invoke(result);
-            }
+            AssertMainThread(nameof(InjectResult));
+            DispatchFinalResult(
+                text,
+                words ?? Array.Empty<VoskWord>(),
+                alternatives ?? Array.Empty<VoskAlternative>());
         }
 
         /// <summary>
-        /// Injects a partial result as if VOSK had recognised it. Fires <see cref="OnPartialResult"/>.
-        /// Empty or null text is passed through to match the real audio path. Must be called
-        /// from the main thread.
+        /// Injects a partial result as if VOSK had recognised it. Empty or null text is
+        /// passed through to match the real audio path. Must be called from the main thread.
         /// </summary>
         public void InjectPartialResult(string text)
         {
-            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
-                "InjectPartialResult must be called from the Unity main thread.");
-
+            AssertMainThread(nameof(InjectPartialResult));
             OnPartialResult?.Invoke(text);
         }
 
+        // ~average English word duration; used to give simulated words a plausible non-zero span.
+        const float SimulatedWordDurationSeconds = 0.3f;
+
         /// <summary>
-        /// Creates a <see cref="VoskWord"/> array from a text string with uniform confidence
-        /// and sequential 0.3-second timing. Use for testing confidence thresholds without a
-        /// real microphone.
-        /// <para>Confidence is passed through unchanged; values outside [0, 1] are valid but
-        /// may behave unexpectedly with downstream <c>minConfidence</c> filters.</para>
+        /// Synthesises a <see cref="VoskWord"/> array from a text string with uniform
+        /// confidence and sequential timing.
+        /// Confidence is passed through unchanged — values outside [0, 1] are valid but
+        /// may interact unexpectedly with downstream <c>minConfidence</c> filters.
         /// </summary>
         public static VoskWord[] CreateSimulatedWords(string text, float confidence = 1.0f)
         {
@@ -292,8 +277,26 @@ namespace VoskXR
             var tokens = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var words = new VoskWord[tokens.Length];
             for (int i = 0; i < tokens.Length; i++)
-                words[i] = new VoskWord(tokens[i], confidence, i * 0.3f, (i + 1) * 0.3f);
+                words[i] = new VoskWord(
+                    tokens[i],
+                    confidence,
+                    i * SimulatedWordDurationSeconds,
+                    (i + 1) * SimulatedWordDurationSeconds);
             return words;
+        }
+
+        void DispatchFinalResult(string text, VoskWord[] words, VoskAlternative[] alternatives)
+        {
+            OnFinalResult?.Invoke(text);
+
+            if (OnResult != null)
+                OnResult.Invoke(new VoskResult(text, words, alternatives));
+        }
+
+        static void AssertMainThread(string method)
+        {
+            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
+                $"{method} must be called from the Unity main thread.");
         }
 
         void Update()
@@ -326,18 +329,19 @@ namespace VoskXR
 
                     if (isFinal)
                     {
-                        OnFinalResult?.Invoke(text);
+                        VoskAlternative[] alternatives = Array.Empty<VoskAlternative>();
+                        VoskWord[] words = Array.Empty<VoskWord>();
 
                         if (OnResult != null)
                         {
-                            var alternatives = ParseAlternativesFromJson(json);
-                            VoskWord[] words;
+                            alternatives = ParseAlternativesFromJson(json);
                             if (alternatives.Length > 0 && alternatives[0].Words.Length > 0)
                                 words = alternatives[0].Words;
                             else
                                 words = ParseWordsFromJson(json);
-                            OnResult.Invoke(new VoskResult(text, words, alternatives));
                         }
+
+                        DispatchFinalResult(text, words, alternatives);
                     }
                     else
                     {

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -235,6 +235,67 @@ namespace VoskXR
             }
         }
 
+        /// <summary>
+        /// Injects a final result as if VOSK had recognised it. Fires <see cref="OnFinalResult"/>
+        /// then <see cref="OnResult"/>, in the same order as the real audio path.
+        /// Use for Editor testing, replay, and CI without a microphone or native bridge.
+        /// <para>Mirrors real VOSK behaviour: empty or null <paramref name="text"/> is passed
+        /// through to subscribers — the real audio path does not short-circuit on empty either,
+        /// so subscribers should handle it. Filter upstream if your test scenario should not
+        /// fire those.</para>
+        /// <para>Bypasses <c>_bridgeAvailable</c>, <see cref="IsModelReady"/>, and
+        /// <see cref="IsRecognising"/>. Subscribers receive events even when no recognition
+        /// session is active — gate them yourself if they assume an active session.</para>
+        /// <para>Must be called from the main thread.</para>
+        /// </summary>
+        public void InjectResult(string text, VoskWord[] words = null, VoskAlternative[] alternatives = null)
+        {
+            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
+                "InjectResult must be called from the Unity main thread.");
+
+            OnFinalResult?.Invoke(text);
+
+            if (OnResult != null)
+            {
+                var result = new VoskResult(
+                    text,
+                    words ?? Array.Empty<VoskWord>(),
+                    alternatives ?? Array.Empty<VoskAlternative>());
+                OnResult.Invoke(result);
+            }
+        }
+
+        /// <summary>
+        /// Injects a partial result as if VOSK had recognised it. Fires <see cref="OnPartialResult"/>.
+        /// Empty or null text is passed through to match the real audio path. Must be called
+        /// from the main thread.
+        /// </summary>
+        public void InjectPartialResult(string text)
+        {
+            Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
+                "InjectPartialResult must be called from the Unity main thread.");
+
+            OnPartialResult?.Invoke(text);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="VoskWord"/> array from a text string with uniform confidence
+        /// and sequential 0.3-second timing. Use for testing confidence thresholds without a
+        /// real microphone.
+        /// <para>Confidence is passed through unchanged; values outside [0, 1] are valid but
+        /// may behave unexpectedly with downstream <c>minConfidence</c> filters.</para>
+        /// </summary>
+        public static VoskWord[] CreateSimulatedWords(string text, float confidence = 1.0f)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return Array.Empty<VoskWord>();
+
+            var tokens = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var words = new VoskWord[tokens.Length];
+            for (int i = 0; i < tokens.Length; i++)
+                words[i] = new VoskWord(tokens[i], confidence, i * 0.3f, (i + 1) * 0.3f);
+            return words;
+        }
+
         void Update()
         {
             if (!_bridgeAvailable || !_isRecognising)

--- a/Samples~/CommandRecognition/README.md
+++ b/Samples~/CommandRecognition/README.md
@@ -1,0 +1,76 @@
+# Command Recognition Sample
+
+Voice-driven command parsing with slots, command sets, and runtime mode
+switching. Demonstrates the `VoskCommandRecogniser` pipeline on top of
+`VoskSpeechRecogniser`.
+
+## Setup
+
+1. **Import the sample** via Package Manager > VOSK XR Speech Recognition > Samples > Command Recognition > Import.
+
+2. **Download a VOSK model:**
+   - Get [vosk-model-small-en-us-0.15](https://alphacephei.com/vosk/models) (~50 MB).
+   - Place the `.zip` in `Assets/StreamingAssets/vosk-model-small-en-us-0.15.zip`.
+
+3. **Create the scene:**
+   - Create a new scene or open your own.
+   - Add an empty GameObject and attach `VoskSpeechRecogniser`.
+   - Add a second GameObject and attach `VoskCommandRecogniser`. Wire its
+     `speechRecogniser` field to the first GameObject.
+   - Add the `CommandDemo` script to any GameObject and wire `recogniser`
+     and `commandRecogniser` in the Inspector.
+
+4. **Build and deploy:**
+   - Switch platform to Android (arm64).
+   - Ensure `RECORD_AUDIO` permission is enabled in Player Settings.
+   - Build and run on a Meta Quest headset.
+
+5. **Speak a command** — try `"fire two missiles at hotel one"`,
+   `"cease fire"`, or `"switch to navigation"`. Recognised commands are
+   logged to the Android logcat under the `CommandDemo` tag.
+
+## What the sample covers
+
+- **Slots**: targets, weapons, quantity, named ranges, plus digit-sequence
+  slots for heading/elevation.
+- **Command sets**: `weapons`, `navigation`, and `common`, each with
+  multiple phrasings per intent.
+- **Runtime mode switching**: the `weapons mode`, `navigation mode`,
+  `all modes`, and `disable all` commands call `SetActiveSets(...)` to
+  swap the active grammar live.
+- **Inspector authoring** (v2.5, optional): toggle `Use Inspector
+  Authoring` on `CommandDemo` and wire the ScriptableObjects under
+  `AssetAuthoring/` to drive `Configure()` from assets instead of code.
+  See `AssetAuthoring/README.md` for details.
+
+## Iterating in the Editor without deploying
+
+The native bridge only runs on-device, so the sample won't parse live
+audio in the Editor. To iterate on your command definitions without a
+Quest build cycle, use the **text injection API** added in v0.10.0:
+
+- `VoskCommandRecogniser.InjectText(text, words)` — pushes a string
+  through the same parser → threshold → buffer → debounce path as real
+  audio, firing `OnCommandRecognised` / `OnCommandsRecognised` /
+  `OnUnrecognisedSpeech` exactly as VOSK would.
+- `VoskCommandRecogniser.FlushPendingBuffer()` — forces any buffered
+  text to parse immediately instead of waiting for `bufferWindow`.
+- `VoskSpeechRecogniser.InjectResult(text, words, alternatives)` and
+  `InjectPartialResult(text)` — fire raw recogniser events directly,
+  bypassing the command pipeline.
+- `VoskSpeechRecogniser.CreateSimulatedWords(text, confidence)` —
+  synthesises a `VoskWord[]` with uniform confidence when you want to
+  exercise the confidence-threshold filter.
+
+All injection methods are main-thread only. See
+`Tests/Runtime/VoskCommandRecogniserInjectionTests.cs` and
+`VoskSpeechRecogniserInjectionTests.cs` in the package for executable
+usage examples.
+
+## Notes
+
+- The model extracts on first launch (a few seconds). Subsequent launches
+  use the cached model.
+- `CommandDemo` activates all three command sets on start. In a real
+  game you would call `SetActiveSets(...)` per game state to scope the
+  active grammar to what the player can currently do.

--- a/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs
+++ b/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskCommandRecogniserInjectionTests
+    {
+        GameObject _go;
+        VoskCommandRecogniser _recogniser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("TestCommandRecogniser");
+            _recogniser = _go.AddComponent<VoskCommandRecogniser>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                UnityEngine.Object.DestroyImmediate(_go);
+        }
+
+        // -------- Fixtures --------
+
+        static VoskSlotDefinition[] MakeSlots()
+        {
+            return new[]
+            {
+                new VoskSlotDefinition("target",
+                    new[] { "hotel one", "hotel two", "alpha one" }),
+                new VoskSlotDefinition("weapon",
+                    new[] { "missiles", "torpedoes" }),
+                new VoskSlotDefinition("quantity",
+                    new[] { "all", "one", "two" }),
+            };
+        }
+
+        static VoskCommandDefinition[] MakeCommands()
+        {
+            return new[]
+            {
+                new VoskCommandDefinition("launch_weapon", new[]
+                {
+                    new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
+                }),
+                new VoskCommandDefinition("cease_fire", new[]
+                {
+                    new[] { "cease", "fire" },
+                }),
+            };
+        }
+
+        void ConfigureWithSyncDefaults()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            // Disable buffer and cooldown so threshold tests can assert events synchronously.
+            SetPrivateField(_recogniser, "bufferWindow", 0f);
+            SetPrivateField(_recogniser, "commandCooldown", 0f);
+        }
+
+        static void SetPrivateField<T>(T target, string field, object value) where T : class
+        {
+            var fi = typeof(T).GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (fi == null)
+                throw new ArgumentException($"Field '{field}' not found on {typeof(T).Name}");
+            fi.SetValue(target, value);
+        }
+
+        // -------- Warning / no-op cases --------
+
+        [Test]
+        public void InjectText_BeforeConfigure_LogsWarningAndDoesNotThrow()
+        {
+            LogAssert.Expect(LogType.Warning, new Regex("InjectText called before parser is ready"));
+
+            Assert.DoesNotThrow(() => _recogniser.InjectText("anything"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void InjectText_NullOrWhitespace_NoOps(string text)
+        {
+            ConfigureWithSyncDefaults();
+            int recognisedCount = 0;
+            int unrecognisedCount = 0;
+            _recogniser.OnCommandRecognised += _ => recognisedCount++;
+            _recogniser.OnUnrecognisedSpeech += _ => unrecognisedCount++;
+
+            _recogniser.InjectText(text);
+
+            Assert.AreEqual(0, recognisedCount);
+            Assert.AreEqual(0, unrecognisedCount);
+        }
+
+        // -------- Match / no-match --------
+
+        [Test]
+        public void InjectText_MatchingCommand_FiresBothEvents()
+        {
+            ConfigureWithSyncDefaults();
+            VoskCommand? singleEvent = null;
+            VoskCommand[] batchEvent = null;
+            _recogniser.OnCommandRecognised += cmd => singleEvent = cmd;
+            _recogniser.OnCommandsRecognised += cmds => batchEvent = cmds;
+
+            _recogniser.InjectText("launch all missiles target hotel one");
+
+            Assert.IsTrue(singleEvent.HasValue, "OnCommandRecognised did not fire");
+            Assert.AreEqual("launch_weapon", singleEvent.Value.Intent);
+            Assert.AreEqual("missiles", singleEvent.Value.GetSlot("weapon"));
+            Assert.AreEqual("hotel one", singleEvent.Value.GetSlot("target"));
+            Assert.AreEqual("all", singleEvent.Value.GetSlot("quantity"));
+
+            Assert.IsNotNull(batchEvent, "OnCommandsRecognised did not fire");
+            Assert.AreEqual(1, batchEvent.Length);
+        }
+
+        [Test]
+        public void InjectText_NoMatch_FiresOnUnrecognisedSpeech()
+        {
+            ConfigureWithSyncDefaults();
+            string received = null;
+            _recogniser.OnUnrecognisedSpeech += text => received = text;
+
+            _recogniser.InjectText("hello world");
+
+            Assert.AreEqual("hello world", received);
+        }
+
+        // -------- Word data propagation --------
+
+        [Test]
+        public void InjectText_PassesWordsThroughToParser_ConfidencePropagated()
+        {
+            ConfigureWithSyncDefaults();
+            VoskCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => received = cmd;
+
+            var words = VoskSpeechRecogniser.CreateSimulatedWords("cease fire", 0.85f);
+            _recogniser.InjectText("cease fire", words);
+
+            Assert.IsTrue(received.HasValue);
+            Assert.AreEqual(0.85f, received.Value.Confidence, 1e-5f,
+                "Confidence from injected words did not propagate to VoskCommand");
+        }
+
+        // -------- Threshold filtering --------
+
+        [Test]
+        public void InjectText_BelowMinConfidence_Rejected()
+        {
+            ConfigureWithSyncDefaults();
+            // minConfidence default is 0.4
+            int recognised = 0;
+            int unrecognised = 0;
+            _recogniser.OnCommandRecognised += _ => recognised++;
+            _recogniser.OnUnrecognisedSpeech += _ => unrecognised++;
+
+            var words = VoskSpeechRecogniser.CreateSimulatedWords("cease fire", 0.2f);
+            _recogniser.InjectText("cease fire", words);
+
+            Assert.AreEqual(0, recognised, "Command should be rejected by minConfidence");
+            // Match but below threshold is silently filtered (not unrecognised).
+            Assert.AreEqual(0, unrecognised);
+        }
+
+        [Test]
+        public void InjectText_AtOrAboveMinConfidence_Accepted()
+        {
+            ConfigureWithSyncDefaults();
+            int recognised = 0;
+            _recogniser.OnCommandRecognised += _ => recognised++;
+
+            var words = VoskSpeechRecogniser.CreateSimulatedWords("cease fire", 0.5f);
+            _recogniser.InjectText("cease fire", words);
+
+            Assert.AreEqual(1, recognised);
+        }
+
+        // -------- Cooldown --------
+
+        [Test]
+        public void InjectText_RespectsCommandCooldown()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            SetPrivateField(_recogniser, "bufferWindow", 0f);
+            SetPrivateField(_recogniser, "commandCooldown", 1.0f);
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            _recogniser.InjectText("cease fire");
+            _recogniser.InjectText("cease fire");
+
+            // Tests run in a single frame so Time.time does not advance — second call is within cooldown.
+            Assert.AreEqual(1, fireCount, "Second injection within cooldown should be rejected");
+        }
+
+        // -------- Buffered path + flush --------
+
+        [Test]
+        public void InjectText_BufferedPath_QueuedUntilFlush()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            SetPrivateField(_recogniser, "bufferWindow", 1.5f);
+            SetPrivateField(_recogniser, "commandCooldown", 0f);
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            _recogniser.InjectText("cease fire");
+            Assert.AreEqual(0, fireCount, "Buffered injection must not fire immediately");
+
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, fireCount, "Flush must release the buffered command");
+        }
+
+        [Test]
+        public void FlushPendingBuffer_NoBufferedSpeech_NoOps()
+        {
+            ConfigureWithSyncDefaults();
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+            _recogniser.OnUnrecognisedSpeech += _ => fireCount++;
+
+            Assert.DoesNotThrow(() => _recogniser.FlushPendingBuffer());
+            Assert.AreEqual(0, fireCount);
+        }
+
+        [Test]
+        public void InjectText_AfterFlush_DoesNotDoubleFire()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            SetPrivateField(_recogniser, "bufferWindow", 1.5f);
+            SetPrivateField(_recogniser, "commandCooldown", 0f);
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            _recogniser.InjectText("cease fire");
+            _recogniser.FlushPendingBuffer();
+            _recogniser.FlushPendingBuffer(); // second flush is a no-op
+
+            Assert.AreEqual(1, fireCount);
+        }
+
+        // -------- Cross-component end-to-end --------
+
+        [Test]
+        public void InjectResult_OnSpeechRecogniser_PropagatesToCommandRecogniser()
+        {
+            // Build both components on the same GameObject and wire them together,
+            // proving the production OnEnable subscription path actually connects.
+            // If OnResult is ever renamed or unsubscribed, the isolated tests still
+            // pass but this one fails.
+            var speech = _go.AddComponent<VoskSpeechRecogniser>();
+            SetPrivateField(_recogniser, "speechRecogniser", speech);
+
+            // Force OnEnable to re-run with the now-set speechRecogniser reference.
+            _recogniser.enabled = false;
+            _recogniser.enabled = true;
+
+            ConfigureWithSyncDefaults();
+
+            VoskCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => received = cmd;
+
+            speech.InjectResult("cease fire");
+
+            Assert.IsTrue(received.HasValue,
+                "Speech-layer InjectResult did not propagate to command recogniser");
+            Assert.AreEqual("cease_fire", received.Value.Intent);
+        }
+    }
+}

--- a/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs
+++ b/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
@@ -63,16 +60,8 @@ namespace VoskXR.Tests.Runtime
         {
             _recogniser.Configure(MakeSlots(), MakeCommands());
             // Disable buffer and cooldown so threshold tests can assert events synchronously.
-            SetPrivateField(_recogniser, "bufferWindow", 0f);
-            SetPrivateField(_recogniser, "commandCooldown", 0f);
-        }
-
-        static void SetPrivateField<T>(T target, string field, object value) where T : class
-        {
-            var fi = typeof(T).GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
-            if (fi == null)
-                throw new ArgumentException($"Field '{field}' not found on {typeof(T).Name}");
-            fi.SetValue(target, value);
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
         }
 
         // -------- Warning / no-op cases --------
@@ -160,7 +149,6 @@ namespace VoskXR.Tests.Runtime
         public void InjectText_BelowMinConfidence_Rejected()
         {
             ConfigureWithSyncDefaults();
-            // minConfidence default is 0.4
             int recognised = 0;
             int unrecognised = 0;
             _recogniser.OnCommandRecognised += _ => recognised++;
@@ -193,8 +181,8 @@ namespace VoskXR.Tests.Runtime
         public void InjectText_RespectsCommandCooldown()
         {
             _recogniser.Configure(MakeSlots(), MakeCommands());
-            SetPrivateField(_recogniser, "bufferWindow", 0f);
-            SetPrivateField(_recogniser, "commandCooldown", 1.0f);
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 1.0f;
 
             int fireCount = 0;
             _recogniser.OnCommandRecognised += _ => fireCount++;
@@ -212,8 +200,8 @@ namespace VoskXR.Tests.Runtime
         public void InjectText_BufferedPath_QueuedUntilFlush()
         {
             _recogniser.Configure(MakeSlots(), MakeCommands());
-            SetPrivateField(_recogniser, "bufferWindow", 1.5f);
-            SetPrivateField(_recogniser, "commandCooldown", 0f);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
 
             int fireCount = 0;
             _recogniser.OnCommandRecognised += _ => fireCount++;
@@ -241,8 +229,8 @@ namespace VoskXR.Tests.Runtime
         public void InjectText_AfterFlush_DoesNotDoubleFire()
         {
             _recogniser.Configure(MakeSlots(), MakeCommands());
-            SetPrivateField(_recogniser, "bufferWindow", 1.5f);
-            SetPrivateField(_recogniser, "commandCooldown", 0f);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
 
             int fireCount = 0;
             _recogniser.OnCommandRecognised += _ => fireCount++;
@@ -264,7 +252,7 @@ namespace VoskXR.Tests.Runtime
             // If OnResult is ever renamed or unsubscribed, the isolated tests still
             // pass but this one fails.
             var speech = _go.AddComponent<VoskSpeechRecogniser>();
-            SetPrivateField(_recogniser, "speechRecogniser", speech);
+            _recogniser.SpeechRecogniser = speech;
 
             // Force OnEnable to re-run with the now-set speechRecogniser reference.
             _recogniser.enabled = false;

--- a/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs.meta
+++ b/Tests/Runtime/VoskCommandRecogniserInjectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1108a5134bf08be429e8580ab42cdd6c

--- a/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs
+++ b/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using VoskXR;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskSpeechRecogniserInjectionTests
+    {
+        GameObject _go;
+        VoskSpeechRecogniser _recogniser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("TestRecogniser");
+            _recogniser = _go.AddComponent<VoskSpeechRecogniser>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                Object.DestroyImmediate(_go);
+        }
+
+        [Test]
+        public void InjectResult_FiresOnFinalResult()
+        {
+            string received = null;
+            _recogniser.OnFinalResult += text => received = text;
+
+            _recogniser.InjectResult("hello world");
+
+            Assert.AreEqual("hello world", received);
+        }
+
+        [Test]
+        public void InjectResult_FiresOnResult_WithProvidedWords()
+        {
+            VoskResult? received = null;
+            _recogniser.OnResult += r => received = r;
+
+            var words = new[]
+            {
+                new VoskWord("hello", 0.9f, 0f, 0.3f),
+                new VoskWord("world", 0.8f, 0.3f, 0.6f),
+            };
+            _recogniser.InjectResult("hello world", words);
+
+            Assert.IsTrue(received.HasValue);
+            Assert.AreEqual("hello world", received.Value.Text);
+            Assert.AreEqual(2, received.Value.Words.Length);
+            Assert.AreEqual("hello", received.Value.Words[0].Text);
+            Assert.AreEqual(0.9f, received.Value.Words[0].Confidence);
+            Assert.AreEqual("world", received.Value.Words[1].Text);
+        }
+
+        [Test]
+        public void InjectResult_FiresOnResult_WithNullWords_DefaultsToEmpty()
+        {
+            VoskResult? received = null;
+            _recogniser.OnResult += r => received = r;
+
+            _recogniser.InjectResult("hello", words: null, alternatives: null);
+
+            Assert.IsTrue(received.HasValue);
+            Assert.IsNotNull(received.Value.Words);
+            Assert.AreEqual(0, received.Value.Words.Length);
+            Assert.IsNotNull(received.Value.Alternatives);
+            Assert.AreEqual(0, received.Value.Alternatives.Length);
+        }
+
+        [Test]
+        public void InjectResult_FiresOnResult_WithProvidedAlternatives()
+        {
+            VoskResult? received = null;
+            _recogniser.OnResult += r => received = r;
+
+            var alternatives = new[]
+            {
+                new VoskAlternative("hello world", 12.5f, System.Array.Empty<VoskWord>()),
+                new VoskAlternative("yellow whirled", 9.1f, System.Array.Empty<VoskWord>()),
+            };
+            _recogniser.InjectResult("hello world", null, alternatives);
+
+            Assert.IsTrue(received.HasValue);
+            Assert.AreEqual(2, received.Value.Alternatives.Length);
+            Assert.AreEqual("hello world", received.Value.Alternatives[0].Text);
+            Assert.AreEqual("yellow whirled", received.Value.Alternatives[1].Text);
+        }
+
+        [Test]
+        public void InjectResult_EmptyText_StillFiresEvents()
+        {
+            // Mirrors real VOSK Update() at VoskSpeechRecogniser.cs:264-280, which does
+            // not short-circuit on empty text. Subscribers must handle empty themselves.
+            int finalCount = 0;
+            int resultCount = 0;
+            _recogniser.OnFinalResult += _ => finalCount++;
+            _recogniser.OnResult += _ => resultCount++;
+
+            _recogniser.InjectResult("");
+
+            Assert.AreEqual(1, finalCount);
+            Assert.AreEqual(1, resultCount);
+        }
+
+        [Test]
+        public void InjectResult_EventOrder_FinalResultBeforeResult()
+        {
+            var order = new List<string>();
+            _recogniser.OnFinalResult += _ => order.Add("final");
+            _recogniser.OnResult += _ => order.Add("result");
+
+            _recogniser.InjectResult("hello");
+
+            Assert.AreEqual(2, order.Count);
+            Assert.AreEqual("final", order[0]);
+            Assert.AreEqual("result", order[1]);
+        }
+
+        [Test]
+        public void InjectPartialResult_FiresOnPartialResult()
+        {
+            string received = null;
+            _recogniser.OnPartialResult += text => received = text;
+
+            _recogniser.InjectPartialResult("hel");
+
+            Assert.AreEqual("hel", received);
+        }
+
+        [Test]
+        public void InjectPartialResult_EmptyText_StillFires()
+        {
+            int count = 0;
+            _recogniser.OnPartialResult += _ => count++;
+
+            _recogniser.InjectPartialResult("");
+
+            Assert.AreEqual(1, count);
+        }
+
+        [TestCase("hello", 1, 1.0f)]
+        [TestCase("hello world", 2, 0.5f)]
+        [TestCase("launch all missiles target hotel one", 6, 0.75f)]
+        public void CreateSimulatedWords_TokenCountAndConfidence(string text, int expectedCount, float confidence)
+        {
+            var words = VoskSpeechRecogniser.CreateSimulatedWords(text, confidence);
+
+            Assert.AreEqual(expectedCount, words.Length);
+            for (int i = 0; i < words.Length; i++)
+                Assert.AreEqual(confidence, words[i].Confidence,
+                    $"Word {i} ({words[i].Text}) confidence mismatch");
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("   ")]
+        [TestCase("\t\n")]
+        public void CreateSimulatedWords_EmptyOrWhitespace_ReturnsEmpty(string text)
+        {
+            var words = VoskSpeechRecogniser.CreateSimulatedWords(text);
+
+            Assert.IsNotNull(words);
+            Assert.AreEqual(0, words.Length);
+        }
+
+        [Test]
+        public void CreateSimulatedWords_TimingIsSequential()
+        {
+            var words = VoskSpeechRecogniser.CreateSimulatedWords("one two three");
+
+            Assert.AreEqual(3, words.Length);
+            for (int i = 0; i < words.Length - 1; i++)
+                Assert.AreEqual(words[i].EndTime, words[i + 1].StartTime, 1e-6f,
+                    $"Gap between word {i} and {i + 1}");
+        }
+    }
+}

--- a/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs
+++ b/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs
@@ -93,8 +93,7 @@ namespace VoskXR.Tests.Runtime
         [Test]
         public void InjectResult_EmptyText_StillFiresEvents()
         {
-            // Mirrors real VOSK Update() at VoskSpeechRecogniser.cs:264-280, which does
-            // not short-circuit on empty text. Subscribers must handle empty themselves.
+            // The real audio path does not short-circuit on empty text, so neither does Inject.
             int finalCount = 0;
             int resultCount = 0;
             _recogniser.OnFinalResult += _ => finalCount++;

--- a/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs.meta
+++ b/Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 824eaf2b5b3049645b5774a0bc87fb7e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AAudio on Android arm64.",
   "unity": "6000.0",

--- a/v3-test-matrix.md
+++ b/v3-test-matrix.md
@@ -1,0 +1,298 @@
+# v3 Phase 1 — Text Injection (Editor-Only) Test Matrix
+
+v3 Phase 1 (shipped as 0.10.0) adds a text injection API so command
+iteration no longer requires a Quest deploy/logcat cycle. The whole
+point of this version is **no device** — every test below runs in the
+Unity Editor with no native bridge, no microphone, and no Android build.
+
+The matrix has two halves:
+
+1. **Phases 0–1: API surface verification.** Bulk of this is covered by
+   Play Mode tests under `Tests/Runtime/`. Phase 0 just runs them; Phase 1
+   spot-checks anything not exercised by an automated test.
+2. **Phases 2–7: Workflow verification.** A developer adds a small driver
+   to a scene, hits Play, and confirms each v2.0–v2.5 feature can be
+   iterated on without ever putting the headset on. This is what the
+   version is actually for.
+
+## Prerequisites
+
+1. **Consuming project**: `D:\Game Development\voxsdk` (per
+   `reference_unity_test_project.md`) — the package is referenced via
+   `file:` and `manifest.json` already has
+   `"testables": ["com.jinwoo1601.vosk-xr"]`.
+2. **No device required.** Quest does not need to be connected. Native
+   bridge does not need to be built. The package can even run on a
+   machine that has never seen `libvosk-bridge`.
+3. **Unity 6000.3.7f1** (matches the Android toolchain pinned in
+   `CLAUDE.md`, but the Editor pieces work on any 2021+ Unity).
+
+## Driver Snippet (used by Phases 2–7)
+
+The CommandDemo sample doesn't expose injection in the Inspector, so
+manual phases use this small driver. Drop it into the consuming
+project's `Assets/` folder, attach to the same GameObject as
+`VoskCommandRecogniser`, and use the right-click context menu items to
+fire each test phrase:
+
+```csharp
+using UnityEngine;
+using VoskXR;
+using VoskXR.Commands;
+
+public class V3InjectionDriver : MonoBehaviour
+{
+    [SerializeField] VoskCommandRecogniser commandRecogniser;
+    [SerializeField] VoskSpeechRecogniser speechRecogniser;
+    [SerializeField, TextArea] string text = "launch all missiles target hotel one";
+    [SerializeField, Range(0f, 1f)] float wordConfidence = 1.0f;
+
+    [ContextMenu("Inject Text (command layer)")]
+    void InjectText()
+    {
+        var words = VoskSpeechRecogniser.CreateSimulatedWords(text, wordConfidence);
+        commandRecogniser.InjectText(text, words);
+    }
+
+    [ContextMenu("Inject Result (speech layer)")]
+    void InjectResult()
+    {
+        var words = VoskSpeechRecogniser.CreateSimulatedWords(text, wordConfidence);
+        speechRecogniser.InjectResult(text, words);
+    }
+
+    [ContextMenu("Flush Pending Buffer")]
+    void Flush() => commandRecogniser.FlushPendingBuffer();
+}
+```
+
+For Phases 2–7, edit the `text` field in the Inspector, then right-click
+the component header → **Inject Text (command layer)**. Watch the
+Console for the same log lines `CommandDemo` already prints
+(`[CommandDemo] Command: ...`, `Batch: ...`, `Unrecognised: ...`).
+
+The driver does **not** need recognition to be running, the model to be
+loaded, or the bridge to be available. That is the v3 promise; verifying
+it is part of Phase 0.
+
+### Scene wiring — required fields
+
+`VoskCommandRecogniser` has its own `Speech Recogniser` SerializeField
+(separate from the one on the driver and `CommandDemo`). **This field
+must be wired** — its `OnEnable()` bails out silently when it is null,
+which skips the `speechRecogniser.OnResult += HandleResult` subscription.
+If you miss this, `Inject Text (command layer)` still works (it calls
+`HandleResult` directly), but `Inject Result (speech layer)` fires into
+the void and every Phase 1 row 1.2 / Phase 6 row looks broken.
+
+Minimum wiring checklist before starting Phase 1:
+- `V3InjectionDriver`: `commandRecogniser` and `speechRecogniser` both set
+- `VoskCommandRecogniser`: `Speech Recogniser` set to the same component
+- `CommandDemo`: `Recogniser` (speech) and `Command Recogniser` both set
+- All four components on the same GameObject
+
+---
+
+## Phase 0: Test Runner — Automated Coverage
+
+Open **Window → General → Test Runner** in the consuming project. Both
+suites should appear. Run all and confirm zero failures.
+
+| #   | Suite                                              | Mode      | Tests | Result |
+|-----|----------------------------------------------------|-----------|-------|--------|
+| 0.1 | `VoskSpeechRecogniserInjectionTests`               | Play Mode | 16    | PASS   |
+| 0.2 | `VoskCommandRecogniserInjectionTests`              | Play Mode | 14    | PASS   |
+| 0.3 | `VoskCommandParserTests` (regression — must still pass) | Play Mode | 60    | PASS   |
+| 0.4 | `VoskAssetConversionTests` (regression — must still pass) | Play Mode | 15 | PASS   |
+| 0.5 | `VoskCommandSetTests` (regression — must still pass)| Play Mode | 5     | PASS   |
+| 0.6 | `ParseWordsFromJsonTests` (7) + `ParseAlternativesFromJsonTests` (6) | Play Mode | 13 | PASS |
+| 0.7 | `VoskSpeechRecogniserLifecycleTests`               | Play Mode | 6     | PASS   |
+| 0.8 | `VoskNumberParserTests` (regression — must still pass) | Play Mode | 16 | PASS   |
+| 0.9 | `ModelExtractorValidationTests` (5) + `VoskBridgeErrorCodeTests` (10) | Edit Mode | 15 | PASS |
+
+The counts under `0.1` and `0.2` include `[TestCase]` parameterised rows
+(`CreateSimulatedWords_TokenCountAndConfidence`,
+`CreateSimulatedWords_EmptyOrWhitespace_ReturnsEmpty`,
+`InjectText_NullOrWhitespace_NoOps`). If Test Runner shows different
+totals, investigate before continuing — counts drifting upward is usually
+fine (new tests added), counts drifting downward means something was
+removed and should be explained.
+
+---
+
+## Phase 1: API Surface Spot-Checks (Editor)
+
+Things the unit tests don't (and probably shouldn't) cover. All run in
+Editor Play Mode using the driver script.
+
+| #   | Setup                                                                 | Action                                                           | Expected                                                                                       | Result |
+|-----|-----------------------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------------------------------------|--------|
+| 1.1 | Scene with `VoskSpeechRecogniser` + `VoskCommandRecogniser`, neither initialised, no native plugin present. Verify the "Scene wiring" checklist above is complete. | Press Play, run driver `Inject Text` with `"cease fire"` (after Configure) | No `DllNotFoundException`, no native bridge calls, command event fires                         | PASS   |
+| 1.2 | Same scene, `VoskSpeechRecogniser.IsModelReady == false`              | Driver `Inject Result` with `"hello world"`                      | `OnFinalResult` and `OnResult` both fire even though no model is loaded. `Unrecognised: "hello world"` appears in Console after the buffer window elapses. | PASS |
+| 1.3 | Driver script with default `wordConfidence = 1.0`                     | `Inject Text` `"cease fire"`                                     | Console shows `[CommandDemo] Command: cease_fire (confidence=1.00, ...)` — *already covered by 1.1 output, no re-test needed* | PASS (by 1.1) |
+| 1.4 | Driver script with `wordConfidence = 0.2` (below default `minConfidence=0.4`) | `Inject Text` `"cease fire"`                             | No command event fires; no `Unrecognised` event either (silently filtered)                     | PASS   |
+| 1.5 | Same as 1.4 but `wordConfidence = 0.4`                                | `Inject Text` `"cease fire"`                                     | Command event fires (boundary inclusive — code uses `<`, not `<=`)                             | PASS   |
+| 1.6 | `VoskCommandRecogniser` with no `Configure()` call (disable `CommandDemo` component; assets unset) | `Inject Text` `"cease fire"`                         | `LogWarning: "InjectText called before parser is ready..."`, no exception, no event            | PASS   |
+
+---
+
+## Phase 2: Command-Layer Injection — Slot Conversion (Code Path)
+
+Re-runs the core slot-extraction phrases from
+`v2.5-test-matrix.md` Phases 1–3 via injection. Use `CommandDemo` with
+`useInspectorAuthoring = false` so the code-based `Configure()` runs.
+For each row, set `text` on the driver and trigger
+`Inject Text (command layer)`.
+
+| #   | Inject text                                       | Expected Intent    | Expected Slots                                       | Why                                                | Result |
+|-----|---------------------------------------------------|--------------------|------------------------------------------------------|----------------------------------------------------|--------|
+| 2.1 | `cease fire`                                      | cease_fire         | (none)                                               | Baseline literal command                           | PASS (score=1.00) |
+| 2.2 | `launch missiles target hotel one`                | launch_weapon      | weapon=missiles, target=hotel one                    | `{?quantity}` optional slot omitted                | PASS (score=0.80 — optional slot absent) |
+| 2.3 | `launch all missiles target hotel one`            | launch_weapon      | quantity=all, weapon=missiles, target=hotel one      | `{?quantity}` optional slot present                | PASS (score=1.00) |
+| 2.4 | `fire torpedoes at bravo two`                     | launch_weapon      | weapon=torpedoes, target=bravo two                   | Alternate pattern, multi-word target               | PASS (score=0.80 — optional slot absent) |
+| 2.5 | `shoot jackals`                                   | launch_weapon      | weapon=jackal (alias resolved)                       | Alias `jackals` → `jackal`                         | PASS (score=1.00) |
+| 2.6 | `fire a torpedoes at alpha three`                 | launch_weapon      | quantity=one (alias), weapon=torpedoes, target=alpha three | Quantity alias `a` → `one`                   | PASS (score=1.00) |
+| 2.7 | `close distance torpedo range target hotel two`   | set_distance_named | range=torpedo range, target=hotel two                | Multi-word enumerated value                        | PASS (score=1.00) |
+
+---
+
+## Phase 3: NumberSequence Slots via Injection
+
+Mirrors `v2.5-test-matrix.md` Phase 3. Verifies `VoskSlotType.NumberSequence`
+runs identically when fed text instead of audio.
+
+| #   | Inject text                                  | Expected Intent | Expected Slots                            | Why                                            | Result |
+|-----|----------------------------------------------|-----------------|-------------------------------------------|------------------------------------------------|--------|
+| 3.1 | `orient heading two seven zero`              | set_heading     | heading=270                               | 3-word number sequence (maxWords)              | PASS   |
+| 3.2 | `orient heading nine`                        | set_heading     | heading=9                                 | 1-word number sequence (minWords)              | PASS   |
+| 3.3 | `orient heading three five mark two`         | set_heading     | heading=35, elevation=2                   | Two NumberSequence slots in one pattern        | PASS   |
+| 3.4 | `set heading one eight zero`                 | set_heading     | heading=180                               | Alternate pattern, same slot                   | PASS   |
+
+---
+
+## Phase 4: Buffered Path & FlushPendingBuffer
+
+Verifies the v2.3 utterance buffer works under injection and that the
+new `FlushPendingBuffer()` API releases queued speech immediately. Set
+`bufferWindow = 1.5` (default) on the recogniser.
+
+| #   | Setup                                           | Action                                                                                                    | Expected                                                                                          | Result |
+|-----|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|--------|
+| 4.1 | `bufferWindow = 1.5`                            | `Inject Text` `"cease fire"`                                                                              | No command fires for ~1.5 s, then `cease_fire` event appears in Console (Update flushes buffer)   | PASS   |
+| 4.2 | `bufferWindow = 1.5`                            | `Inject Text` `"cease fire"`, then immediately `Flush Pending Buffer`                                     | `cease_fire` fires synchronously, before the 1.5 s window elapses                                 | PASS   |
+| 4.3 | `bufferWindow = 30` *(widened from 1.5 — three Inspector edits in <1.5s is not manually achievable; the row verifies batching + sequential extraction, not timing)* | `Inject Text` `"cease fire"`, then `Inject Text` `"launch missiles target hotel one"`, then `Flush Pending Buffer` | Two events fire from one batch (`cease_fire` then `launch_weapon`) — sequential extraction (v2.3). `Batch: 2 command(s) from single utterance` log line is the marker. | PASS   |
+| 4.4 | `bufferWindow = 1.5`, no prior injection        | `Flush Pending Buffer`                                                                                    | No-op, no exception, no event                                                                     | PASS   |
+| 4.5 | `bufferWindow = 0` (disabled)                   | `Inject Text` `"cease fire"`                                                                              | `cease_fire` fires synchronously (v2.2 unbuffered behaviour)                                      | PASS   |
+
+> After Phase 4, restore `bufferWindow = 1.5` before continuing.
+
+---
+
+## Phase 5: Cooldown / Debounce & Threshold Filtering
+
+Verifies the v2.3 per-intent debounce behaves identically when fed via
+injection. Set `commandCooldown = 1.0`, `bufferWindow = 0` for these
+rows so events are synchronous.
+
+| #   | Setup                                | Action                                                                              | Expected                                                                                       | Result |
+|-----|--------------------------------------|-------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|--------|
+| 5.1 | `commandCooldown = 1.0`              | `Inject Text` `"cease fire"` twice within 1 s                                       | First fires, second is suppressed by per-intent debounce (one event total)                     | PASS   |
+| 5.2 | `commandCooldown = 1.0`              | `Inject Text` `"cease fire"`, wait >1 s in Play mode, `Inject Text` `"cease fire"` again | Both fire (cooldown expired)                                                              | PASS   |
+| 5.3 | `commandCooldown = 0`, `wordConfidence = 0.2` | `Inject Text` `"cease fire"`                                              | Below `minConfidence=0.4` → silently filtered, no event                                        | PASS   |
+| 5.4 | `commandCooldown = 0`, `wordConfidence = 1.0`, recogniser `minScore = 0.95` | `Inject Text` `"cease"` (partial pattern, missing "fire")                                                       | Silently filtered — no event. Parser scores the partial match at `0.25` (1 matched literal + 1 missed, normalised by pattern length 2), which is below `minScore=0.95`. `ProcessParsedResults` takes the "filtered" branch (`accepted.Count == 0`) and returns silently; the `Unrecognised` branch only fires when `results.Length == 0` from the parser. See `VoskCommandRecogniser.cs:421` vs `:391`. | PASS |
+
+---
+
+## Phase 6: Cross-Component Pipeline (Speech → Command)
+
+Verifies that calling `InjectResult` on `VoskSpeechRecogniser` propagates
+through the live `OnResult` subscription on `VoskCommandRecogniser`. This
+is the path that catches future regressions where someone renames
+`OnResult` or breaks the `OnEnable` subscription — the per-component
+tests would still pass but the integration would silently break.
+
+| #   | Setup                                                                         | Action                                                                | Expected                                                                  | Result |
+|-----|-------------------------------------------------------------------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------|--------|
+| 6.1 | CommandDemo scene, `useInspectorAuthoring = false`, both components wired     | Driver `Inject Result` with `"cease fire"`                            | `cease_fire` command event fires in `CommandDemo` Console output          | PASS   |
+| 6.2 | Same                                                                          | Driver `Inject Result` with `"launch all missiles target hotel one"`  | `launch_weapon` event with quantity=all, weapon=missiles, target=hotel one| PASS   |
+| 6.3 | Same                                                                          | Driver `Inject Result` with `"hello world"`                           | `Unrecognised: "hello world"` log line (after buffer window)              | PASS   |
+| 6.4 | Disable the `VoskCommandRecogniser` **component** (uncheck its checkbox in the Inspector — not the GameObject, which would also disable the Speech Recogniser and driver), then driver `Inject Result` `"cease fire"` | Speech-layer events fire but `CommandDemo` logs nothing      | `OnDisable` correctly unsubscribed; re-enable and try again to confirm subscription path is restored | PASS   |
+
+---
+
+## Phase 7: Asset-Driven Authoring (v2.5 Path) via Injection
+
+Repeats the gating cases from `v2.5-test-matrix.md` Phase 1 but driven
+through injection in the Editor. Confirms ScriptableObject authoring +
+text injection compose correctly. Set
+`useInspectorAuthoring = true` on `CommandDemo` and import the
+**Command Recognition** sample so the 6 slot assets / 11 command assets /
+3 command set assets are wired on `VoskCommandRecogniser`.
+
+| #   | Inject text                                         | Expected Intent    | Expected Slots                                | Asset feature exercised                            | Result |
+|-----|-----------------------------------------------------|--------------------|-----------------------------------------------|----------------------------------------------------|--------|
+| 7.1 | (Play start, no injection)                          | —                  | —                                             | Console: `Active sets: [weapons, navigation, common]` from `initialActiveSetNames`. No exceptions on `Awake()`. | PASS |
+| 7.2 | `cease fire`                                        | cease_fire         | (none)                                        | Asset-driven literal command                       | PASS   |
+| 7.3 | `launch missiles target hotel one`                  | launch_weapon      | weapon=missiles, target=hotel one             | Asset-driven slotted command                       | PASS   |
+| 7.4 | `orient heading two seven zero`                     | set_heading        | heading=270                                   | Asset-driven NumberSequence                        | PASS   |
+| 7.5 | `weapons mode` then `cease fire` then `approach target alpha one` | mode_weapons; cease_fire; (unrecognised) | —                       | Runtime set switching still works through injection (navigation set inactive after mode switch) | PASS |
+| 7.6 | `all modes` then `approach target alpha one`        | mode_all; approach_target | target=alpha one                       | Restoring all sets via injection re-activates navigation | PASS |
+
+> Note: 7.5 line 3 should produce an `Unrecognised` event because
+> `approach_target` is in the navigation set, and `weapons mode` deactivated
+> it. Unlike the on-Quest run, there is no acoustic-level filtering — VOSK
+> isn't running — so the parser sees the full text `"approach target alpha one"`
+> and reports it as unrecognised. This is expected and matches the v2.4/v2.5
+> "no match in active grammar" semantics.
+
+---
+
+## Results Summary
+
+| Phase | Tests | Pass | Fail | Skip |
+|-------|-------|------|------|------|
+| 0 — Test Runner (automated, 9 suites / 145 tests) |  9 |  9 | 0 | 0 |
+| 1 — API Surface Spot-Checks             |  6 |  6 | 0 | 0 |
+| 2 — Slot Conversion via Injection       |  7 |  7 | 0 | 0 |
+| 3 — NumberSequence via Injection        |  4 |  4 | 0 | 0 |
+| 4 — Buffered Path & Flush               |  5 |  5 | 0 | 0 |
+| 5 — Cooldown & Threshold Filtering      |  4 |  4 | 0 | 0 |
+| 6 — Cross-Component Pipeline            |  4 |  4 | 0 | 0 |
+| 7 — Asset-Driven Authoring (v2.5 path)  |  6 |  6 | 0 | 0 |
+| **Total**                               | **45** | **45** | **0** | **0** |
+
+### What this matrix proves
+
+- The injection API surface compiles, runs, and fires the documented
+  events on a machine that has **no** Quest device, **no** Android build,
+  and **no** native bridge library.
+- Every v2.0–v2.5 feature category (literals, enumerated slots, aliases,
+  optional slots, NumberSequence, buffer, sequential extraction,
+  debounce, threshold filtering, command sets, asset authoring) is
+  reachable via injection, so command-iteration changes can be validated
+  without a deploy cycle.
+- The code-based and asset-based configuration paths both work under
+  injection, so v2.5 Inspector authoring users get the same v3 benefit.
+- The cross-component subscription path (`VoskSpeechRecogniser.OnResult` →
+  `VoskCommandRecogniser.HandleResult`) is exercised end-to-end. Future
+  refactors that break this connection will be caught by Phase 6 even if
+  the per-component injection tests still pass.
+
+### What this matrix does NOT cover
+
+- **Live audio input in the Editor.** That is v3 Phase 2 (desktop VOSK +
+  Unity Microphone), tracked in `v3-and-beyond-analysis.md`. When that
+  ships it gets its own matrix.
+- **Acoustic-model behaviour.** Injection bypasses VOSK entirely, so any
+  test that depends on what VOSK actually hears (e.g. the
+  `switch to weapons` → `switch two weapons` known issue from v2.5
+  Phase 4.5) is out of scope. Those still need a Quest run.
+- **Audio capture timing / grammar reload latency.** The 50 ms gap noted
+  in v2.5 Phase 5.4 is an audio-capture restart artefact and only
+  reproduces on-device.
+
+If you're iterating on **command definitions, slot combinations,
+patterns, scoring, thresholds, debounce, command sets, or asset
+authoring**, this matrix is sufficient before tagging a release. If
+you're iterating on **what VOSK actually hears**, you still need to
+deploy.

--- a/v3-test-matrix.md.meta
+++ b/v3-test-matrix.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16e6f26dc1d5d3149ad4f0ce37cd9fe9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
  ## Summary

  - Adds a **text injection API** on both recognisers so command-config
    iteration no longer requires a Quest deploy cycle. `InjectText` on
    `VoskCommandRecogniser` pushes text through the full parser →
    threshold → buffer → debounce path, exercising the same code as real
    audio. `InjectResult` / `InjectPartialResult` /
    `CreateSimulatedWords` on `VoskSpeechRecogniser` cover the lower
    layer for tests that need raw recogniser events. `FlushPendingBuffer`
    forces buffered speech to parse synchronously (also useful in
    production for push-to-talk release).
  - Adds a **Play Mode injection test suite** (145 tests across 9 files,
    new work in `VoskCommandRecogniserInjectionTests.cs` and
    `VoskSpeechRecogniserInjectionTests.cs`) plus a manual matrix in
    `v3-test-matrix.md` — **45/45 passing across 8 phases, no device,
    native bridge, or model required**. Verifies every v2.0–v2.5 feature
    category (literals, aliases, optional slots, NumberSequence,
    utterance buffer, sequential extraction, debounce, threshold
    filtering, command sets, Inspector authoring) is reachable via
    injection.
  - Adds the **missing top-level README** for `Samples~/CommandRecognition/`
    (BasicTranscription already had one). Documents setup, mode-switching
    behaviour, and points at the injection API as the supported
    Editor-iteration path, with the injection tests as executable usage
    examples.
  - Bumps `package.json` to **0.10.0** and documents the release in
    `CHANGELOG.md`.

  ## Test plan

  - [x] `Tests/Runtime/VoskSpeechRecogniserInjectionTests.cs` —
    injection, empty/null passthrough, simulated-word timing
  - [x] `Tests/Runtime/VoskCommandRecogniserInjectionTests.cs` —
    parser wiring, buffer flush, debounce, threshold filter,
    `SetActiveSets` interaction
  - [x] Full `v3-test-matrix.md` Phase 0–7 — 45/45 PASS
  - [x] Existing v2.0–v2.5 test suites still green
  - [ ] One-time Quest 3 smoke run of `CommandDemo` after merge to
    confirm nothing on the real-audio path regressed (injection path is
    Editor-only, doesn't exercise the native bridge)