### PR TITLE
V3.2 Add Editor command debug window with live pipeline diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-04-10
+
+### Added
+
+- `VoskDebugWindow` Editor window (Window > VOSK XR > Command Debug) for live command pipeline diagnostics during Play Mode. Two-panel layout: left panel shows audio level meters (pre/post-AGC RMS, AGC gain), partial result, final result text, per-word confidence bars, and n-best alternatives; right panel shows active command sets, last match breakdown with score/confidence threshold pass/fail, slot word positions with per-slot confidence, and a scrolling match history (last 20 entries). Bottom bar provides text injection for testing without a microphone, plus pause and clear controls.
+- `VoskMatchDiagnostics`, `VoskMatchAttempt`, and `VoskDiagnosticSlotMatch` diagnostic structs in `Runtime/Commands/VoskMatchDiagnostics.cs` — Editor-only (`#if UNITY_EDITOR`) data captured per utterance by the command pipeline for the debug window to poll.
+- `Jinwoo1601.VoskXR.Editor` assembly definition for Editor-only code with a reference to the runtime assembly.
+
+### Changed
+
+- `VoskCommandParser` now records matched pattern strings, slot word positions (start/end indices), and per-parse diagnostic entries behind `#if UNITY_EDITOR`. `UnkToken`, `SplitSeparator`, and `ComputeConfidence` visibility widened to `internal` for Editor assembly access.
+- `VoskCommandRecogniser` builds a `VoskMatchDiagnostics` snapshot at the end of each parse cycle with per-attempt accept/reject reasons (score, confidence, debounce). Subscribes to `OnPartialResult` in Editor for live partial text display.
+- `EditorMicBackend` exposes `PreAgcRms`, `PostAgcRms`, and `AgcGain` properties for the debug window's audio level meters.
+- `VoskSpeechRecogniser` exposes `EditorLastResult` (Editor-only) and audio level forwarding properties (`EditorPreAgcRms`, `EditorPostAgcRms`, `EditorAgcGain` — Windows Editor only).
+
 ## [0.11.0] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VoskCommandRecogniser` builds a `VoskMatchDiagnostics` snapshot at the end of each parse cycle with per-attempt accept/reject reasons (score, confidence, debounce). Subscribes to `OnPartialResult` in Editor for live partial text display.
 - `EditorMicBackend` exposes `PreAgcRms`, `PostAgcRms`, and `AgcGain` properties for the debug window's audio level meters.
 - `VoskSpeechRecogniser` exposes `EditorLastResult` (Editor-only) and audio level forwarding properties (`EditorPreAgcRms`, `EditorPostAgcRms`, `EditorAgcGain` — Windows Editor only).
+- `VoskCommandRecogniser.SpeechRecogniser` internal setter now manages event subscriptions (unsubscribes from old recogniser, subscribes to new) for Edit Mode test support.
+- `EditorMicBackend.ComputeRms` visibility widened from `private` to `internal` for test access.
+- `CommandDemo` sample stripped of verbose `Debug.Log` calls — event handlers are now minimal stubs.
+
+### Fixed
+
+- Debug window pause/resume now freezes the display with a snapshot and skips stale results on resume instead of jumping to the latest frame.
+- Enter-key text injection works reliably — event is consumed before `TextField`, and `KeypadEnter` is accepted alongside `Return`.
+- Word confidence column shows `[n/a]` when VOSK omits per-word `conf` (happens with `maxAlternatives > 0`) instead of a misleading 0% bar.
+- `VoskSpeechRecogniser` now always parses full result JSON in Editor builds even when `OnResult` has no subscribers, so the debug window receives word and alternative data.
+- `ParseWordsFromJson` handles absent `"conf"` field with a -1 sentinel instead of defaulting to 0.
+
+### Added (tests)
+
+- `AudioMetricTests` — Edit Mode tests for `ComputeRms` (silence, DC, known-amplitude sine).
+- `VoskCommandParserDiagnosticTests` — verifies parser populates `DiagnosticEntries` with matched pattern, slot positions, and score.
+- `VoskCommandRecogniserDiagnosticTests` — end-to-end diagnostic struct population via `InjectText`, covering accept/reject reasons and slot match data.
+- `VoskMatchDiagnosticsTests` — struct-level tests for `VoskMatchDiagnostics`, `VoskMatchAttempt`, and `VoskDiagnosticSlotMatch` defaults and field storage.
 
 ## [0.11.0] - 2026-04-09
 

--- a/Documentation~/vosk-xr.md
+++ b/Documentation~/vosk-xr.md
@@ -27,6 +27,7 @@
   - [Grammar Mode vs Free Speech](#grammar-mode-vs-free-speech)
 - [Inspector Authoring](#inspector-authoring)
 - [Editor Iteration](#editor-iteration)
+  - [Command Debug Window](#command-debug-window)
   - [Live Microphone (Windows Editor)](#live-microphone-windows-editor)
   - [Text Injection API](#text-injection-api)
 - [Push-to-Talk Pattern](#push-to-talk-pattern)
@@ -50,7 +51,7 @@
 To pin a specific version (recommended):
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.11.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0
 ```
 
 ### Via manifest.json
@@ -60,7 +61,7 @@ Add to `Packages/manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.11.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0"
   }
 }
 ```
@@ -688,7 +689,31 @@ The Command Recognition sample includes a complete set of 20 ScriptableObject as
 
 ## Editor Iteration
 
-Two complementary approaches let you iterate without deploying to Quest.
+Three complementary approaches let you iterate without deploying to Quest.
+
+### Command Debug Window
+
+Open **Window > VOSK XR > Command Debug** during Play Mode to inspect the full command pipeline in real time.
+
+**Left panel** (recognition state):
+- Audio level meters -- pre-AGC RMS, post-AGC RMS, and current AGC gain.
+- Partial result -- live VOSK partial transcript as you speak.
+- Final result -- the completed transcript text.
+- Per-word confidence bars -- each word with a colour-coded confidence bar (green > yellow > red). Shows `[n/a]` when VOSK omits per-word confidence (happens with `maxAlternatives > 0`).
+- N-best alternatives -- alternative hypotheses with confidence scores.
+
+**Right panel** (command matching):
+- Active command sets -- which sets are currently loaded.
+- Last match breakdown -- for each command definition attempted: intent, score, confidence, threshold pass/fail, and reject reason (if any). Accepted commands are highlighted in green.
+- Slot details -- matched slot word positions (start/end indices) with per-slot confidence.
+- Match history -- scrolling list of the last 20 match results with timestamps.
+
+**Bottom toolbar:**
+- **Inject field** -- type a phrase and press Enter (or click Send) to push it through the full command pipeline without a microphone. Useful for testing specific phrases or edge cases.
+- **Clear** -- clears match history and resets the display.
+- **Pause / Resume** -- freezes the display so you can inspect a result without it being overwritten by the next utterance. On resume, stale results are skipped so the display jumps to the next genuinely new result.
+
+The debug window is Editor-only (`#if UNITY_EDITOR`) and has zero cost in builds. The underlying diagnostic structs (`VoskMatchDiagnostics`, `VoskMatchAttempt`, `VoskDiagnosticSlotMatch`) are compiled out of non-Editor builds.
 
 ### Live Microphone (Windows Editor)
 
@@ -793,7 +818,7 @@ recogniser.OnError += (code, message) =>
 
 ## Running Tests
 
-The package includes 13 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
+The package includes 17 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
 
 | Suite | Mode | Covers |
 |-------|------|--------|
@@ -810,6 +835,10 @@ The package includes 13 test suites (Edit Mode and Play Mode) that run without a
 | `AgcTests` | Edit Mode | AGC convergence, silence, extreme input, reset |
 | `ModelExtractorValidationTests` | Edit Mode | Model path validation and error handling |
 | `VoskBridgeErrorCodeTests` | Edit Mode | Error code descriptions |
+| `AudioMetricTests` | Edit Mode | `ComputeRms` (silence, DC, known-amplitude sine) |
+| `VoskCommandParserDiagnosticTests` | Edit Mode | Parser diagnostic entries, matched pattern, slot positions, score |
+| `VoskCommandRecogniserDiagnosticTests` | Edit Mode | End-to-end diagnostic struct population via `InjectText`, accept/reject reasons |
+| `VoskMatchDiagnosticsTests` | Edit Mode | Diagnostic struct defaults, field storage, slot match data |
 
 To run in a consuming Unity project:
 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Jinwoo1601.VoskXR.Editor.asmdef
+++ b/Editor/Jinwoo1601.VoskXR.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Jinwoo1601.VoskXR.Editor",
+    "rootNamespace": "VoskXR.Editor",
+    "references": [
+        "Jinwoo1601.VoskXR.Runtime"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Jinwoo1601.VoskXR.Editor.asmdef.meta
+++ b/Editor/Jinwoo1601.VoskXR.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/VoskDebugWindow.cs
+++ b/Editor/VoskDebugWindow.cs
@@ -1,0 +1,508 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Editor
+{
+    /// <summary>
+    /// IMGUI EditorWindow showing the VOSK command recognition pipeline state in real time.
+    /// Pull model: polls runtime components every repaint during Play Mode.
+    /// </summary>
+    public class VoskDebugWindow : EditorWindow
+    {
+        const int MaxHistoryEntries = 20;
+        const float LevelMeterHeight = 16f;
+        const float LevelMeterWidth = 200f;
+
+        VoskSpeechRecogniser _speechRecogniser;
+        VoskCommandRecogniser _commandRecogniser;
+
+        readonly List<HistoryEntry> _history = new List<HistoryEntry>();
+        int _lastDiagFrame = -1;
+        bool _paused;
+        string _injectText = "";
+
+        Vector2 _leftScroll;
+        Vector2 _rightScroll;
+        Vector2 _historyScroll;
+
+        GUIStyle _boldIntentStyle;
+        GUIStyle _rejectStyle;
+        GUIStyle _thresholdStyle;
+        GUIStyle _historyStyle;
+
+        struct HistoryEntry
+        {
+            public string Label;
+            public bool Accepted;
+            public VoskMatchDiagnostics Diagnostics;
+        }
+
+        [MenuItem("Window/VOSK XR/Command Debug")]
+        static void Open()
+        {
+            GetWindow<VoskDebugWindow>("VOSK Command Debug");
+        }
+
+        void OnEnable()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeChanged;
+            FindComponents();
+        }
+
+        void OnDisable()
+        {
+            EditorApplication.playModeStateChanged -= OnPlayModeChanged;
+        }
+
+        void OnPlayModeChanged(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.EnteredPlayMode)
+                FindComponents();
+            else if (state == PlayModeStateChange.ExitingPlayMode)
+            {
+                _speechRecogniser = null;
+                _commandRecogniser = null;
+            }
+        }
+
+        void FindComponents()
+        {
+            if (!EditorApplication.isPlaying) return;
+            _speechRecogniser = FindFirstObjectByType<VoskSpeechRecogniser>();
+            _commandRecogniser = FindFirstObjectByType<VoskCommandRecogniser>();
+        }
+
+        void OnInspectorUpdate()
+        {
+            if (EditorApplication.isPlaying)
+                Repaint();
+        }
+
+        void OnGUI()
+        {
+            if (!EditorApplication.isPlaying)
+            {
+                EditorGUILayout.HelpBox("Enter Play Mode to see live command diagnostics.", MessageType.Info);
+                return;
+            }
+
+            if (_commandRecogniser == null)
+            {
+                if (GUILayout.Button("Find Components"))
+                    FindComponents();
+                EditorGUILayout.HelpBox(
+                    "No VoskCommandRecogniser found in the scene. " +
+                    "Ensure a GameObject has both VoskSpeechRecogniser and VoskCommandRecogniser.",
+                    MessageType.Warning);
+                return;
+            }
+
+            PollDiagnostics();
+
+            EditorGUILayout.BeginHorizontal();
+
+            // Left panel — Audio & Recognition
+            EditorGUILayout.BeginVertical(GUILayout.Width(position.width * 0.45f));
+            _leftScroll = EditorGUILayout.BeginScrollView(_leftScroll);
+            DrawLeftPanel();
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+
+            // Separator
+            DrawVerticalSeparator();
+
+            // Right panel — Command Matching
+            EditorGUILayout.BeginVertical();
+            _rightScroll = EditorGUILayout.BeginScrollView(_rightScroll);
+            DrawRightPanel();
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.EndHorizontal();
+
+            DrawBottomBar();
+        }
+
+        void PollDiagnostics()
+        {
+            if (_paused) return;
+            if (_commandRecogniser == null) return;
+
+            var diag = _commandRecogniser.LastMatchDiagnostics;
+            if (diag.Frame != 0 && diag.Frame != _lastDiagFrame)
+            {
+                _lastDiagFrame = diag.Frame;
+                AddToHistory(diag);
+            }
+        }
+
+        void AddToHistory(VoskMatchDiagnostics diag)
+        {
+            if (diag.Attempts == null || diag.Attempts.Length == 0) return;
+
+            foreach (var attempt in diag.Attempts)
+            {
+                string label;
+                if (attempt.IsAccepted)
+                    label = $"{attempt.Intent} ({attempt.Score:F2})";
+                else if (attempt.Intent != null)
+                    label = $"{attempt.Intent}: {attempt.RejectReason}";
+                else
+                    label = attempt.RejectReason ?? "no match";
+
+                _history.Add(new HistoryEntry
+                {
+                    Label = label,
+                    Accepted = attempt.IsAccepted,
+                    Diagnostics = diag,
+                });
+
+                while (_history.Count > MaxHistoryEntries)
+                    _history.RemoveAt(0);
+            }
+        }
+
+        // ─── Left Panel ─────────────────────────────────────────────────
+
+        void DrawLeftPanel()
+        {
+            EditorGUILayout.LabelField("Audio & Recognition", EditorStyles.boldLabel);
+            EditorGUILayout.Space(4);
+
+            DrawAudioLevels();
+            EditorGUILayout.Space(8);
+            DrawPartialResult();
+            EditorGUILayout.Space(4);
+            DrawFinalResult();
+            EditorGUILayout.Space(4);
+            DrawWordConfidence();
+            EditorGUILayout.Space(4);
+            DrawAlternatives();
+        }
+
+        void DrawAudioLevels()
+        {
+#if UNITY_EDITOR_WIN
+            if (_speechRecogniser == null)
+            {
+                EditorGUILayout.LabelField("Audio levels: no speech recogniser");
+                return;
+            }
+
+            float preRms = _speechRecogniser.EditorPreAgcRms;
+            float postRms = _speechRecogniser.EditorPostAgcRms;
+            float gain = _speechRecogniser.EditorAgcGain;
+
+            DrawLevelMeter("Pre-AGC", preRms, Color.cyan);
+            DrawLevelMeter("Post-AGC", postRms, Color.green);
+            EditorGUILayout.LabelField($"AGC Gain: {gain:F2}x");
+#else
+            EditorGUILayout.LabelField("Audio levels: Editor-Win only");
+#endif
+        }
+
+        void DrawLevelMeter(string label, float rms, Color color)
+        {
+            var rect = EditorGUILayout.GetControlRect(false, LevelMeterHeight);
+            float labelWidth = 70f;
+
+            var labelRect = new Rect(rect.x, rect.y, labelWidth, rect.height);
+            EditorGUI.LabelField(labelRect, label);
+
+            var meterRect = new Rect(rect.x + labelWidth, rect.y, LevelMeterWidth, rect.height);
+
+            // Background
+            EditorGUI.DrawRect(meterRect, new Color(0.15f, 0.15f, 0.15f));
+
+            // RMS bar — scale: 0.0–0.5 RMS maps to full bar (speech rarely exceeds 0.3)
+            float fill = Mathf.Clamp01(rms * 3f);
+            var fillRect = new Rect(meterRect.x, meterRect.y, meterRect.width * fill, meterRect.height);
+            EditorGUI.DrawRect(fillRect, color);
+
+            // Value text
+            var valueRect = new Rect(meterRect.xMax + 4, rect.y, 60, rect.height);
+            EditorGUI.LabelField(valueRect, $"{rms:F4}");
+        }
+
+        void DrawPartialResult()
+        {
+            string partial = _commandRecogniser?.LastPartialResult ?? "";
+            EditorGUILayout.LabelField("Partial", EditorStyles.miniLabel);
+            EditorGUILayout.SelectableLabel(
+                string.IsNullOrEmpty(partial) ? "(listening...)" : partial,
+                EditorStyles.wordWrappedLabel, GUILayout.MinHeight(20));
+        }
+
+        void DrawFinalResult()
+        {
+            var diag = _commandRecogniser.LastMatchDiagnostics;
+            string text = diag.InputText ?? "(none)";
+
+            EditorGUILayout.LabelField("Final Result", EditorStyles.miniLabel);
+            EditorGUILayout.SelectableLabel(text, EditorStyles.wordWrappedLabel,
+                GUILayout.MinHeight(20));
+        }
+
+        void DrawWordConfidence()
+        {
+            var diag = _commandRecogniser.LastMatchDiagnostics;
+            if (diag.Words == null || diag.Words.Length == 0) return;
+
+            EditorGUILayout.LabelField("Word Confidence", EditorStyles.miniLabel);
+
+            foreach (var word in diag.Words)
+            {
+                var rect = EditorGUILayout.GetControlRect(false, 18f);
+                float textWidth = 100f;
+                float confWidth = 40f;
+                float barWidth = rect.width - textWidth - confWidth - 8f;
+                if (barWidth < 20f) barWidth = 20f;
+
+                // Word text
+                EditorGUI.LabelField(new Rect(rect.x, rect.y, textWidth, rect.height), word.Text);
+
+                // Confidence value
+                EditorGUI.LabelField(
+                    new Rect(rect.x + textWidth, rect.y, confWidth, rect.height),
+                    $"[{word.Confidence:F2}]");
+
+                // Confidence bar
+                var barRect = new Rect(rect.x + textWidth + confWidth + 4, rect.y + 2,
+                    barWidth, rect.height - 4);
+                EditorGUI.DrawRect(barRect, new Color(0.15f, 0.15f, 0.15f));
+
+                float fill = Mathf.Clamp01(word.Confidence);
+                Color barColor = word.Confidence >= 0.8f ? new Color(0.2f, 0.8f, 0.2f)
+                    : word.Confidence >= 0.5f ? new Color(0.9f, 0.8f, 0.1f)
+                    : new Color(0.9f, 0.2f, 0.2f);
+                EditorGUI.DrawRect(
+                    new Rect(barRect.x, barRect.y, barRect.width * fill, barRect.height),
+                    barColor);
+            }
+        }
+
+        void DrawAlternatives()
+        {
+            if (_speechRecogniser == null) return;
+
+            var lastResult = _speechRecogniser.EditorLastResult;
+            if (lastResult.Alternatives == null || lastResult.Alternatives.Length <= 1) return;
+
+            EditorGUILayout.LabelField("Alternatives", EditorStyles.miniLabel);
+            for (int i = 0; i < lastResult.Alternatives.Length; i++)
+            {
+                var alt = lastResult.Alternatives[i];
+                EditorGUILayout.LabelField(
+                    $"  {i}: \"{alt.Text}\" (conf={alt.Confidence:F1})");
+            }
+        }
+
+        // ─── Right Panel ────────────────────────────────────────────────
+
+        void DrawRightPanel()
+        {
+            EditorGUILayout.LabelField("Command Matching", EditorStyles.boldLabel);
+            EditorGUILayout.Space(4);
+
+            DrawActiveSets();
+            EditorGUILayout.Space(4);
+            DrawLastMatchBreakdown();
+            EditorGUILayout.Space(8);
+            DrawHistory();
+        }
+
+        void DrawActiveSets()
+        {
+            var setNames = _commandRecogniser.ActiveSetNames;
+            if (setNames.Length == 0)
+            {
+                EditorGUILayout.LabelField("Active Sets: (all commands / no sets)");
+            }
+            else
+            {
+                EditorGUILayout.LabelField($"Active Sets: {string.Join(", ", setNames)}");
+            }
+        }
+
+        void DrawLastMatchBreakdown()
+        {
+            var diag = _commandRecogniser.LastMatchDiagnostics;
+            if (diag.Attempts == null || diag.Attempts.Length == 0)
+            {
+                EditorGUILayout.LabelField("No match data yet.", EditorStyles.miniLabel);
+                return;
+            }
+
+            for (int a = 0; a < diag.Attempts.Length; a++)
+            {
+                var attempt = diag.Attempts[a];
+
+                if (diag.Attempts.Length > 1)
+                    DrawSectionHeader($"Match {a + 1}/{diag.Attempts.Length}");
+                else
+                    DrawSectionHeader("Last Match");
+
+                // Intent
+                if (attempt.Intent != null)
+                {
+                    string icon = attempt.IsAccepted ? " [PASS]" : " [FAIL]";
+                    _boldIntentStyle ??= new GUIStyle(EditorStyles.label)
+                        { richText = true, fontStyle = FontStyle.Bold };
+                    EditorGUILayout.LabelField($"Intent: {attempt.Intent}{icon}", _boldIntentStyle);
+                }
+                else
+                {
+                    EditorGUILayout.LabelField("Intent: (no match)", EditorStyles.boldLabel);
+                }
+
+                // Pattern
+                if (attempt.Pattern != null)
+                    EditorGUILayout.LabelField($"Pattern: {attempt.Pattern}");
+
+                // Score
+                DrawThresholdLine("Score", attempt.Score, attempt.MinScore);
+
+                // Confidence
+                if (attempt.AggregateConfidence >= 0f)
+                    DrawThresholdLine("Confidence", attempt.AggregateConfidence, attempt.MinConfidence);
+                else
+                    EditorGUILayout.LabelField("Confidence: n/a (no word data)");
+
+                // Reject reason
+                if (attempt.RejectReason != null)
+                {
+                    _rejectStyle ??= new GUIStyle(EditorStyles.label)
+                        { normal = { textColor = new Color(1f, 0.4f, 0.4f) } };
+                    EditorGUILayout.LabelField($"Rejected: {attempt.RejectReason}", _rejectStyle);
+                }
+
+                // Slots
+                if (attempt.Slots != null && attempt.Slots.Length > 0)
+                {
+                    EditorGUILayout.LabelField("Slots:", EditorStyles.miniLabel);
+                    foreach (var slot in attempt.Slots)
+                    {
+                        string confStr = slot.Confidence >= 0f ? $" conf={slot.Confidence:F2}" : "";
+                        EditorGUILayout.LabelField(
+                            $"  {slot.Name} = \"{slot.Value}\"  words[{slot.StartWord}..{slot.EndWord}]{confStr}");
+                    }
+                }
+
+                EditorGUILayout.Space(4);
+            }
+        }
+
+        void DrawThresholdLine(string label, float value, float threshold)
+        {
+            bool pass = value >= threshold;
+            string icon = pass ? " [PASS]" : " [FAIL]";
+            Color color = pass ? new Color(0.3f, 0.9f, 0.3f) : new Color(1f, 0.4f, 0.4f);
+
+            _thresholdStyle ??= new GUIStyle(EditorStyles.label);
+            _thresholdStyle.normal.textColor = color;
+            EditorGUILayout.LabelField(
+                $"{label}: {value:F2} / {threshold:F2}{icon}", _thresholdStyle);
+        }
+
+        void DrawHistory()
+        {
+            DrawSectionHeader("History");
+
+            if (_history.Count == 0)
+            {
+                EditorGUILayout.LabelField("(empty)", EditorStyles.miniLabel);
+                return;
+            }
+
+            _historyScroll = EditorGUILayout.BeginScrollView(_historyScroll,
+                GUILayout.MaxHeight(200));
+
+            // Draw newest first
+            for (int i = _history.Count - 1; i >= 0; i--)
+            {
+                var entry = _history[i];
+                string icon = entry.Accepted ? "[PASS]" : "[FAIL]";
+                Color color = entry.Accepted
+                    ? new Color(0.3f, 0.9f, 0.3f)
+                    : new Color(0.7f, 0.7f, 0.7f);
+
+                _historyStyle ??= new GUIStyle(EditorStyles.miniLabel);
+                _historyStyle.normal.textColor = color;
+                EditorGUILayout.LabelField($"{icon} {entry.Label}", _historyStyle);
+            }
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        // ─── Bottom Bar ─────────────────────────────────────────────────
+
+        void DrawBottomBar()
+        {
+            DrawHorizontalSeparator();
+
+            EditorGUILayout.BeginHorizontal();
+
+            // Inject text field
+            EditorGUILayout.LabelField("Inject:", GUILayout.Width(42));
+            _injectText = EditorGUILayout.TextField(_injectText);
+
+            bool enterPressed = Event.current.type == EventType.KeyDown
+                && Event.current.keyCode == KeyCode.Return
+                && !string.IsNullOrWhiteSpace(_injectText);
+
+            if ((GUILayout.Button("Send", GUILayout.Width(50)) || enterPressed)
+                && !string.IsNullOrWhiteSpace(_injectText)
+                && _commandRecogniser != null)
+            {
+                _commandRecogniser.InjectText(_injectText);
+                _injectText = "";
+                GUI.FocusControl(null);
+                if (enterPressed) Event.current.Use();
+            }
+
+            // Clear history
+            if (GUILayout.Button("Clear", GUILayout.Width(50)))
+            {
+                _history.Clear();
+                _lastDiagFrame = -1;
+            }
+
+            // Pause/resume
+            string pauseLabel = _paused ? "Resume" : "Pause";
+            if (GUILayout.Button(pauseLabel, GUILayout.Width(60)))
+                _paused = !_paused;
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────
+
+        static void DrawSectionHeader(string title)
+        {
+            EditorGUILayout.Space(2);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+            EditorGUILayout.LabelField(title, EditorStyles.miniBoldLabel);
+        }
+
+        static void DrawHorizontalSeparator()
+        {
+            EditorGUILayout.Space(2);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+            EditorGUILayout.Space(2);
+        }
+
+        void DrawVerticalSeparator()
+        {
+            var rect = EditorGUILayout.GetControlRect(false, GUILayout.Width(1));
+            rect.height = position.height;
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+        }
+
+    }
+}

--- a/Editor/VoskDebugWindow.cs
+++ b/Editor/VoskDebugWindow.cs
@@ -23,7 +23,9 @@ namespace VoskXR.Editor
         readonly List<HistoryEntry> _history = new List<HistoryEntry>();
         int _lastDiagFrame = -1;
         bool _paused;
+        bool _resumePending;
         string _injectText = "";
+        VoskMatchDiagnostics _frozenDiag;
 
         Vector2 _leftScroll;
         Vector2 _rightScroll;
@@ -129,16 +131,22 @@ namespace VoskXR.Editor
 
         void PollDiagnostics()
         {
-            if (_paused) return;
             if (_commandRecogniser == null) return;
+            if (_paused) return;
 
             var diag = _commandRecogniser.LastMatchDiagnostics;
+
             if (diag.Frame != 0 && diag.Frame != _lastDiagFrame)
             {
                 _lastDiagFrame = diag.Frame;
+                _frozenDiag = diag;
+                _resumePending = false;
                 AddToHistory(diag);
             }
         }
+
+        VoskMatchDiagnostics CurrentDiag =>
+            (_paused || _resumePending) ? _frozenDiag : (_commandRecogniser != null ? _commandRecogniser.LastMatchDiagnostics : default);
 
         void AddToHistory(VoskMatchDiagnostics diag)
         {
@@ -230,7 +238,7 @@ namespace VoskXR.Editor
 
         void DrawPartialResult()
         {
-            string partial = _commandRecogniser?.LastPartialResult ?? "";
+            string partial = (_paused || _resumePending) ? "" : (_commandRecogniser?.LastPartialResult ?? "");
             EditorGUILayout.LabelField("Partial", EditorStyles.miniLabel);
             EditorGUILayout.SelectableLabel(
                 string.IsNullOrEmpty(partial) ? "(listening...)" : partial,
@@ -239,7 +247,7 @@ namespace VoskXR.Editor
 
         void DrawFinalResult()
         {
-            var diag = _commandRecogniser.LastMatchDiagnostics;
+            var diag = CurrentDiag;
             string text = diag.InputText ?? "(none)";
 
             EditorGUILayout.LabelField("Final Result", EditorStyles.miniLabel);
@@ -249,7 +257,7 @@ namespace VoskXR.Editor
 
         void DrawWordConfidence()
         {
-            var diag = _commandRecogniser.LastMatchDiagnostics;
+            var diag = CurrentDiag;
             if (diag.Words == null || diag.Words.Length == 0) return;
 
             EditorGUILayout.LabelField("Word Confidence", EditorStyles.miniLabel);
@@ -264,6 +272,15 @@ namespace VoskXR.Editor
 
                 // Word text
                 EditorGUI.LabelField(new Rect(rect.x, rect.y, textWidth, rect.height), word.Text);
+
+                if (word.Confidence < 0f)
+                {
+                    // Confidence unavailable (maxAlternatives > 0 omits per-word conf)
+                    EditorGUI.LabelField(
+                        new Rect(rect.x + textWidth, rect.y, confWidth + barWidth, rect.height),
+                        "[n/a]");
+                    continue;
+                }
 
                 // Confidence value
                 EditorGUI.LabelField(
@@ -330,7 +347,7 @@ namespace VoskXR.Editor
 
         void DrawLastMatchBreakdown()
         {
-            var diag = _commandRecogniser.LastMatchDiagnostics;
+            var diag = CurrentDiag;
             if (diag.Attempts == null || diag.Attempts.Length == 0)
             {
                 EditorGUILayout.LabelField("No match data yet.", EditorStyles.miniLabel);
@@ -448,11 +465,16 @@ namespace VoskXR.Editor
 
             // Inject text field
             EditorGUILayout.LabelField("Inject:", GUILayout.Width(42));
-            _injectText = EditorGUILayout.TextField(_injectText);
+            GUI.SetNextControlName("VoskInjectField");
 
+            // Check for Enter BEFORE TextField — IMGUI TextField consumes the Return KeyDown event
             bool enterPressed = Event.current.type == EventType.KeyDown
-                && Event.current.keyCode == KeyCode.Return
+                && (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
+                && GUI.GetNameOfFocusedControl() == "VoskInjectField"
                 && !string.IsNullOrWhiteSpace(_injectText);
+            if (enterPressed) Event.current.Use();
+
+            _injectText = EditorGUILayout.TextField(_injectText);
 
             if ((GUILayout.Button("Send", GUILayout.Width(50)) || enterPressed)
                 && !string.IsNullOrWhiteSpace(_injectText)
@@ -461,20 +483,32 @@ namespace VoskXR.Editor
                 _commandRecogniser.InjectText(_injectText);
                 _injectText = "";
                 GUI.FocusControl(null);
-                if (enterPressed) Event.current.Use();
             }
 
-            // Clear history
+            // Clear all
             if (GUILayout.Button("Clear", GUILayout.Width(50)))
             {
                 _history.Clear();
-                _lastDiagFrame = -1;
+                _frozenDiag = default;
+                // Sync to current frame so PollDiagnostics doesn't re-add the last entry
+                if (_commandRecogniser != null)
+                    _lastDiagFrame = _commandRecogniser.LastMatchDiagnostics.Frame;
+                _resumePending = true;
             }
 
             // Pause/resume
             string pauseLabel = _paused ? "Resume" : "Pause";
             if (GUILayout.Button(pauseLabel, GUILayout.Width(60)))
+            {
                 _paused = !_paused;
+                // On resume, skip anything that arrived while paused
+                // and keep showing frozen display until a genuinely new result arrives
+                if (!_paused && _commandRecogniser != null)
+                {
+                    _lastDiagFrame = _commandRecogniser.LastMatchDiagnostics.Frame;
+                    _resumePending = true;
+                }
+            }
 
             EditorGUILayout.EndHorizontal();
         }

--- a/Editor/VoskDebugWindow.cs.meta
+++ b/Editor/VoskDebugWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 - Mix and match: Inspector authoring and code-based configuration on the same recogniser
 
 **Testing & Iteration**
+- Editor command debug window (Window > VOSK XR > Command Debug) with live audio meters, match breakdowns, and match history
 - Text injection API for Editor testing, CI, and replay without audio hardware
 - Live microphone in the Windows Editor -- speak into your PC mic, see commands fire in the Console
-- 13 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, and asset conversion
+- 17 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, and asset conversion
 - Extensively tested on Quest 3 with published test matrices for every release
 
 ## Requirements
@@ -53,7 +54,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 **Pinned version:**
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.11.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0
 ```
 
 **Via manifest.json:**
@@ -61,7 +62,7 @@ https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.11.0
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.11.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0"
   }
 }
 ```
@@ -188,6 +189,15 @@ var heading = VoskSlotDefinition.NumberSequence("heading", minWords: 1, maxWords
 
 ## Editor Iteration (No Quest Required)
 
+### Command Debug Window
+
+Open **Window > VOSK XR > Command Debug** during Play Mode to inspect the full command pipeline in real time. The two-panel layout shows:
+
+- **Left panel:** Audio level meters (pre/post-AGC RMS, AGC gain), partial result, final result text, per-word confidence bars, and n-best alternatives.
+- **Right panel:** Active command sets, last match breakdown with score/confidence threshold pass/fail, slot word positions with per-slot confidence, and a scrolling match history (last 20 entries).
+
+The bottom toolbar provides text injection (type a phrase and press Enter to test without a microphone), plus pause and clear controls. Pause freezes the display so you can inspect a result without it being overwritten.
+
 ### Live Microphone (Windows Editor)
 
 On Windows, `StartRecognition()` transparently routes audio through `UnityEngine.Microphone` and a desktop `libvosk.dll`. Existing scenes work with zero code changes -- speak into your PC mic and watch commands fire in the Console.
@@ -223,7 +233,7 @@ Import samples via **Package Manager > VOSK XR Speech Recognition > Samples**.
 
 ## Running Tests
 
-The package includes 13 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
+The package includes 17 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
 
 To run them in a consuming Unity project:
 
@@ -231,7 +241,7 @@ To run them in a consuming Unity project:
 2. Open **Window > General > Test Runner**.
 3. Run Edit Mode and Play Mode tests.
 
-Tests cover: command parser logic, injection API wiring, recogniser lifecycle, JSON parsing, number parsing, command sets, asset-to-runtime conversion, DSP (AGC, downsampler), model extractor validation, and error codes.
+Tests cover: command parser logic, injection API wiring, recogniser lifecycle, JSON parsing, number parsing, command sets, asset-to-runtime conversion, DSP (AGC, downsampler), model extractor validation, error codes, audio metrics, and Editor diagnostic structs.
 
 ## Architecture
 
@@ -280,6 +290,7 @@ This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.
 
 | Version | Milestone |
 |---|---|
+| 0.12.0 | Editor command debug window with live diagnostics |
 | 0.11.0 | Windows Editor live microphone backend |
 | 0.10.0 | Text injection API for Editor/CI testing |
 | 0.9.0 | Inspector authoring (ScriptableObject assets) |

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Jinwoo1601.VoskXR.Tests.Runtime")]
 [assembly: InternalsVisibleTo("Jinwoo1601.VoskXR.Tests.Editor")]
+[assembly: InternalsVisibleTo("Jinwoo1601.VoskXR.Editor")]

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -9,14 +9,14 @@ namespace VoskXR.Commands
     /// </summary>
     internal class VoskCommandParser
     {
-        const string UnkToken = "[unk]";
+        internal const string UnkToken = "[unk]";
 
         const float MatchScore = 1.0f;
         const float OptionalLiteralScore = 0.5f;
         const float RequiredSlotMissPenalty = -1.0f;
         const float RequiredLiteralMissPenalty = -0.5f;
 
-        static readonly char[] SplitSeparator = { ' ' };
+        internal static readonly char[] SplitSeparator = { ' ' };
 
         readonly VoskSlotDefinition[] _slots;
         readonly VoskCommandDefinition[] _commands;
@@ -189,11 +189,21 @@ namespace VoskXR.Commands
         public VoskCommandResult[] Parse(string text, VoskWord[] words)
         {
             if (string.IsNullOrWhiteSpace(text))
+            {
+#if UNITY_EDITOR
+                LastParseDiagnostics = Array.Empty<ParseDiagnosticEntry>();
+#endif
                 return Array.Empty<VoskCommandResult>();
+            }
 
             string[] tokens = text.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
             if (tokens.Length == 0)
+            {
+#if UNITY_EDITOR
+                LastParseDiagnostics = Array.Empty<ParseDiagnosticEntry>();
+#endif
                 return Array.Empty<VoskCommandResult>();
+            }
 
             Dictionary<string, float> wordConfidence = null;
             if (words != null && words.Length > 0)
@@ -208,6 +218,9 @@ namespace VoskXR.Commands
 
             var results = new List<VoskCommandResult>();
             int searchStart = 0;
+#if UNITY_EDITOR
+            var diagnosticEntries = new List<ParseDiagnosticEntry>();
+#endif
 
             while (searchStart < tokens.Length)
             {
@@ -217,6 +230,11 @@ namespace VoskXR.Commands
                 int bestStartIdx = int.MaxValue;
                 int bestEndIdx = 0;
                 List<VoskSlotMatch> bestSlots = null;
+#if UNITY_EDITOR
+                int bestPatternIdx = -1;
+                List<int> bestSlotStartWords = null;
+                List<int> bestSlotEndWords = null;
+#endif
 
                 for (int ci = 0; ci < _commands.Length; ci++)
                 {
@@ -243,6 +261,11 @@ namespace VoskXR.Commands
                                 bestStartIdx = startIdx;
                                 bestEndIdx = matchResult.EndIdx;
                                 bestSlots = matchResult.Slots;
+#if UNITY_EDITOR
+                                bestPatternIdx = pi;
+                                bestSlotStartWords = matchResult.SlotStartWords;
+                                bestSlotEndWords = matchResult.SlotEndWords;
+#endif
                             }
                         }
                     }
@@ -270,9 +293,22 @@ namespace VoskXR.Commands
                     _slotNames);
 
                 results.Add(new VoskCommandResult(command));
+#if UNITY_EDITOR
+                diagnosticEntries.Add(new ParseDiagnosticEntry
+                {
+                    PatternString = string.Join(" ", _commands[bestCommandIdx].Patterns[bestPatternIdx]),
+                    SlotStartWords = bestSlotStartWords?.ToArray(),
+                    SlotEndWords = bestSlotEndWords?.ToArray(),
+                });
+#endif
                 searchStart = bestEndIdx;
             }
 
+#if UNITY_EDITOR
+            LastParseDiagnostics = diagnosticEntries.Count > 0
+                ? diagnosticEntries.ToArray()
+                : Array.Empty<ParseDiagnosticEntry>();
+#endif
             return results.Count > 0 ? results.ToArray() : Array.Empty<VoskCommandResult>();
         }
 
@@ -378,7 +414,22 @@ namespace VoskXR.Commands
             public int LiteralCount;
             public List<VoskSlotMatch> Slots;
             public int EndIdx;
+#if UNITY_EDITOR
+            public List<int> SlotStartWords;
+            public List<int> SlotEndWords;
+#endif
         }
+
+#if UNITY_EDITOR
+        internal struct ParseDiagnosticEntry
+        {
+            public string PatternString;
+            public int[] SlotStartWords;
+            public int[] SlotEndWords;
+        }
+
+        internal ParseDiagnosticEntry[] LastParseDiagnostics;
+#endif
 
         /// <summary>
         /// Scored matching from a given start position in the token array.
@@ -391,6 +442,10 @@ namespace VoskXR.Commands
             int patternLength = pattern.Length;
             int literalCount = 0;
             List<VoskSlotMatch> slots = null;
+#if UNITY_EDITOR
+            List<int> slotStartWords = null;
+            List<int> slotEndWords = null;
+#endif
 
             for (int patIdx = 0; patIdx < pattern.Length; patIdx++)
             {
@@ -419,6 +474,15 @@ namespace VoskXR.Commands
                     {
                         if (slots == null)
                             slots = new List<VoskSlotMatch>();
+#if UNITY_EDITOR
+                        if (slotStartWords == null)
+                        {
+                            slotStartWords = new List<int>();
+                            slotEndWords = new List<int>();
+                        }
+                        slotStartWords.Add(tokenIdx);
+                        slotEndWords.Add(tokenIdx + consumed);
+#endif
                         slots.Add(new VoskSlotMatch(slotName, matchedValue));
                         tokenIdx += consumed;
                         rawScore += MatchScore;
@@ -461,7 +525,11 @@ namespace VoskXR.Commands
                 Score = normalizedScore,
                 LiteralCount = literalCount,
                 Slots = slots,
-                EndIdx = tokenIdx
+                EndIdx = tokenIdx,
+#if UNITY_EDITOR
+                SlotStartWords = slotStartWords,
+                SlotEndWords = slotEndWords,
+#endif
             };
         }
 
@@ -542,7 +610,7 @@ namespace VoskXR.Commands
             return sb.ToString();
         }
 
-        float ComputeConfidence(string[] tokens, int startIdx, int endIdx,
+        internal static float ComputeConfidence(string[] tokens, int startIdx, int endIdx,
             Dictionary<string, float> wordConfidence)
         {
             if (wordConfidence == null || wordConfidence.Count == 0)

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -50,6 +50,17 @@ namespace VoskXR.Commands
         public event Action<VoskCommand[]> OnCommandsRecognised;
         public event Action<string> OnUnrecognisedSpeech;
 
+#if UNITY_EDITOR
+        /// <summary>
+        /// Diagnostic snapshot of the last utterance processed through the command pipeline.
+        /// The debug window polls this via the <see cref="VoskMatchDiagnostics.Frame"/> field.
+        /// </summary>
+        internal VoskMatchDiagnostics LastMatchDiagnostics { get; private set; }
+
+        /// <summary>Last partial result text from VOSK (updates as the user speaks).</summary>
+        internal string LastPartialResult { get; private set; }
+#endif
+
         VoskCommandParser _parser;
         string _grammarJson;
         bool _grammarApplied;
@@ -307,6 +318,9 @@ namespace VoskXR.Commands
 
             speechRecogniser.OnModelReady += HandleModelReady;
             speechRecogniser.OnResult += HandleResult;
+#if UNITY_EDITOR
+            speechRecogniser.OnPartialResult += HandlePartialResult;
+#endif
 
             if (!Debug.isDebugBuild && freeSpeechMode)
             {
@@ -322,6 +336,9 @@ namespace VoskXR.Commands
 
             speechRecogniser.OnModelReady -= HandleModelReady;
             speechRecogniser.OnResult -= HandleResult;
+#if UNITY_EDITOR
+            speechRecogniser.OnPartialResult -= HandlePartialResult;
+#endif
 
             // Flush any pending buffer on disable
             if (_bufferActive)
@@ -386,14 +403,37 @@ namespace VoskXR.Commands
         {
             var results = _parser.Parse(text, words);
 
+#if UNITY_EDITOR
+            var parseDiag = _parser.LastParseDiagnostics;
+            string[] diagTokens = text.Split(VoskCommandParser.SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+            Dictionary<string, float> diagWordConf = null;
+            if (words != null && words.Length > 0)
+            {
+                diagWordConf = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
+                foreach (var w in words)
+                    if (!string.IsNullOrEmpty(w.Text) && !diagWordConf.ContainsKey(w.Text))
+                        diagWordConf[w.Text] = w.Confidence;
+            }
+#endif
+
             if (results.Length == 0)
             {
+#if UNITY_EDITOR
+                LastMatchDiagnostics = new VoskMatchDiagnostics(
+                    text, words,
+                    new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
+                        null, "no match", false) },
+                    Time.frameCount);
+#endif
                 OnUnrecognisedSpeech?.Invoke(text);
                 return;
             }
 
             float now = Time.time;
             var accepted = new List<VoskCommand>();
+#if UNITY_EDITOR
+            var attempts = new List<VoskMatchAttempt>(results.Length);
+#endif
 
             for (int i = 0; i < results.Length; i++)
             {
@@ -401,21 +441,47 @@ namespace VoskXR.Commands
 
                 // Reject if below score threshold
                 if (cmd.Score < minScore)
+                {
+#if UNITY_EDITOR
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                        $"score {cmd.Score:F2} < minScore {minScore:F2}", false));
+#endif
                     continue;
+                }
 
                 // Reject if below confidence threshold (skip when word data unavailable, i.e. -1)
                 if (cmd.Confidence >= 0f && cmd.Confidence < minConfidence)
+                {
+#if UNITY_EDITOR
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                        $"confidence {cmd.Confidence:F2} < minConfidence {minConfidence:F2}", false));
+#endif
                     continue;
+                }
 
                 // Per-intent debounce
                 if (commandCooldown > 0f &&
                     _lastFireTime.TryGetValue(cmd.Intent, out float lastTime) &&
                     now - lastTime < commandCooldown)
+                {
+#if UNITY_EDITOR
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                        $"debounced ({commandCooldown:F1}s cooldown)", false));
+#endif
                     continue;
+                }
 
                 _lastFireTime[cmd.Intent] = now;
                 accepted.Add(cmd);
+#if UNITY_EDITOR
+                attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf, null, true));
+#endif
             }
+
+#if UNITY_EDITOR
+            LastMatchDiagnostics = new VoskMatchDiagnostics(
+                text, words, attempts.ToArray(), Time.frameCount);
+#endif
 
             if (accepted.Count == 0)
                 return;
@@ -428,5 +494,45 @@ namespace VoskXR.Commands
             if (OnCommandsRecognised != null)
                 OnCommandsRecognised.Invoke(accepted.ToArray());
         }
+
+#if UNITY_EDITOR
+        void HandlePartialResult(string text)
+        {
+            LastPartialResult = text;
+        }
+
+        VoskMatchAttempt BuildAttempt(VoskCommand cmd,
+            VoskCommandParser.ParseDiagnosticEntry[] parseDiag, int index,
+            string[] tokens, Dictionary<string, float> wordConf,
+            string rejectReason, bool isAccepted)
+        {
+            string pattern = null;
+            VoskDiagnosticSlotMatch[] diagSlots = Array.Empty<VoskDiagnosticSlotMatch>();
+
+            if (parseDiag != null && index < parseDiag.Length)
+            {
+                pattern = parseDiag[index].PatternString;
+
+                if (cmd.Slots.Length > 0 && parseDiag[index].SlotStartWords != null)
+                {
+                    int slotCount = Math.Min(cmd.Slots.Length, parseDiag[index].SlotStartWords.Length);
+                    diagSlots = new VoskDiagnosticSlotMatch[slotCount];
+                    for (int s = 0; s < slotCount; s++)
+                    {
+                        int sw = parseDiag[index].SlotStartWords[s];
+                        int ew = parseDiag[index].SlotEndWords[s];
+                        float slotConf = VoskCommandParser.ComputeConfidence(tokens, sw, ew, wordConf);
+                        diagSlots[s] = new VoskDiagnosticSlotMatch(
+                            cmd.Slots[s].Name, cmd.Slots[s].Value, sw, ew, slotConf);
+                    }
+                }
+            }
+
+            return new VoskMatchAttempt(
+                cmd.Intent, pattern, cmd.Score, minScore,
+                cmd.Confidence, minConfidence, diagSlots,
+                rejectReason, isAccepted);
+        }
+#endif
     }
 }

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -239,7 +239,34 @@ namespace VoskXR.Commands
         // Test-only setters. Production callers configure via the Inspector.
         internal float BufferWindow { set => bufferWindow = value; }
         internal float CommandCooldown { set => commandCooldown = value; }
-        internal VoskSpeechRecogniser SpeechRecogniser { set => speechRecogniser = value; }
+        internal VoskSpeechRecogniser SpeechRecogniser
+        {
+            set
+            {
+                // Unsubscribe from the old recogniser if any.
+                if (speechRecogniser != null)
+                {
+                    speechRecogniser.OnModelReady -= HandleModelReady;
+                    speechRecogniser.OnResult -= HandleResult;
+#if UNITY_EDITOR
+                    speechRecogniser.OnPartialResult -= HandlePartialResult;
+#endif
+                }
+
+                speechRecogniser = value;
+
+                // Subscribe immediately when the component is already active
+                // (Edit Mode tests may not re-trigger OnEnable after SetActive).
+                if (value != null && isActiveAndEnabled)
+                {
+                    value.OnModelReady += HandleModelReady;
+                    value.OnResult += HandleResult;
+#if UNITY_EDITOR
+                    value.OnPartialResult += HandlePartialResult;
+#endif
+                }
+            }
+        }
 
         void RebuildParserAndGrammar(VoskCommandDefinition[] commands)
         {

--- a/Runtime/Commands/VoskMatchDiagnostics.cs
+++ b/Runtime/Commands/VoskMatchDiagnostics.cs
@@ -1,0 +1,126 @@
+#if UNITY_EDITOR
+using System;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Diagnostic snapshot of a single utterance's journey through the command pipeline.
+    /// Populated by <see cref="VoskCommandRecogniser"/> at the end of each parse cycle.
+    /// The Editor debug window polls <see cref="Frame"/> to detect new data.
+    /// </summary>
+    internal readonly struct VoskMatchDiagnostics
+    {
+        /// <summary>The raw text that entered the parser.</summary>
+        public readonly string InputText;
+
+        /// <summary>Per-word confidence data from VOSK (may be empty for injected text).</summary>
+        public readonly VoskWord[] Words;
+
+        /// <summary>
+        /// One entry per command extracted (or attempted) from this utterance.
+        /// Covers both accepted and rejected matches, plus a "no match" entry
+        /// when the parser found nothing.
+        /// </summary>
+        public readonly VoskMatchAttempt[] Attempts;
+
+        /// <summary>
+        /// <see cref="UnityEngine.Time.frameCount"/> when this diagnostic was created.
+        /// The debug window compares against its last-seen frame to detect new data.
+        /// </summary>
+        public readonly int Frame;
+
+        public VoskMatchDiagnostics(string inputText, VoskWord[] words,
+            VoskMatchAttempt[] attempts, int frame)
+        {
+            InputText = inputText;
+            Words = words ?? Array.Empty<VoskWord>();
+            Attempts = attempts ?? Array.Empty<VoskMatchAttempt>();
+            Frame = frame;
+        }
+    }
+
+    /// <summary>
+    /// Diagnostic detail for a single command match attempt within an utterance.
+    /// </summary>
+    internal readonly struct VoskMatchAttempt
+    {
+        /// <summary>Matched intent name, or null if no pattern matched.</summary>
+        public readonly string Intent;
+
+        /// <summary>The pattern string that matched (e.g. "fire {weapon}"), or null.</summary>
+        public readonly string Pattern;
+
+        /// <summary>Normalised match score from the parser (0.0–1.0).</summary>
+        public readonly float Score;
+
+        /// <summary>The minScore threshold that was applied.</summary>
+        public readonly float MinScore;
+
+        /// <summary>Minimum word confidence across the matched token span.</summary>
+        public readonly float AggregateConfidence;
+
+        /// <summary>The minConfidence threshold that was applied.</summary>
+        public readonly float MinConfidence;
+
+        /// <summary>Per-slot diagnostic detail with word positions and confidence.</summary>
+        public readonly VoskDiagnosticSlotMatch[] Slots;
+
+        /// <summary>
+        /// Human-readable rejection reason, or null if the command was accepted.
+        /// Examples: "score 0.42 &lt; minScore 0.60", "no match".
+        /// </summary>
+        public readonly string RejectReason;
+
+        /// <summary>True if the command passed all thresholds and was fired.</summary>
+        public readonly bool IsAccepted;
+
+        public VoskMatchAttempt(string intent, string pattern, float score, float minScore,
+            float aggregateConfidence, float minConfidence, VoskDiagnosticSlotMatch[] slots,
+            string rejectReason, bool isAccepted)
+        {
+            Intent = intent;
+            Pattern = pattern;
+            Score = score;
+            MinScore = minScore;
+            AggregateConfidence = aggregateConfidence;
+            MinConfidence = minConfidence;
+            Slots = slots ?? Array.Empty<VoskDiagnosticSlotMatch>();
+            RejectReason = rejectReason;
+            IsAccepted = isAccepted;
+        }
+    }
+
+    /// <summary>
+    /// Diagnostic-only slot match with word-level position and confidence data.
+    /// Separate from the runtime <see cref="VoskSlotMatch"/> to avoid enriching
+    /// the hot path with fields only the debug window uses.
+    /// </summary>
+    internal readonly struct VoskDiagnosticSlotMatch
+    {
+        /// <summary>Slot name (e.g. "weapon").</summary>
+        public readonly string Name;
+
+        /// <summary>Matched canonical value (e.g. "missiles").</summary>
+        public readonly string Value;
+
+        /// <summary>Index of the first token consumed by this slot (inclusive).</summary>
+        public readonly int StartWord;
+
+        /// <summary>Index past the last token consumed by this slot (exclusive).</summary>
+        public readonly int EndWord;
+
+        /// <summary>Minimum word confidence across the slot's token span (-1 if unavailable).</summary>
+        public readonly float Confidence;
+
+        public VoskDiagnosticSlotMatch(string name, string value,
+            int startWord, int endWord, float confidence)
+        {
+            Name = name;
+            Value = value;
+            StartWord = startWord;
+            EndWord = endWord;
+            Confidence = confidence;
+        }
+    }
+}
+#endif

--- a/Runtime/Commands/VoskMatchDiagnostics.cs.meta
+++ b/Runtime/Commands/VoskMatchDiagnostics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3c7e4f1b2d84a6e9f0c5d3e7b1a9f42

--- a/Runtime/EditorMicBackend.cs
+++ b/Runtime/EditorMicBackend.cs
@@ -57,6 +57,10 @@ namespace VoskXR
         internal bool IsInitialised { get; private set; }
         internal bool IsRunning { get; private set; }
 
+        internal float PreAgcRms { get; private set; }
+        internal float PostAgcRms { get; private set; }
+        internal float AgcGain => _agc.CurrentGain;
+
         internal async Task<bool> InitialiseAsync(
             string modelPath,
             float sampleRate,
@@ -351,7 +355,10 @@ namespace VoskXR
             int dsCount = _downsampler.Process(_workBuffer, available, _downsampledBuffer);
             if (dsCount == 0) return;
 
+            PreAgcRms = ComputeRms(_downsampledBuffer, dsCount);
             _agc.Process(_downsampledBuffer, dsCount);
+            PostAgcRms = ComputeRms(_downsampledBuffer, dsCount);
+
             FloatToInt16(_downsampledBuffer, _int16Buffer, dsCount);
 
             int result = VoskNative.vosk_recognizer_accept_waveform_s(
@@ -385,6 +392,14 @@ namespace VoskXR
             var r = _resultQueue.Dequeue();
             json = r.Json; isFinal = r.IsFinal;
             return true;
+        }
+
+        static float ComputeRms(float[] samples, int count)
+        {
+            float sum = 0f;
+            for (int i = 0; i < count; i++)
+                sum += samples[i] * samples[i];
+            return count > 0 ? (float)Math.Sqrt(sum / count) : 0f;
         }
 
         // Float [-1, 1] → int16, with clamping. Matches vosk_bridge.cpp:44-51.

--- a/Runtime/EditorMicBackend.cs
+++ b/Runtime/EditorMicBackend.cs
@@ -394,7 +394,7 @@ namespace VoskXR
             return true;
         }
 
-        static float ComputeRms(float[] samples, int count)
+        internal static float ComputeRms(float[] samples, int count)
         {
             float sum = 0f;
             for (int i = 0; i < count; i++)

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -49,6 +49,16 @@ namespace VoskXR
         EditorMicBackend _editorBackend;
 #endif
 
+#if UNITY_EDITOR
+        internal VoskResult EditorLastResult { get; private set; }
+#endif
+
+#if UNITY_EDITOR_WIN
+        internal float EditorPreAgcRms => _editorBackend?.PreAgcRms ?? 0f;
+        internal float EditorPostAgcRms => _editorBackend?.PostAgcRms ?? 0f;
+        internal float EditorAgcGain => _editorBackend?.AgcGain ?? 1f;
+#endif
+
         public bool IsModelReady { get; private set; }
 
         public bool IsInitialised
@@ -335,10 +345,12 @@ namespace VoskXR
 
         void DispatchFinalResult(string text, VoskWord[] words, VoskAlternative[] alternatives)
         {
+            var result = new VoskResult(text, words, alternatives);
+#if UNITY_EDITOR
+            EditorLastResult = result;
+#endif
             OnFinalResult?.Invoke(text);
-
-            if (OnResult != null)
-                OnResult.Invoke(new VoskResult(text, words, alternatives));
+            OnResult?.Invoke(result);
         }
 
         static void AssertMainThread(string method)

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -424,7 +424,11 @@ namespace VoskXR
                 VoskAlternative[] alternatives = Array.Empty<VoskAlternative>();
                 VoskWord[] words = Array.Empty<VoskWord>();
 
-                if (OnResult != null)
+                bool needFullParse = OnResult != null;
+#if UNITY_EDITOR
+                needFullParse = true;
+#endif
+                if (needFullParse)
                 {
                     alternatives = ParseAlternativesFromJson(json);
                     if (alternatives.Length > 0 && alternatives[0].Words.Length > 0)
@@ -534,7 +538,10 @@ namespace VoskXR
                 int objEnd = json.IndexOf('}', objStart);
                 if (objEnd < 0 || objEnd > arrayEnd) break;
 
-                float conf = ParseFloatValue(json, objStart, objEnd, "\"conf\"");
+                // "conf" is absent when maxAlternatives > 0; use -1 sentinel.
+                bool hasConf = json.IndexOf("\"conf\"", objStart, objEnd - objStart,
+                    StringComparison.Ordinal) >= 0;
+                float conf = hasConf ? ParseFloatValue(json, objStart, objEnd, "\"conf\"") : -1f;
                 float start = ParseFloatValue(json, objStart, objEnd, "\"start\"");
                 float end = ParseFloatValue(json, objStart, objEnd, "\"end\"");
                 string word = ParseStringValue(json, objStart, objEnd, "\"word\"");

--- a/Samples~/CommandRecognition/CommandDemo.cs
+++ b/Samples~/CommandRecognition/CommandDemo.cs
@@ -36,7 +36,6 @@ public class CommandDemo : MonoBehaviour
         {
             // Slots/commands/sets came from ScriptableObject assets in Awake().
             // Just wire events and start recognition.
-            LogActiveSets();
             commandRecogniser.OnCommandRecognised += OnCommand;
             commandRecogniser.OnCommandsRecognised += OnCommandBatch;
             commandRecogniser.OnUnrecognisedSpeech += OnUnrecognised;
@@ -150,7 +149,6 @@ public class CommandDemo : MonoBehaviour
 
         // Activate all sets for demo — in a real game you'd activate per game state
         commandRecogniser.SetActiveSets("weapons", "navigation", "common");
-        LogActiveSets();
 
         commandRecogniser.OnCommandRecognised += OnCommand;
         commandRecogniser.OnCommandsRecognised += OnCommandBatch;
@@ -171,47 +169,8 @@ public class CommandDemo : MonoBehaviour
 
     void OnCommand(VoskCommand cmd)
     {
-        Debug.Log($"[CommandDemo] Command: {cmd.Intent} " +
-            $"(confidence={cmd.Confidence:F2}, score={cmd.Score:F2})");
-
         switch (cmd.Intent)
         {
-            case Intents.LaunchWeapon:
-                string weapon = cmd.GetSlot("weapon");
-                string qty = cmd.HasSlot("quantity") ? cmd.GetSlot("quantity") : "1";
-                string target = cmd.GetSlot("target");
-                Debug.Log($"[CommandDemo]   Launch {qty} {weapon} at {target}");
-                break;
-
-            case Intents.CeaseFire:
-                Debug.Log("[CommandDemo]   Cease fire!");
-                break;
-
-            case Intents.ResumeFire:
-                Debug.Log("[CommandDemo]   Resume fire!");
-                break;
-
-            case Intents.SetDistanceNamed:
-                Debug.Log($"[CommandDemo]   Set distance {cmd.GetSlot("range")} " +
-                    $"from {cmd.GetSlot("target")}");
-                break;
-
-            case Intents.ApproachTarget:
-                Debug.Log($"[CommandDemo]   Approach {cmd.GetSlot("target")}");
-                break;
-
-            case Intents.RetreatFromTarget:
-                Debug.Log($"[CommandDemo]   Retreat from {cmd.GetSlot("target")}");
-                break;
-
-            case Intents.SetHeading:
-                string hdg = cmd.GetSlot("heading");
-                int hdgVal = VoskNumberParser.ParseDigitSequence(hdg);
-                string elevStr = cmd.HasSlot("elevation") ? cmd.GetSlot("elevation") : null;
-                int elevVal = elevStr != null ? VoskNumberParser.ParseDigitSequence(elevStr) : -1;
-                Debug.Log($"[CommandDemo]   Heading={hdgVal} (raw=\"{hdg}\"), Elevation={elevVal}");
-                break;
-
             case Intents.ModeWeapons:
                 SwitchToWeaponsMode();
                 break;
@@ -230,52 +189,30 @@ public class CommandDemo : MonoBehaviour
         }
     }
 
-    void OnCommandBatch(VoskCommand[] commands)
-    {
-        Debug.Log($"[CommandDemo] Batch: {commands.Length} command(s) from single utterance");
-        for (int i = 0; i < commands.Length; i++)
-            Debug.Log($"[CommandDemo]   [{i}] {commands[i].Intent} (score={commands[i].Score:F2})");
-    }
+    void OnCommandBatch(VoskCommand[] commands) { }
 
-    void OnUnrecognised(string text)
-    {
-        Debug.Log($"[CommandDemo] Unrecognised: \"{text}\"");
-    }
+    void OnUnrecognised(string text) { }
 
     // --- Mode switching (voice-triggered or called from UI/game logic) ---
-
-    void LogActiveSets()
-    {
-        var sets = commandRecogniser.ActiveSetNames;
-        Debug.Log($"[CommandDemo] Active sets: [{string.Join(", ", sets)}]");
-    }
 
     public void SwitchToWeaponsMode()
     {
         commandRecogniser.SetActiveSets("weapons", "common");
-        LogActiveSets();
-        Debug.Log("[CommandDemo] Switched to WEAPONS mode");
     }
 
     public void SwitchToNavigationMode()
     {
         commandRecogniser.SetActiveSets("navigation", "common");
-        LogActiveSets();
-        Debug.Log("[CommandDemo] Switched to NAVIGATION mode");
     }
 
     public void SwitchToAllModes()
     {
         commandRecogniser.SetActiveSets("weapons", "navigation", "common");
-        LogActiveSets();
-        Debug.Log("[CommandDemo] Switched to ALL mode");
     }
 
     public void DisableAllModes()
     {
         commandRecogniser.SetActiveSets();
-        LogActiveSets();
-        Debug.Log("[CommandDemo] All commands DISABLED — auto-restoring in 5s");
         StartCoroutine(RestoreAllModesAfterDelay(5f));
     }
 
@@ -283,7 +220,5 @@ public class CommandDemo : MonoBehaviour
     {
         yield return new WaitForSeconds(delay);
         commandRecogniser.SetActiveSets("weapons", "navigation", "common");
-        LogActiveSets();
-        Debug.Log("[CommandDemo] Auto-restored ALL mode");
     }
 }

--- a/THIRD_PARTY_NOTICES.md.meta
+++ b/THIRD_PARTY_NOTICES.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f2e6e82699db9b74799e7dc068a3ac7b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/AudioMetricTests.cs
+++ b/Tests/Editor/AudioMetricTests.cs
@@ -1,0 +1,85 @@
+#if UNITY_EDITOR_WIN
+using NUnit.Framework;
+using UnityEngine;
+using VoskXR;
+
+namespace VoskXR.Tests.Editor
+{
+    /// <summary>
+    /// Category 5: Audio metric tests (ComputeRms, forwarded properties).
+    /// Windows Editor only — the underlying code is #if UNITY_EDITOR_WIN guarded.
+    /// </summary>
+    public class AudioMetricTests
+    {
+        // 5.4
+        [Test]
+        public void ComputeRms_EmptyBuffer_ReturnsZero()
+        {
+            float result = EditorMicBackend.ComputeRms(new float[0], 0);
+            Assert.AreEqual(0f, result);
+        }
+
+        // 5.5
+        [Test]
+        public void ComputeRms_KnownSignal_ReturnsExpected()
+        {
+            // Buffer of constant 0.5 values → RMS = sqrt(0.25) = 0.5
+            var buffer = new float[100];
+            for (int i = 0; i < buffer.Length; i++)
+                buffer[i] = 0.5f;
+
+            float result = EditorMicBackend.ComputeRms(buffer, buffer.Length);
+            Assert.AreEqual(0.5f, result, 1e-5f);
+        }
+
+        // 5.6
+        [Test]
+        public void ForwardedEditorPreAgcRms_NullBackend_ReturnsZero()
+        {
+            var go = new GameObject("SpeechTest");
+            try
+            {
+                var speech = go.AddComponent<VoskSpeechRecogniser>();
+                // _editorBackend is null before InitialiseAsync
+                Assert.AreEqual(0f, speech.EditorPreAgcRms);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        // 5.7
+        [Test]
+        public void ForwardedEditorPostAgcRms_NullBackend_ReturnsZero()
+        {
+            var go = new GameObject("SpeechTest");
+            try
+            {
+                var speech = go.AddComponent<VoskSpeechRecogniser>();
+                Assert.AreEqual(0f, speech.EditorPostAgcRms);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        // 5.8
+        [Test]
+        public void ForwardedEditorAgcGain_NullBackend_ReturnsOne()
+        {
+            var go = new GameObject("SpeechTest");
+            try
+            {
+                var speech = go.AddComponent<VoskSpeechRecogniser>();
+                Assert.AreEqual(1f, speech.EditorAgcGain);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Editor/AudioMetricTests.cs.meta
+++ b/Tests/Editor/AudioMetricTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5fcea217ca92cb64a93e97a6a605ec75

--- a/Tests/Editor/VoskCommandParserDiagnosticTests.cs
+++ b/Tests/Editor/VoskCommandParserDiagnosticTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Editor
+{
+    /// <summary>
+    /// Category 3: Parser diagnostic fields (LastParseDiagnostics, slot positions,
+    /// ComputeConfidence, internal access).
+    /// </summary>
+    public class VoskCommandParserDiagnosticTests
+    {
+        static VoskSlotDefinition[] MakeSlots() => new[]
+        {
+            new VoskSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+            new VoskSlotDefinition("target", new[] { "hotel one", "hotel two" }),
+            new VoskSlotDefinition("quantity", new[] { "all", "one", "two" }),
+        };
+
+        static VoskCommandDefinition[] MakeCommands() => new[]
+        {
+            new VoskCommandDefinition("launch_weapon", new[]
+            {
+                new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
+                new[] { "shoot", "{weapon}" },
+            }),
+            new VoskCommandDefinition("cease_fire", new[]
+            {
+                new[] { "cease", "fire" },
+            }),
+        };
+
+        VoskCommandParser CreateParser() =>
+            new VoskCommandParser(MakeSlots(), MakeCommands());
+
+        // 3.1
+        [Test]
+        public void LastParseDiagnostics_EmptyOnNoInput()
+        {
+            var parser = CreateParser();
+            parser.Parse("", null);
+
+            Assert.IsNotNull(parser.LastParseDiagnostics);
+            Assert.AreEqual(0, parser.LastParseDiagnostics.Length);
+        }
+
+        // 3.2
+        [Test]
+        public void LastParseDiagnostics_EmptyOnNoMatch()
+        {
+            var parser = CreateParser();
+            parser.Parse("xyz abc", null);
+
+            Assert.IsNotNull(parser.LastParseDiagnostics);
+            Assert.AreEqual(0, parser.LastParseDiagnostics.Length);
+        }
+
+        // 3.3
+        [Test]
+        public void LastParseDiagnostics_OneEntryPerCommand()
+        {
+            var parser = CreateParser();
+            parser.Parse("shoot missiles", null);
+
+            Assert.AreEqual(1, parser.LastParseDiagnostics.Length);
+        }
+
+        // 3.4
+        [Test]
+        public void PatternString_RecordedCorrectly()
+        {
+            var parser = CreateParser();
+            parser.Parse("shoot missiles", null);
+
+            Assert.AreEqual("shoot {weapon}",
+                parser.LastParseDiagnostics[0].PatternString);
+        }
+
+        // 3.5
+        [Test]
+        public void SlotStartWords_Recorded()
+        {
+            var parser = CreateParser();
+            // "shoot missiles" → pattern "shoot {weapon}", slot at token 1
+            parser.Parse("shoot missiles", null);
+
+            var entry = parser.LastParseDiagnostics[0];
+            Assert.IsNotNull(entry.SlotStartWords);
+            Assert.AreEqual(1, entry.SlotStartWords.Length);
+            Assert.AreEqual(1, entry.SlotStartWords[0]);
+        }
+
+        // 3.6
+        [Test]
+        public void SlotEndWords_Recorded_Exclusive()
+        {
+            var parser = CreateParser();
+            // "shoot missiles" → {weapon} consumes 1 token starting at 1 → EndWord = 2
+            parser.Parse("shoot missiles", null);
+
+            var entry = parser.LastParseDiagnostics[0];
+            Assert.IsNotNull(entry.SlotEndWords);
+            Assert.AreEqual(1, entry.SlotEndWords.Length);
+            Assert.AreEqual(2, entry.SlotEndWords[0]);
+        }
+
+        // 3.7
+        [Test]
+        public void MultiSlot_Positions()
+        {
+            var parser = CreateParser();
+            // "launch all missiles target hotel one" →
+            //   pattern "launch {?quantity} {weapon} target {target}"
+            //   {quantity}=all at [1,2), {weapon}=missiles at [2,3), {target}=hotel one at [4,6)
+            parser.Parse("launch all missiles target hotel one", null);
+
+            var entry = parser.LastParseDiagnostics[0];
+            Assert.AreEqual(3, entry.SlotStartWords.Length);
+            Assert.AreEqual(3, entry.SlotEndWords.Length);
+
+            // {quantity}
+            Assert.AreEqual(1, entry.SlotStartWords[0]);
+            Assert.AreEqual(2, entry.SlotEndWords[0]);
+            // {weapon}
+            Assert.AreEqual(2, entry.SlotStartWords[1]);
+            Assert.AreEqual(3, entry.SlotEndWords[1]);
+            // {target}
+            Assert.AreEqual(4, entry.SlotStartWords[2]);
+            Assert.AreEqual(6, entry.SlotEndWords[2]);
+        }
+
+        // 3.8
+        [Test]
+        public void MultipleCommandsExtracted_MultipleEntries()
+        {
+            var parser = CreateParser();
+            // Sequential extraction: "cease fire" then "shoot missiles"
+            parser.Parse("cease fire shoot missiles", null);
+
+            Assert.AreEqual(2, parser.LastParseDiagnostics.Length);
+            Assert.AreEqual("cease fire", parser.LastParseDiagnostics[0].PatternString);
+            Assert.AreEqual("shoot {weapon}", parser.LastParseDiagnostics[1].PatternString);
+        }
+
+        // 3.9
+        [Test]
+        public void ComputeConfidence_InternalAccess()
+        {
+            var tokens = new[] { "cease", "fire" };
+            var wordConf = new Dictionary<string, float>
+            {
+                { "cease", 0.9f },
+                { "fire", 0.7f },
+            };
+
+            float conf = VoskCommandParser.ComputeConfidence(tokens, 0, 2, wordConf);
+            Assert.AreEqual(0.7f, conf, 1e-5f, "Should return min confidence across span");
+        }
+
+        [Test]
+        public void ComputeConfidence_NoWordData_ReturnsNegativeOne()
+        {
+            var tokens = new[] { "cease", "fire" };
+            float conf = VoskCommandParser.ComputeConfidence(tokens, 0, 2, null);
+            Assert.AreEqual(-1f, conf);
+        }
+
+        // 3.10
+        [Test]
+        public void UnkToken_InternalAccess()
+        {
+            Assert.AreEqual("[unk]", VoskCommandParser.UnkToken);
+        }
+
+        [Test]
+        public void SplitSeparator_InternalAccess()
+        {
+            Assert.IsNotNull(VoskCommandParser.SplitSeparator);
+            Assert.AreEqual(1, VoskCommandParser.SplitSeparator.Length);
+            Assert.AreEqual(' ', VoskCommandParser.SplitSeparator[0]);
+        }
+    }
+}

--- a/Tests/Editor/VoskCommandParserDiagnosticTests.cs.meta
+++ b/Tests/Editor/VoskCommandParserDiagnosticTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 829e56632971b0f4aab9aa191bf8acb9

--- a/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs
+++ b/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs
@@ -1,0 +1,234 @@
+using NUnit.Framework;
+using UnityEngine;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Editor
+{
+    /// <summary>
+    /// Category 4: Recogniser diagnostic population (LastMatchDiagnostics,
+    /// rejection reasons, per-slot confidence, partial result).
+    /// </summary>
+    public class VoskCommandRecogniserDiagnosticTests
+    {
+        GameObject _go;
+        VoskCommandRecogniser _recogniser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("DiagTestRecogniser");
+            _recogniser = _go.AddComponent<VoskCommandRecogniser>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                Object.DestroyImmediate(_go);
+        }
+
+        static VoskSlotDefinition[] MakeSlots() => new[]
+        {
+            new VoskSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+            new VoskSlotDefinition("target", new[] { "hotel one", "hotel two" }),
+            new VoskSlotDefinition("quantity", new[] { "all", "one", "two" }),
+        };
+
+        static VoskCommandDefinition[] MakeCommands() => new[]
+        {
+            new VoskCommandDefinition("launch_weapon", new[]
+            {
+                new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
+                new[] { "shoot", "{weapon}" },
+            }),
+            new VoskCommandDefinition("cease_fire", new[]
+            {
+                new[] { "cease", "fire" },
+            }),
+        };
+
+        void ConfigureSync()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
+        }
+
+        // 4.1
+        [Test]
+        public void LastMatchDiagnostics_UpdatedAfterParse()
+        {
+            ConfigureSync();
+            _recogniser.InjectText("cease fire");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual("cease fire", diag.InputText);
+        }
+
+        // 4.2
+        [Test]
+        public void NoMatch_CreatesSingleAttempt_WithNoMatchReason()
+        {
+            ConfigureSync();
+            _recogniser.InjectText("hello world");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsNull(diag.Attempts[0].Intent);
+            Assert.AreEqual("no match", diag.Attempts[0].RejectReason);
+            Assert.IsFalse(diag.Attempts[0].IsAccepted);
+        }
+
+        // 4.3
+        [Test]
+        public void ScoreRejection_ReasonFormat()
+        {
+            ConfigureSync();
+            // "launch missiles" partially matches the 5-element pattern with a low score (~0.08).
+            // Default minScore is 0.6.
+            _recogniser.InjectText("launch missiles");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsFalse(diag.Attempts[0].IsAccepted);
+            StringAssert.Contains("score", diag.Attempts[0].RejectReason);
+            StringAssert.Contains("minScore", diag.Attempts[0].RejectReason);
+        }
+
+        // 4.4
+        [Test]
+        public void ConfidenceRejection_ReasonFormat()
+        {
+            ConfigureSync();
+            // "cease fire" matches perfectly (score 1.0) but low confidence words.
+            // Default minConfidence is 0.4, so 0.2 triggers rejection.
+            var words = VoskSpeechRecogniser.CreateSimulatedWords("cease fire", 0.2f);
+            _recogniser.InjectText("cease fire", words);
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsFalse(diag.Attempts[0].IsAccepted);
+            StringAssert.Contains("confidence", diag.Attempts[0].RejectReason);
+            StringAssert.Contains("minConfidence", diag.Attempts[0].RejectReason);
+        }
+
+        // 4.5
+        [Test]
+        public void DebounceRejection_Reason()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 1.0f;
+
+            // First injection is accepted.
+            _recogniser.InjectText("cease fire");
+            // Second injection within same frame → debounced.
+            _recogniser.InjectText("cease fire");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsFalse(diag.Attempts[0].IsAccepted);
+            StringAssert.Contains("debounced", diag.Attempts[0].RejectReason);
+        }
+
+        // 4.6
+        [Test]
+        public void AcceptedCommand_NoRejection()
+        {
+            ConfigureSync();
+            _recogniser.InjectText("cease fire");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsTrue(diag.Attempts[0].IsAccepted);
+            Assert.IsNull(diag.Attempts[0].RejectReason);
+            Assert.AreEqual("cease_fire", diag.Attempts[0].Intent);
+        }
+
+        // 4.7
+        [Test]
+        public void PerSlotConfidence_Computed()
+        {
+            ConfigureSync();
+            var words = new[]
+            {
+                new VoskWord("shoot", 0.9f, 0f, 0.3f),
+                new VoskWord("missiles", 0.75f, 0.3f, 0.6f),
+            };
+            _recogniser.InjectText("shoot missiles", words);
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.IsTrue(diag.Attempts[0].IsAccepted);
+            Assert.AreEqual(1, diag.Attempts[0].Slots.Length);
+
+            var slot = diag.Attempts[0].Slots[0];
+            Assert.AreEqual("weapon", slot.Name);
+            Assert.AreEqual("missiles", slot.Value);
+            Assert.AreEqual(0.75f, slot.Confidence, 1e-5f);
+        }
+
+        // 4.8
+        [Test]
+        public void PerSlotConfidence_NegativeOneForInjectedText()
+        {
+            ConfigureSync();
+            // No word data → confidence unavailable
+            _recogniser.InjectText("shoot missiles");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(1, diag.Attempts.Length);
+            Assert.AreEqual(1, diag.Attempts[0].Slots.Length);
+            Assert.AreEqual(-1f, diag.Attempts[0].Slots[0].Confidence);
+        }
+
+        // 4.9
+        [Test]
+        public void MultipleCommands_MultipleAttempts()
+        {
+            ConfigureSync();
+            // Sequential extraction: "cease fire" + "shoot missiles"
+            _recogniser.InjectText("cease fire shoot missiles");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(2, diag.Attempts.Length);
+            Assert.AreEqual("cease_fire", diag.Attempts[0].Intent);
+            Assert.AreEqual("launch_weapon", diag.Attempts[1].Intent);
+            Assert.IsTrue(diag.Attempts[0].IsAccepted);
+            Assert.IsTrue(diag.Attempts[1].IsAccepted);
+        }
+
+        // 4.10
+        [Test]
+        public void Frame_SetToTimeFrameCount()
+        {
+            ConfigureSync();
+            _recogniser.InjectText("cease fire");
+
+            var diag = _recogniser.LastMatchDiagnostics;
+            Assert.AreEqual(Time.frameCount, diag.Frame);
+        }
+
+        // 4.12
+        [Test]
+        public void LastPartialResult_EmptyStringHandling()
+        {
+            // Assign SpeechRecogniser after AddComponent so the setter subscribes
+            // while the component is already active (Edit Mode OnEnable is unreliable).
+            var go = new GameObject("PartialResultTest");
+            var speech = go.AddComponent<VoskSpeechRecogniser>();
+            var recogniser = go.AddComponent<VoskCommandRecogniser>();
+            recogniser.SpeechRecogniser = speech;
+
+            recogniser.Configure(MakeSlots(), MakeCommands());
+            recogniser.BufferWindow = 0f;
+            recogniser.CommandCooldown = 0f;
+
+            speech.InjectPartialResult("");
+
+            Assert.AreEqual("", recogniser.LastPartialResult);
+            Object.DestroyImmediate(go);
+        }
+    }
+}

--- a/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs.meta
+++ b/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e595bec382706dc4e8890310ac7ea05b

--- a/Tests/Editor/VoskMatchDiagnosticsTests.cs
+++ b/Tests/Editor/VoskMatchDiagnosticsTests.cs
@@ -1,0 +1,112 @@
+using NUnit.Framework;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Editor
+{
+    /// <summary>
+    /// Category 2: Diagnostic data structure construction and immutability.
+    /// </summary>
+    public class VoskMatchDiagnosticsTests
+    {
+        // 2.1
+        [Test]
+        public void Constructor_NullWords_DefaultsToEmpty()
+        {
+            var diag = new VoskMatchDiagnostics("hello", null,
+                new VoskMatchAttempt[0], 1);
+
+            Assert.IsNotNull(diag.Words);
+            Assert.AreEqual(0, diag.Words.Length);
+        }
+
+        // 2.2
+        [Test]
+        public void Constructor_NullAttempts_DefaultsToEmpty()
+        {
+            var diag = new VoskMatchDiagnostics("hello",
+                new VoskWord[0], null, 1);
+
+            Assert.IsNotNull(diag.Attempts);
+            Assert.AreEqual(0, diag.Attempts.Length);
+        }
+
+        // 2.3
+        [Test]
+        public void AttemptConstructor_NullSlots_DefaultsToEmpty()
+        {
+            var attempt = new VoskMatchAttempt(
+                "fire", "fire {weapon}", 0.9f, 0.6f, 0.85f, 0.4f,
+                null, null, true);
+
+            Assert.IsNotNull(attempt.Slots);
+            Assert.AreEqual(0, attempt.Slots.Length);
+        }
+
+        // 2.4 — readonly struct enforced at compile time. This test verifies
+        //        the fields are read-only by checking they survive round-trip.
+        [Test]
+        public void Structs_AreReadonly_FieldsPreserved()
+        {
+            var diag = new VoskMatchDiagnostics("text",
+                new[] { new VoskWord("w", 0.9f, 0f, 0.3f) },
+                new[] { new VoskMatchAttempt("intent", "pattern", 1f, 0.6f, 0.9f, 0.4f, null, null, true) },
+                42);
+
+            Assert.AreEqual("text", diag.InputText);
+            Assert.AreEqual(42, diag.Frame);
+            Assert.AreEqual(1, diag.Words.Length);
+            Assert.AreEqual(1, diag.Attempts.Length);
+        }
+
+        // 2.5
+        [Test]
+        public void Frame_StoresFrameCountSnapshot()
+        {
+            var diag = new VoskMatchDiagnostics("text", null, null, 42);
+            Assert.AreEqual(42, diag.Frame);
+        }
+
+        // 2.6
+        [Test]
+        public void Attempt_Accepted_NoRejectReason()
+        {
+            var attempt = new VoskMatchAttempt(
+                "fire", "fire {weapon}", 0.9f, 0.6f, 0.85f, 0.4f,
+                null, null, true);
+
+            Assert.IsTrue(attempt.IsAccepted);
+            Assert.IsNull(attempt.RejectReason);
+        }
+
+        // 2.7
+        [Test]
+        public void Attempt_Rejected_HasRejectReason()
+        {
+            var attempt = new VoskMatchAttempt(
+                "fire", "fire {weapon}", 0.3f, 0.6f, 0.85f, 0.4f,
+                null, "score 0.30 < minScore 0.60", false);
+
+            Assert.IsFalse(attempt.IsAccepted);
+            Assert.IsNotNull(attempt.RejectReason);
+            Assert.AreEqual("score 0.30 < minScore 0.60", attempt.RejectReason);
+        }
+
+        // 2.8
+        [Test]
+        public void SlotMatch_Confidence_NegativeOneWhenUnavailable()
+        {
+            var slot = new VoskDiagnosticSlotMatch("weapon", "missiles", 1, 2, -1f);
+            Assert.AreEqual(-1f, slot.Confidence);
+        }
+
+        // 2.9
+        [Test]
+        public void SlotMatch_WordSpan_StartEndCorrect()
+        {
+            var slot = new VoskDiagnosticSlotMatch("target", "hotel one", 2, 4, 0.9f);
+            Assert.AreEqual(2, slot.StartWord);
+            Assert.AreEqual(4, slot.EndWord);
+        }
+    }
+}

--- a/Tests/Editor/VoskMatchDiagnosticsTests.cs.meta
+++ b/Tests/Editor/VoskMatchDiagnosticsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ecc5d938e1ccbe248927f80bd4a6a9c0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
  ## Summary

  - **Command Debug Window** (`Window > VOSK XR > Command Debug`) — Editor-only two-panel window for
  inspecting the full command pipeline in real time during Play Mode. Left panel shows audio levels
  (pre/post-AGC RMS, gain), partial/final results, per-word confidence bars, and n-best alternatives.
  Right panel shows active command sets, per-attempt match breakdowns with score/confidence/threshold
  pass/fail, slot word positions, and a scrolling match history (last 20 entries). Bottom toolbar
  provides text injection, pause/clear controls.
  - **Diagnostic structs** — `VoskMatchDiagnostics`, `VoskMatchAttempt`, `VoskDiagnosticSlotMatch`
  captured per utterance behind `#if UNITY_EDITOR`, zero cost in builds.
  - **Fixes** — pause/resume now freezes display correctly; Enter-key injection handles IMGUI event
  ordering and KeypadEnter; word confidence shows `[n/a]` when VOSK omits `conf` (maxAlternatives >
  0); result JSON always fully parsed in Editor even without `OnResult` subscribers.
  - **Tests** — 4 new Edit Mode suites: `AudioMetricTests`, `VoskCommandParserDiagnosticTests`,
  `VoskCommandRecogniserDiagnosticTests`, `VoskMatchDiagnosticsTests` (17 total suites).
  - **Docs** — README and package documentation updated with debug window section, version pins bumped
   to v0.12.0.

  ## Changed files

  | Area | Files |
  |------|-------|
  | Editor window | `Editor/VoskDebugWindow.cs` |
  | Diagnostic structs | `Runtime/Commands/VoskMatchDiagnostics.cs` |
  | Runtime fixes | `VoskSpeechRecogniser.cs`, `VoskCommandRecogniser.cs`, `EditorMicBackend.cs` |
  | Sample | `Samples~/CommandRecognition/CommandDemo.cs` |
  | Tests | `Tests/Editor/AudioMetricTests.cs`, `VoskCommandParserDiagnosticTests.cs`,
  `VoskCommandRecogniserDiagnosticTests.cs`, `VoskMatchDiagnosticsTests.cs` |
  | Docs | `README.md`, `Documentation~/vosk-xr.md`, `CHANGELOG.md` |

  ## Test plan

  - [x] Open Command Debug window in Play Mode with live mic — verify audio meters, partial/final
  results, and match breakdown update
  - [x] Pause → speak → Resume — verify display was frozen and skips stale results on resume
  - [x] Type a phrase in the inject field and press Enter — verify it goes through the pipeline and
  appears in match history
  - [x] Set `maxAlternatives > 0` — verify word confidence shows `[n/a]` instead of 0% bars
  - [x] Run all 17 Edit Mode + Play Mode test suites in Test Runner — all pass