### PR TITLE
V3.3 Add batch test runner for regression-testing command definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-04-11
+
+### Added
+
+- Batch test runner for regression-testing command definitions after changes. Two interfaces:
+  - `VoskBatchTestRunner` — pure C# runner that instantiates a `VoskCommandParser`, feeds test cases, applies threshold filtering, and compares against expected intents and slots. Works in Edit Mode without Play Mode or audio hardware; CI-safe.
+  - `VoskBatchTestWindow` Editor window (Window > VOSK XR > Batch Test Runner) — visual table with input/expected/actual/score/status columns, Run All and Re-run Failed buttons, per-row diagnostics expansion, CSV export, and JSON import/export.
+- `VoskTestCase` data class for test case authoring: input text, expected intent, expected slots, optional simulated word confidence, and description.
+- `VoskTestResult` and `VoskBatchResults` result classes — per-case pass/fail with failure reason, plus `AllPassed` and `FailureSummary` for NUnit assertion integration.
+- `VoskTestSuiteAsset` ScriptableObject (Assets > Create > VOSK XR > Test Suite) for Inspector-based test case authoring with JSON import/export for portability.
+- `VoskBatchTestRunnerTests` — Edit Mode meta-tests verifying the runner correctly reports pass/fail for matching commands, intent mismatches, slot mismatches, threshold rejection, command sets, CSV export, and edge cases.
+
 ## [0.12.0] - 2026-04-10
 
 ### Added

--- a/Documentation~/vosk-xr.md
+++ b/Documentation~/vosk-xr.md
@@ -30,6 +30,7 @@
   - [Command Debug Window](#command-debug-window)
   - [Live Microphone (Windows Editor)](#live-microphone-windows-editor)
   - [Text Injection API](#text-injection-api)
+  - [Batch Test Runner](#batch-test-runner)
 - [Push-to-Talk Pattern](#push-to-talk-pattern)
 - [Error Handling](#error-handling)
 - [Running Tests](#running-tests)
@@ -51,7 +52,7 @@
 To pin a specific version (recommended):
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0
 ```
 
 ### Via manifest.json
@@ -61,7 +62,7 @@ Add to `Packages/manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0"
   }
 }
 ```
@@ -464,6 +465,33 @@ For zero-code Inspector authoring. Create via **Assets > Create > VOSK XR**.
 | Method | Description |
 |--------|-------------|
 | `ToSet()` | Converts to runtime `VoskCommandSet` struct. Skips null entries with a warning. |
+
+### VoskTestSuiteAsset
+
+`public class VoskTestSuiteAsset : ScriptableObject` -- Create via **Assets > Create > VOSK XR > Test Suite**.
+
+A collection of test cases for regression-testing command definitions with the [Batch Test Runner](#batch-test-runner).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `suiteName` | `string` | Human-readable name for this test suite |
+| `cases` | `List<VoskTestCase>` | Test cases to run |
+
+| Method | Description |
+|--------|-------------|
+| `ToArray()` | Returns `cases` as a `VoskTestCase[]` for `VoskBatchTestRunner.RunAll()`. |
+| `ToJson()` | Serializes all cases to a JSON string for portability and version control. |
+| `FromJson(string json)` | Replaces `cases` from a JSON string. |
+
+**VoskTestCase** (serializable struct):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input` | `string` | Text to feed through the command parser |
+| `expectedIntent` | `string` | Expected intent name. Empty = expect rejection. |
+| `expectedSlots` | `ExpectedSlot[]` | Array of `{name, value}` pairs. Omit to skip slot verification. |
+| `wordConfidence` | `float` | Simulated uniform word confidence (0--1). `-1` = omit word data. |
+| `description` | `string` | Human-readable description for the results table |
 
 ---
 

--- a/Documentation~/vosk-xr.md
+++ b/Documentation~/vosk-xr.md
@@ -755,6 +755,79 @@ All injection methods are main-thread only. They fire the same events as real re
 
 See `Tests/Runtime/VoskCommandRecogniserInjectionTests.cs` and `VoskSpeechRecogniserInjectionTests.cs` for executable usage examples.
 
+### Batch Test Runner
+
+Regression-test command definitions after changing thresholds, aliases, or slot values. Feeds a list of test cases through the command parser, applies threshold filtering, and compares against expected intents and slots.
+
+**Visual UI:** Window > VOSK XR > Batch Test Runner. Assign slot/command assets and a `VoskTestSuiteAsset`, then click Run All. Results appear in a table with per-row expansion for diagnostics. Export results as CSV for diffing across runs.
+
+**Programmatic API (Edit Mode tests / CI):**
+
+```csharp
+using VoskXR.Commands;
+using VoskXR.Testing;
+
+var runner = new VoskBatchTestRunner(slots, commands, minScore: 0.6f, minConfidence: 0.4f);
+var results = runner.RunAll(testCases);
+Assert.IsTrue(results.AllPassed, results.FailureSummary);
+```
+
+`VoskBatchTestRunner` is pure C# — no MonoBehaviour dependency, works in Edit Mode without Play Mode or audio hardware. It instantiates a `VoskCommandParser` directly (the same path that `InjectText` uses internally).
+
+**Test case authoring:**
+
+Create a `VoskTestSuiteAsset` via Assets > Create > VOSK XR > Test Suite and author test cases in the Inspector. Or import/export as JSON for portability:
+
+```json
+{
+    "cases": [
+        {
+            "input": "launch all missiles target hotel one",
+            "expectedIntent": "launch_weapon",
+            "expectedSlots": [{"name": "target", "value": "hotel one"}],
+            "wordConfidence": -1,
+            "description": "Full launch command with target"
+        },
+        {
+            "input": "hello world",
+            "expectedIntent": "",
+            "description": "Out-of-grammar phrase should be rejected"
+        },
+        {
+            "input": "cease fire",
+            "expectedIntent": "",
+            "wordConfidence": 0.3,
+            "description": "Low confidence should be rejected by threshold"
+        }
+    ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `input` | Text to feed through the command parser. |
+| `expectedIntent` | Expected intent name. Empty/null = expect rejection (no match or below threshold). |
+| `expectedSlots` | Array of `{name, value}` pairs. Omit to skip slot verification. |
+| `wordConfidence` | Simulated uniform word confidence (0–1). Set to -1 to omit word data. |
+| `description` | Human-readable description for the results table. |
+
+**API Reference:**
+
+| Method | Description |
+|--------|-------------|
+| `VoskBatchTestRunner(slots, commands, minScore, minConfidence)` | Constructor. All commands active. |
+| `VoskBatchTestRunner(slots, sets, activeSetNames, minScore, minConfidence)` | Constructor with named command sets. |
+| `RunAll(VoskTestCase[])` | Returns `VoskBatchResults` with per-case pass/fail. |
+| `Run(VoskTestCase)` | Returns a single `VoskTestResult`. |
+| `ToCsv(VoskBatchResults)` | Static. Exports results as a CSV string. |
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `VoskBatchResults.AllPassed` | `bool` | True when every test case passed. |
+| `VoskBatchResults.FailureSummary` | `string` | Multi-line summary of all failures for NUnit assertion messages. |
+| `VoskBatchResults.PassCount` | `int` | Number of passing test cases. |
+| `VoskBatchResults.FailCount` | `int` | Number of failing test cases. |
+
 ---
 
 ## Push-to-Talk Pattern
@@ -818,7 +891,7 @@ recogniser.OnError += (code, message) =>
 
 ## Running Tests
 
-The package includes 17 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
+The package includes 18 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
 
 | Suite | Mode | Covers |
 |-------|------|--------|
@@ -839,6 +912,7 @@ The package includes 17 test suites (Edit Mode and Play Mode) that run without a
 | `VoskCommandParserDiagnosticTests` | Edit Mode | Parser diagnostic entries, matched pattern, slot positions, score |
 | `VoskCommandRecogniserDiagnosticTests` | Edit Mode | End-to-end diagnostic struct population via `InjectText`, accept/reject reasons |
 | `VoskMatchDiagnosticsTests` | Edit Mode | Diagnostic struct defaults, field storage, slot match data |
+| `VoskBatchTestRunnerTests` | Edit Mode | Batch runner pass/fail reporting, threshold filtering, slot checks, CSV export |
 
 To run in a consuming Unity project:
 

--- a/Editor/VoskBatchTestWindow.cs
+++ b/Editor/VoskBatchTestWindow.cs
@@ -1,0 +1,446 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using VoskXR.Commands;
+using VoskXR.Testing;
+
+namespace VoskXR.Editor
+{
+    /// <summary>
+    /// EditorWindow for visually running batch test suites against command definitions.
+    /// Displays a results table with pass/fail, score, per-row diagnostics expansion,
+    /// and CSV export.
+    /// </summary>
+    public class VoskBatchTestWindow : EditorWindow
+    {
+        [SerializeField] VoskTestSuiteAsset testSuite;
+        [SerializeField] VoskSlotAsset[] slotAssets;
+        [SerializeField] VoskCommandSetAsset[] commandSetAssets;
+        [SerializeField] string[] activeSetNames;
+
+        [SerializeField] float minScore = 0.6f;
+        [SerializeField] float minConfidence = 0.4f;
+
+        VoskBatchResults _results;
+        bool[] _expanded;
+        Vector2 _scroll;
+
+        GUIStyle _passStyle;
+        GUIStyle _failStyle;
+        GUIStyle _headerStyle;
+
+        SerializedObject _serializedSelf;
+        SerializedProperty _propTestSuite;
+        SerializedProperty _propSlotAssets;
+        SerializedProperty _propCommandSetAssets;
+        SerializedProperty _propActiveSetNames;
+
+        [MenuItem("Window/VOSK XR/Batch Test Runner")]
+        static void Open()
+        {
+            GetWindow<VoskBatchTestWindow>("VOSK Batch Tests");
+        }
+
+        void OnEnable()
+        {
+            _serializedSelf = new SerializedObject(this);
+            _propTestSuite = _serializedSelf.FindProperty(nameof(testSuite));
+            _propSlotAssets = _serializedSelf.FindProperty(nameof(slotAssets));
+            _propCommandSetAssets = _serializedSelf.FindProperty(nameof(commandSetAssets));
+            _propActiveSetNames = _serializedSelf.FindProperty(nameof(activeSetNames));
+        }
+
+        void OnDisable()
+        {
+            _passStyle = null;
+            _failStyle = null;
+            _headerStyle = null;
+        }
+
+        void OnGUI()
+        {
+            _serializedSelf.Update();
+
+            DrawConfiguration();
+            EditorGUILayout.Space(4);
+            DrawToolbar();
+            EditorGUILayout.Space(4);
+            DrawResults();
+
+            _serializedSelf.ApplyModifiedProperties();
+        }
+
+        // ─── Configuration ──────────────────────────────────────────────
+
+        void DrawConfiguration()
+        {
+            EditorGUILayout.LabelField("Configuration", EditorStyles.boldLabel);
+
+            EditorGUILayout.PropertyField(_propTestSuite, new GUIContent("Test Suite"));
+
+            EditorGUILayout.PropertyField(_propSlotAssets,
+                new GUIContent("Slot Definitions"), true);
+
+            EditorGUILayout.PropertyField(_propCommandSetAssets,
+                new GUIContent("Command Sets"), true);
+
+            EditorGUILayout.PropertyField(_propActiveSetNames,
+                new GUIContent("Active Sets"), true);
+
+            EditorGUILayout.Space(2);
+            minScore = EditorGUILayout.FloatField("Min Score", minScore);
+            minConfidence = EditorGUILayout.FloatField("Min Confidence", minConfidence);
+        }
+
+        // ─── Toolbar ────────────────────────────────────────────────────
+
+        void DrawToolbar()
+        {
+            EditorGUILayout.BeginHorizontal();
+
+            bool canRun = testSuite != null && testSuite.cases.Count > 0
+                && slotAssets != null && slotAssets.Length > 0
+                && commandSetAssets != null && commandSetAssets.Length > 0;
+
+            GUI.enabled = canRun;
+            if (GUILayout.Button("Run All", GUILayout.Width(80)))
+                RunAll();
+
+            GUI.enabled = canRun && _results != null && _results.FailCount > 0;
+            if (GUILayout.Button("Re-run Failed", GUILayout.Width(100)))
+                RerunFailed();
+
+            GUI.enabled = _results != null;
+            if (GUILayout.Button("Export CSV", GUILayout.Width(80)))
+                ExportCsv();
+
+            GUI.enabled = true;
+
+            GUILayout.FlexibleSpace();
+
+            if (testSuite != null)
+            {
+                if (GUILayout.Button("Import JSON", GUILayout.Width(90)))
+                    ImportJson();
+                if (GUILayout.Button("Export JSON", GUILayout.Width(90)))
+                    ExportJson();
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            if (!canRun && testSuite != null)
+            {
+                string missing = "";
+                if (slotAssets == null || slotAssets.Length == 0) missing += "slot definitions, ";
+                if (commandSetAssets == null || commandSetAssets.Length == 0) missing += "command sets, ";
+                if (testSuite.cases.Count == 0) missing += "test cases, ";
+                if (missing.Length > 0) missing = missing.Substring(0, missing.Length - 2);
+                EditorGUILayout.HelpBox($"Missing: {missing}", MessageType.Info);
+            }
+
+            // Summary bar
+            if (_results != null)
+            {
+                string summary = $"{_results.PassCount} passed, {_results.FailCount} failed " +
+                    $"/ {_results.Results.Length} total";
+                MessageType msgType = _results.AllPassed ? MessageType.Info : MessageType.Warning;
+                EditorGUILayout.HelpBox(summary, msgType);
+            }
+        }
+
+        // ─── Results Table ──────────────────────────────────────────────
+
+        void DrawResults()
+        {
+            if (_results == null) return;
+
+            _headerStyle ??= new GUIStyle(EditorStyles.miniLabel)
+                { fontStyle = FontStyle.Bold };
+            _passStyle ??= new GUIStyle(EditorStyles.label)
+                { normal = { textColor = new Color(0.2f, 0.8f, 0.2f) } };
+            _failStyle ??= new GUIStyle(EditorStyles.label)
+                { normal = { textColor = new Color(1f, 0.4f, 0.4f) } };
+
+            // Header row
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("", GUILayout.Width(20));
+            EditorGUILayout.LabelField("Input", _headerStyle, GUILayout.MinWidth(150));
+            EditorGUILayout.LabelField("Expected", _headerStyle, GUILayout.Width(120));
+            EditorGUILayout.LabelField("Result", _headerStyle, GUILayout.Width(120));
+            EditorGUILayout.LabelField("Score", _headerStyle, GUILayout.Width(50));
+            EditorGUILayout.LabelField("Status", _headerStyle, GUILayout.Width(50));
+            EditorGUILayout.EndHorizontal();
+
+            DrawHorizontalSeparator();
+
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+
+            for (int i = 0; i < _results.Results.Length; i++)
+                DrawResultRow(i);
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        void DrawResultRow(int index)
+        {
+            var r = _results.Results[index];
+            var style = r.Passed ? _passStyle : _failStyle;
+
+            EditorGUILayout.BeginHorizontal();
+
+            // Expand toggle
+            bool wasExpanded = _expanded != null && index < _expanded.Length && _expanded[index];
+            bool nowExpanded = EditorGUILayout.Toggle(wasExpanded, GUILayout.Width(20));
+            if (_expanded != null && index < _expanded.Length)
+                _expanded[index] = nowExpanded;
+
+            // Input
+            EditorGUILayout.LabelField(Truncate(r.TestCase.input, 60),
+                EditorStyles.label, GUILayout.MinWidth(150));
+
+            // Expected
+            string expected = r.TestCase.ExpectsRejection ? "(none)" : r.TestCase.expectedIntent;
+            EditorGUILayout.LabelField(expected, GUILayout.Width(120));
+
+            // Actual result
+            string actual = FormatActual(r);
+            EditorGUILayout.LabelField(actual, GUILayout.Width(120));
+
+            // Score
+            EditorGUILayout.LabelField(r.Score > 0f ? $"{r.Score:F2}" : "-",
+                GUILayout.Width(50));
+
+            // Status
+            EditorGUILayout.LabelField(r.Passed ? "PASS" : "FAIL", style,
+                GUILayout.Width(50));
+
+            EditorGUILayout.EndHorizontal();
+
+            // Expanded detail
+            if (nowExpanded)
+                DrawExpandedDetail(r);
+        }
+
+        void DrawExpandedDetail(VoskTestResult r)
+        {
+            EditorGUI.indentLevel += 2;
+
+            if (!string.IsNullOrEmpty(r.TestCase.description))
+                EditorGUILayout.LabelField($"Description: {r.TestCase.description}",
+                    EditorStyles.wordWrappedLabel);
+
+            if (r.FailureReason != null)
+                EditorGUILayout.LabelField($"Failure: {r.FailureReason}",
+                    _failStyle ?? EditorStyles.label);
+
+            if (r.Confidence >= 0f)
+                EditorGUILayout.LabelField($"Confidence: {r.Confidence:F2}");
+
+            if (r.TestCase.wordConfidence >= 0f)
+                EditorGUILayout.LabelField(
+                    $"Simulated word confidence: {r.TestCase.wordConfidence:F2}");
+
+            // Slots
+            if (r.ActualSlots != null && r.ActualSlots.Length > 0)
+            {
+                EditorGUILayout.LabelField("Slots:");
+                EditorGUI.indentLevel++;
+                foreach (var slot in r.ActualSlots)
+                    EditorGUILayout.LabelField($"{slot.Name} = \"{slot.Value}\"");
+                EditorGUI.indentLevel--;
+            }
+
+#if UNITY_EDITOR
+            // Diagnostic attempts
+            if (r.Diagnostics.Attempts != null && r.Diagnostics.Attempts.Length > 0)
+            {
+                EditorGUILayout.LabelField("Diagnostics:");
+                EditorGUI.indentLevel++;
+                foreach (var attempt in r.Diagnostics.Attempts)
+                {
+                    string status = attempt.IsAccepted ? "[PASS]" : "[FAIL]";
+                    string intent = attempt.Intent ?? "(no match)";
+                    EditorGUILayout.LabelField(
+                        $"{status} {intent} — score {attempt.Score:F2}/{attempt.MinScore:F2}");
+
+                    if (attempt.Pattern != null)
+                        EditorGUILayout.LabelField($"  Pattern: {attempt.Pattern}");
+
+                    if (attempt.RejectReason != null)
+                        EditorGUILayout.LabelField($"  Rejected: {attempt.RejectReason}");
+                }
+                EditorGUI.indentLevel--;
+            }
+#endif
+
+            EditorGUI.indentLevel -= 2;
+            EditorGUILayout.Space(4);
+        }
+
+        // ─── Actions ────────────────────────────────────────────────────
+
+        void RunAll()
+        {
+            var runner = CreateRunner();
+            if (runner == null) return;
+
+            _results = runner.RunAll(testSuite.ToArray());
+            _expanded = new bool[_results.Results.Length];
+        }
+
+        void RerunFailed()
+        {
+            if (_results == null) return;
+
+            var runner = CreateRunner();
+            if (runner == null) return;
+
+            for (int i = 0; i < _results.Results.Length; i++)
+            {
+                if (!_results.Results[i].Passed)
+                    _results.Results[i] = runner.Run(_results.Results[i].TestCase);
+            }
+
+            _results.Recount();
+        }
+
+        VoskBatchTestRunner CreateRunner()
+        {
+            VoskSlotDefinition[] slots;
+            try
+            {
+                slots = BuildSlots();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[VoskBatchTest] Failed to build slots: {e.Message}");
+                return null;
+            }
+
+            try
+            {
+                var sets = BuildSets();
+
+                if (activeSetNames != null && activeSetNames.Length > 0)
+                    return new VoskBatchTestRunner(slots, sets, activeSetNames,
+                        minScore, minConfidence);
+
+                // No active set filter — use all commands from all sets
+                var allNames = new string[sets.Length];
+                for (int i = 0; i < sets.Length; i++)
+                    allNames[i] = sets[i].Name;
+
+                return new VoskBatchTestRunner(slots, sets, allNames,
+                    minScore, minConfidence);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[VoskBatchTest] Failed to create runner: {e.Message}");
+                return null;
+            }
+        }
+
+        VoskSlotDefinition[] BuildSlots()
+        {
+            var list = new VoskSlotDefinition[slotAssets.Length];
+            for (int i = 0; i < slotAssets.Length; i++)
+            {
+                if (slotAssets[i] == null)
+                    throw new InvalidOperationException($"slotAssets[{i}] is null.");
+                list[i] = slotAssets[i].ToDefinition();
+            }
+            return list;
+        }
+
+        VoskCommandSet[] BuildSets()
+        {
+            var list = new VoskCommandSet[commandSetAssets.Length];
+            for (int i = 0; i < commandSetAssets.Length; i++)
+            {
+                if (commandSetAssets[i] == null)
+                    throw new InvalidOperationException($"commandSetAssets[{i}] is null.");
+                list[i] = commandSetAssets[i].ToSet();
+            }
+            return list;
+        }
+
+        void ExportCsv()
+        {
+            if (_results == null) return;
+
+            string path = EditorUtility.SaveFilePanel("Export CSV", "", "test-results.csv", "csv");
+            if (string.IsNullOrEmpty(path)) return;
+
+            File.WriteAllText(path, VoskBatchTestRunner.ToCsv(_results));
+            Debug.Log($"[VoskBatchTest] Exported CSV to {path}");
+        }
+
+        void ImportJson()
+        {
+            if (testSuite == null) return;
+
+            string path = EditorUtility.OpenFilePanel("Import Test Cases", "", "json");
+            if (string.IsNullOrEmpty(path)) return;
+
+            string json = File.ReadAllText(path);
+            Undo.RecordObject(testSuite, "Import Test Cases");
+            testSuite.FromJson(json);
+            EditorUtility.SetDirty(testSuite);
+            _results = null;
+            Debug.Log($"[VoskBatchTest] Imported {testSuite.cases.Count} test cases from {path}");
+        }
+
+        void ExportJson()
+        {
+            if (testSuite == null) return;
+
+            string path = EditorUtility.SaveFilePanel("Export Test Cases", "",
+                testSuite.suiteName + ".json", "json");
+            if (string.IsNullOrEmpty(path)) return;
+
+            File.WriteAllText(path, testSuite.ToJson());
+            Debug.Log($"[VoskBatchTest] Exported {testSuite.cases.Count} test cases to {path}");
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────
+
+        static string FormatActual(VoskTestResult r)
+        {
+            if (r.ActualIntent == null)
+                return "(none)";
+
+            if (r.ActualSlots != null && r.ActualSlots.Length > 0)
+            {
+                var sb = new System.Text.StringBuilder();
+                sb.Append(r.ActualIntent);
+                sb.Append('(');
+                for (int i = 0; i < r.ActualSlots.Length; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    sb.Append(r.ActualSlots[i].Name);
+                    sb.Append(':');
+                    sb.Append(r.ActualSlots[i].Value);
+                }
+                sb.Append(')');
+                return sb.ToString();
+            }
+
+            return r.ActualIntent;
+        }
+
+        static string Truncate(string value, int maxLen)
+        {
+            if (string.IsNullOrEmpty(value)) return "";
+            return value.Length <= maxLen ? value : value.Substring(0, maxLen - 3) + "...";
+        }
+
+        static void DrawHorizontalSeparator()
+        {
+            EditorGUILayout.Space(1);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+            EditorGUILayout.Space(1);
+        }
+    }
+}

--- a/Editor/VoskBatchTestWindow.cs.meta
+++ b/Editor/VoskBatchTestWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da8c17064005a034dbb3b232b44f2eaf

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 
 **Testing & Iteration**
 - Editor command debug window (Window > VOSK XR > Command Debug) with live audio meters, match breakdowns, and match history
+- Batch test runner (Window > VOSK XR > Batch Test Runner) for regression-testing command definitions -- visual results table, CSV export, CI-safe Edit Mode API
 - Text injection API for Editor testing, CI, and replay without audio hardware
 - Live microphone in the Windows Editor -- speak into your PC mic, see commands fire in the Console
-- 17 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, and asset conversion
+- 18 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, batch testing, and asset conversion
 - Extensively tested on Quest 3 with published test matrices for every release
 
 ## Requirements
@@ -54,7 +55,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 **Pinned version:**
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0
 ```
 
 **Via manifest.json:**
@@ -62,7 +63,7 @@ https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.12.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0"
   }
 }
 ```
@@ -222,6 +223,36 @@ recogniser.InjectResult("hello world");
 recogniser.InjectPartialResult("hel");
 ```
 
+### Batch Test Runner
+
+Regression-test command definitions after changing thresholds, aliases, or slot values. Visual UI via **Window > VOSK XR > Batch Test Runner**, or programmatic for CI:
+
+```csharp
+var runner = new VoskBatchTestRunner(slots, commands, minScore: 0.6f, minConfidence: 0.4f);
+var results = runner.RunAll(testCases);
+Assert.IsTrue(results.AllPassed, results.FailureSummary);
+```
+
+Test cases can be authored as `VoskTestSuiteAsset` ScriptableObjects in the Inspector or imported/exported as JSON:
+
+```json
+{
+    "cases": [
+        {
+            "input": "launch all missiles target hotel one",
+            "expectedIntent": "launch_weapon",
+            "expectedSlots": [{"name": "target", "value": "hotel one"}],
+            "description": "Full launch command with target"
+        },
+        {
+            "input": "hello world",
+            "expectedIntent": "",
+            "description": "Out-of-grammar phrase should be rejected"
+        }
+    ]
+}
+```
+
 ## Samples
 
 Import samples via **Package Manager > VOSK XR Speech Recognition > Samples**.
@@ -233,7 +264,7 @@ Import samples via **Package Manager > VOSK XR Speech Recognition > Samples**.
 
 ## Running Tests
 
-The package includes 17 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
+The package includes 18 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model.
 
 To run them in a consuming Unity project:
 
@@ -241,7 +272,7 @@ To run them in a consuming Unity project:
 2. Open **Window > General > Test Runner**.
 3. Run Edit Mode and Play Mode tests.
 
-Tests cover: command parser logic, injection API wiring, recogniser lifecycle, JSON parsing, number parsing, command sets, asset-to-runtime conversion, DSP (AGC, downsampler), model extractor validation, error codes, audio metrics, and Editor diagnostic structs.
+Tests cover: command parser logic, injection API wiring, recogniser lifecycle, JSON parsing, number parsing, command sets, asset-to-runtime conversion, DSP (AGC, downsampler), model extractor validation, error codes, audio metrics, Editor diagnostic structs, and batch test runner pass/fail reporting.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.
 
 | Version | Milestone |
 |---|---|
+| 0.13.0 | Batch test runner for regression-testing command definitions |
 | 0.12.0 | Editor command debug window with live diagnostics |
 | 0.11.0 | Windows Editor live microphone backend |
 | 0.10.0 | Text injection API for Editor/CI testing |

--- a/Runtime/Testing.meta
+++ b/Runtime/Testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45649f7bf1cdf76468688b65fcf5c305
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Testing/VoskBatchTestRunner.cs
+++ b/Runtime/Testing/VoskBatchTestRunner.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using VoskXR.Commands;
+
+namespace VoskXR.Testing
+{
+    /// <summary>
+    /// Feeds a list of test cases through the command parser and produces a results matrix.
+    /// Pure C# — no MonoBehaviour dependency, works in Edit Mode and CI.
+    /// Reuses <see cref="VoskCommandParser"/> directly (the same path that
+    /// <see cref="VoskCommandRecogniser.InjectText"/> uses internally).
+    /// </summary>
+    public class VoskBatchTestRunner
+    {
+        readonly VoskCommandParser _parser;
+        readonly float _minScore;
+        readonly float _minConfidence;
+
+        /// <summary>
+        /// Creates a batch test runner with the given slot and command definitions.
+        /// All commands are active (no command sets).
+        /// </summary>
+        /// <param name="slots">Slot definitions used by the commands.</param>
+        /// <param name="commands">Command definitions to test against.</param>
+        /// <param name="minScore">Minimum match score threshold (default 0.6).</param>
+        /// <param name="minConfidence">Minimum word confidence threshold (default 0.4).</param>
+        public VoskBatchTestRunner(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands,
+            float minScore = 0.6f, float minConfidence = 0.4f)
+        {
+            if (slots == null) throw new ArgumentNullException(nameof(slots));
+            if (commands == null) throw new ArgumentNullException(nameof(commands));
+
+            _parser = new VoskCommandParser(slots, commands);
+            _minScore = minScore;
+            _minConfidence = minConfidence;
+        }
+
+        /// <summary>
+        /// Creates a batch test runner with named command sets. Only commands from
+        /// the specified active sets are tested.
+        /// </summary>
+        /// <param name="slots">Slot definitions used by the commands.</param>
+        /// <param name="sets">Named command sets.</param>
+        /// <param name="activeSetNames">Which sets to activate.</param>
+        /// <param name="minScore">Minimum match score threshold (default 0.6).</param>
+        /// <param name="minConfidence">Minimum word confidence threshold (default 0.4).</param>
+        public VoskBatchTestRunner(VoskSlotDefinition[] slots, VoskCommandSet[] sets,
+            string[] activeSetNames, float minScore = 0.6f, float minConfidence = 0.4f)
+        {
+            if (slots == null) throw new ArgumentNullException(nameof(slots));
+            if (sets == null) throw new ArgumentNullException(nameof(sets));
+            if (activeSetNames == null) throw new ArgumentNullException(nameof(activeSetNames));
+
+            var setLookup = new Dictionary<string, VoskCommandSet>(sets.Length, StringComparer.Ordinal);
+            foreach (var set in sets)
+                setLookup[set.Name] = set;
+
+            int total = 0;
+            foreach (var name in activeSetNames)
+            {
+                if (!setLookup.ContainsKey(name))
+                    throw new ArgumentException($"Unknown command set name: '{name}'.", nameof(activeSetNames));
+                total += setLookup[name].Commands.Length;
+            }
+
+            var commands = new VoskCommandDefinition[total];
+            int offset = 0;
+            foreach (var name in activeSetNames)
+            {
+                var c = setLookup[name].Commands;
+                Array.Copy(c, 0, commands, offset, c.Length);
+                offset += c.Length;
+            }
+
+            _parser = new VoskCommandParser(slots, commands);
+            _minScore = minScore;
+            _minConfidence = minConfidence;
+        }
+
+        /// <summary>
+        /// Runs all test cases and returns aggregated results.
+        /// </summary>
+        public VoskBatchResults RunAll(VoskTestCase[] testCases)
+        {
+            if (testCases == null) throw new ArgumentNullException(nameof(testCases));
+
+            var results = new VoskTestResult[testCases.Length];
+            for (int i = 0; i < testCases.Length; i++)
+                results[i] = Run(testCases[i]);
+
+            return new VoskBatchResults(results);
+        }
+
+        /// <summary>
+        /// Runs a single test case through the parser and threshold filter.
+        /// </summary>
+        public VoskTestResult Run(VoskTestCase testCase)
+        {
+            if (testCase == null) throw new ArgumentNullException(nameof(testCase));
+
+            VoskWord[] words = null;
+            if (testCase.wordConfidence >= 0f)
+                words = VoskSpeechRecogniser.CreateSimulatedWords(
+                    testCase.input, testCase.wordConfidence);
+
+            var parseResults = words != null
+                ? _parser.Parse(testCase.input, words)
+                : _parser.Parse(testCase.input);
+
+            string acceptedIntent = null;
+            VoskSlotMatch[] acceptedSlots = null;
+            float bestScore = 0f;
+            float bestConfidence = -1f;
+            string rejectReason = null;
+
+            if (parseResults.Length == 0)
+            {
+                if (testCase.ExpectsRejection)
+                    return MakeResult(testCase, null, null, 0f, -1f, true, null,
+                        parseResults, words);
+
+                return MakeResult(testCase, null, null, 0f, -1f, false,
+                    $"expected intent '{testCase.expectedIntent}' but no pattern matched",
+                    parseResults, words);
+            }
+
+            for (int i = 0; i < parseResults.Length; i++)
+            {
+                var cmd = parseResults[i].Command;
+
+                if (!PassesThresholds(cmd, out string reason))
+                {
+                    if (cmd.Score > bestScore)
+                    {
+                        bestScore = cmd.Score;
+                        bestConfidence = cmd.Confidence;
+                        rejectReason = reason;
+                    }
+                    continue;
+                }
+
+                acceptedIntent = cmd.Intent;
+                acceptedSlots = cmd.Slots;
+                bestScore = cmd.Score;
+                bestConfidence = cmd.Confidence;
+                rejectReason = null;
+                break;
+            }
+
+            // Compare against expectations
+            bool passed;
+            string failureReason;
+
+            if (testCase.ExpectsRejection)
+            {
+                if (acceptedIntent == null)
+                {
+                    passed = true;
+                    failureReason = null;
+                }
+                else
+                {
+                    passed = false;
+                    failureReason = $"expected rejection but got intent '{acceptedIntent}'";
+                }
+            }
+            else if (acceptedIntent == null)
+            {
+                passed = false;
+                failureReason = rejectReason != null
+                    ? $"expected intent '{testCase.expectedIntent}' but rejected: {rejectReason}"
+                    : $"expected intent '{testCase.expectedIntent}' but no command accepted";
+            }
+            else if (!string.Equals(acceptedIntent, testCase.expectedIntent, StringComparison.Ordinal))
+            {
+                passed = false;
+                failureReason = $"expected intent '{testCase.expectedIntent}' but got '{acceptedIntent}'";
+            }
+            else
+            {
+                string slotFailure = CheckSlots(testCase.expectedSlots, acceptedSlots);
+                passed = slotFailure == null;
+                failureReason = slotFailure;
+            }
+
+            return MakeResult(testCase, acceptedIntent, acceptedSlots, bestScore, bestConfidence,
+                passed, failureReason, parseResults, words);
+        }
+
+        bool PassesThresholds(VoskCommand cmd, out string rejectReason)
+        {
+            if (cmd.Score < _minScore)
+            {
+                rejectReason = $"score {cmd.Score:F2} < minScore {_minScore:F2}";
+                return false;
+            }
+            if (cmd.Confidence >= 0f && cmd.Confidence < _minConfidence)
+            {
+                rejectReason = $"confidence {cmd.Confidence:F2} < minConfidence {_minConfidence:F2}";
+                return false;
+            }
+            rejectReason = null;
+            return true;
+        }
+
+        static string CheckSlots(ExpectedSlot[] expected, VoskSlotMatch[] actual)
+        {
+            if (expected == null || expected.Length == 0)
+                return null;
+
+            foreach (var exp in expected)
+            {
+                bool found = false;
+                for (int i = 0; i < actual.Length; i++)
+                {
+                    if (string.Equals(actual[i].Name, exp.name, StringComparison.Ordinal))
+                    {
+                        found = true;
+                        if (!string.Equals(actual[i].Value, exp.value, StringComparison.Ordinal))
+                        {
+                            return $"slot '{exp.name}': expected '{exp.value}' but got '{actual[i].Value}'";
+                        }
+                        break;
+                    }
+                }
+
+                if (!found)
+                    return $"expected slot '{exp.name}' not found in result";
+            }
+
+            return null;
+        }
+
+        VoskTestResult MakeResult(VoskTestCase testCase, string actualIntent,
+            VoskSlotMatch[] actualSlots, float score, float confidence,
+            bool passed, string failureReason,
+            VoskCommandResult[] parseResults, VoskWord[] words)
+        {
+#if UNITY_EDITOR
+            // Build per-command diagnostic attempts from parser diagnostics
+            var parseDiag = _parser.LastParseDiagnostics;
+            VoskMatchAttempt[] attempts;
+
+            if (parseResults.Length > 0 && parseDiag != null && parseDiag.Length > 0)
+            {
+                int count = Math.Min(parseResults.Length, parseDiag.Length);
+                attempts = new VoskMatchAttempt[count];
+                for (int i = 0; i < count; i++)
+                {
+                    var cmd = parseResults[i].Command;
+                    bool accepted = PassesThresholds(cmd, out string reason);
+
+                    attempts[i] = new VoskMatchAttempt(
+                        cmd.Intent, parseDiag[i].PatternString,
+                        cmd.Score, _minScore, cmd.Confidence, _minConfidence,
+                        null, reason, accepted);
+                }
+            }
+            else
+            {
+                attempts = new[] { new VoskMatchAttempt(
+                    actualIntent, null, score, _minScore,
+                    confidence, _minConfidence, null,
+                    failureReason ?? "no match", actualIntent != null) };
+            }
+
+            var diagWords = words ?? Array.Empty<VoskWord>();
+            var diagnostics = new VoskMatchDiagnostics(testCase.input, diagWords, attempts, 0);
+
+            return new VoskTestResult(testCase, actualIntent, actualSlots,
+                score, confidence, passed, failureReason, diagnostics);
+#else
+            return new VoskTestResult(testCase, actualIntent, actualSlots,
+                score, confidence, passed, failureReason);
+#endif
+        }
+
+        /// <summary>
+        /// Exports batch results as a CSV string for diffing across runs.
+        /// </summary>
+        public static string ToCsv(VoskBatchResults results)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Input,Expected,Actual,Score,Confidence,Status,Reason");
+
+            foreach (var r in results.Results)
+            {
+                string expected = r.TestCase.ExpectsRejection ? "(none)" : r.TestCase.expectedIntent;
+                string actual = r.ActualIntent ?? "(none)";
+                string status = r.Passed ? "PASS" : "FAIL";
+                string reason = r.FailureReason != null ? CsvEscape(r.FailureReason) : "";
+
+                sb.AppendLine($"{CsvEscape(r.TestCase.input)},{CsvEscape(expected)}," +
+                    $"{CsvEscape(actual)},{r.Score:F2},{r.Confidence:F2},{status},{reason}");
+            }
+
+            return sb.ToString();
+        }
+
+        static string CsvEscape(string value)
+        {
+            if (value == null) return "";
+            if (value.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+                return "\"" + value.Replace("\"", "\"\"") + "\"";
+            return value;
+        }
+    }
+}

--- a/Runtime/Testing/VoskBatchTestRunner.cs.meta
+++ b/Runtime/Testing/VoskBatchTestRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36795350b16227343a872211cd4da59e

--- a/Runtime/Testing/VoskTestCase.cs
+++ b/Runtime/Testing/VoskTestCase.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace VoskXR.Testing
+{
+    /// <summary>
+    /// A single test case for the batch test runner.
+    /// Specifies input text, expected command result, and optional simulated word confidence.
+    /// </summary>
+    [Serializable]
+    public class VoskTestCase
+    {
+        /// <summary>The text to feed through the command parser.</summary>
+        [Tooltip("Text to feed through the command parser (as if from VOSK).")]
+        public string input;
+
+        /// <summary>
+        /// Expected intent name after threshold filtering. Null or empty means
+        /// the input should be rejected (no match or below threshold).
+        /// </summary>
+        [Tooltip("Expected intent name. Leave empty to expect rejection (no match or below threshold).")]
+        public string expectedIntent;
+
+        /// <summary>Expected slot values. Each entry is a name/value pair.</summary>
+        [Tooltip("Expected slot name/value pairs.")]
+        public ExpectedSlot[] expectedSlots;
+
+        /// <summary>
+        /// Simulated uniform word confidence for threshold testing.
+        /// Set to -1 (default) to omit word data. When >= 0, the runner calls
+        /// <see cref="VoskSpeechRecogniser.CreateSimulatedWords"/> to generate
+        /// per-word confidence data.
+        /// </summary>
+        [Tooltip("Simulated word confidence (0-1). Set to -1 to omit word data.")]
+        public float wordConfidence = -1f;
+
+        /// <summary>Human-readable description of what this test case verifies.</summary>
+        [TextArea]
+        public string description;
+
+        /// <summary>True when the test expects no command to be accepted.</summary>
+        internal bool ExpectsRejection =>
+            string.IsNullOrEmpty(expectedIntent);
+    }
+
+    /// <summary>
+    /// A single expected slot name/value pair within a <see cref="VoskTestCase"/>.
+    /// </summary>
+    [Serializable]
+    public struct ExpectedSlot
+    {
+        public string name;
+        public string value;
+    }
+}

--- a/Runtime/Testing/VoskTestCase.cs.meta
+++ b/Runtime/Testing/VoskTestCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc7f0b572a3d54d42966071e555f723e

--- a/Runtime/Testing/VoskTestResult.cs
+++ b/Runtime/Testing/VoskTestResult.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Text;
+using VoskXR.Commands;
+
+namespace VoskXR.Testing
+{
+    /// <summary>
+    /// Result of running a single <see cref="VoskTestCase"/> through the batch test runner.
+    /// </summary>
+    public class VoskTestResult
+    {
+        /// <summary>The test case that produced this result.</summary>
+        public readonly VoskTestCase TestCase;
+
+        /// <summary>The intent that was accepted, or null if no command passed thresholds.</summary>
+        public readonly string ActualIntent;
+
+        /// <summary>Slot matches from the accepted command.</summary>
+        public readonly VoskSlotMatch[] ActualSlots;
+
+        /// <summary>Best match score from the parser (0 if no match).</summary>
+        public readonly float Score;
+
+        /// <summary>Minimum word confidence across matched tokens (-1 if unavailable).</summary>
+        public readonly float Confidence;
+
+        /// <summary>True if the actual result matches expectations.</summary>
+        public readonly bool Passed;
+
+        /// <summary>Human-readable failure reason, or null if passed.</summary>
+        public readonly string FailureReason;
+
+#if UNITY_EDITOR
+        /// <summary>Full diagnostic data from the parse cycle (Editor only).</summary>
+        internal readonly VoskMatchDiagnostics Diagnostics;
+#endif
+
+        public VoskTestResult(VoskTestCase testCase, string actualIntent,
+            VoskSlotMatch[] actualSlots, float score, float confidence,
+            bool passed, string failureReason)
+        {
+            TestCase = testCase;
+            ActualIntent = actualIntent;
+            ActualSlots = actualSlots ?? Array.Empty<VoskSlotMatch>();
+            Score = score;
+            Confidence = confidence;
+            Passed = passed;
+            FailureReason = failureReason;
+        }
+
+#if UNITY_EDITOR
+        internal VoskTestResult(VoskTestCase testCase, string actualIntent,
+            VoskSlotMatch[] actualSlots, float score, float confidence,
+            bool passed, string failureReason, VoskMatchDiagnostics diagnostics)
+            : this(testCase, actualIntent, actualSlots, score, confidence, passed, failureReason)
+        {
+            Diagnostics = diagnostics;
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Aggregated results from <see cref="VoskBatchTestRunner.RunAll"/>.
+    /// Provides <see cref="AllPassed"/> and <see cref="FailureSummary"/> for
+    /// convenient use in NUnit assertions.
+    /// </summary>
+    public class VoskBatchResults
+    {
+        /// <summary>Individual results for each test case, in input order.</summary>
+        public readonly VoskTestResult[] Results;
+
+        /// <summary>True when every test case passed.</summary>
+        public bool AllPassed { get; private set; }
+
+        /// <summary>Number of test cases that passed.</summary>
+        public int PassCount { get; private set; }
+
+        /// <summary>Number of test cases that failed.</summary>
+        public int FailCount { get; private set; }
+
+        /// <summary>
+        /// Multi-line summary of all failures. Empty string when all passed.
+        /// Suitable for passing as the message argument to <c>Assert.IsTrue</c>.
+        /// </summary>
+        public string FailureSummary
+        {
+            get
+            {
+                var sb = new StringBuilder();
+                for (int i = 0; i < Results.Length; i++)
+                {
+                    if (Results[i].Passed) continue;
+                    if (sb.Length > 0) sb.AppendLine();
+
+                    var r = Results[i];
+                    string desc = string.IsNullOrEmpty(r.TestCase.description)
+                        ? r.TestCase.input
+                        : r.TestCase.description;
+                    sb.Append($"[{i}] {desc}: {r.FailureReason}");
+                }
+                return sb.ToString();
+            }
+        }
+
+        public VoskBatchResults(VoskTestResult[] results)
+        {
+            Results = results ?? throw new ArgumentNullException(nameof(results));
+            Recount();
+        }
+
+        /// <summary>
+        /// Recalculates PassCount, FailCount, and AllPassed after in-place result updates.
+        /// </summary>
+        internal void Recount()
+        {
+            int pass = 0;
+            for (int i = 0; i < Results.Length; i++)
+                if (Results[i].Passed) pass++;
+            PassCount = pass;
+            FailCount = Results.Length - pass;
+            AllPassed = pass == Results.Length;
+        }
+    }
+}

--- a/Runtime/Testing/VoskTestResult.cs.meta
+++ b/Runtime/Testing/VoskTestResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b68d4af6d8e8462438175ad31af7703c

--- a/Runtime/Testing/VoskTestSuiteAsset.cs
+++ b/Runtime/Testing/VoskTestSuiteAsset.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VoskXR.Testing
+{
+    /// <summary>
+    /// ScriptableObject wrapping a list of <see cref="VoskTestCase"/> entries.
+    /// Create via Assets > Create > VOSK XR > Test Suite.
+    /// Supports JSON import/export for portability and version control.
+    /// </summary>
+    [CreateAssetMenu(menuName = "VOSK XR/Test Suite")]
+    public class VoskTestSuiteAsset : ScriptableObject
+    {
+        [Tooltip("Human-readable name for this test suite.")]
+        public string suiteName;
+
+        public List<VoskTestCase> cases = new List<VoskTestCase>();
+
+        /// <summary>
+        /// Returns the test cases as an array for <see cref="VoskBatchTestRunner.RunAll"/>.
+        /// </summary>
+        public VoskTestCase[] ToArray() => cases.ToArray();
+
+        /// <summary>
+        /// Serialises the test cases to a JSON string.
+        /// </summary>
+        public string ToJson()
+        {
+            var wrapper = new JsonWrapper { cases = cases.ToArray() };
+            return JsonUtility.ToJson(wrapper, true);
+        }
+
+        /// <summary>
+        /// Replaces the current test cases with those parsed from a JSON string.
+        /// </summary>
+        public void FromJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                throw new ArgumentException("JSON string is null or empty.", nameof(json));
+
+            var wrapper = JsonUtility.FromJson<JsonWrapper>(json);
+            cases.Clear();
+            if (wrapper.cases != null)
+                cases.AddRange(wrapper.cases);
+        }
+
+        [Serializable]
+        struct JsonWrapper
+        {
+            public VoskTestCase[] cases;
+        }
+    }
+}

--- a/Runtime/Testing/VoskTestSuiteAsset.cs.meta
+++ b/Runtime/Testing/VoskTestSuiteAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5388216d9daca946bac472b38174fc4

--- a/Tests/Editor/VoskBatchTestRunnerTests.cs
+++ b/Tests/Editor/VoskBatchTestRunnerTests.cs
@@ -1,0 +1,431 @@
+using System;
+using NUnit.Framework;
+using VoskXR;
+using VoskXR.Commands;
+using VoskXR.Testing;
+
+namespace VoskXR.Tests.Editor
+{
+    /// <summary>
+    /// Meta-tests for the batch test runner itself.
+    /// Verifies that the runner correctly reports pass/fail for various scenarios.
+    /// </summary>
+    public class VoskBatchTestRunnerTests
+    {
+        static VoskSlotDefinition[] MakeSlots() => new[]
+        {
+            new VoskSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+            new VoskSlotDefinition("target", new[] { "hotel one", "hotel two", "alpha one" }),
+            new VoskSlotDefinition("quantity", new[] { "all", "one", "two" }),
+        };
+
+        static VoskCommandDefinition[] MakeCommands() => new[]
+        {
+            new VoskCommandDefinition("launch_weapon", new[]
+            {
+                new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
+            }),
+            new VoskCommandDefinition("cease_fire", new[]
+            {
+                new[] { "cease", "fire" },
+            }),
+        };
+
+        VoskBatchTestRunner CreateRunner(float minScore = 0.6f, float minConfidence = 0.4f)
+        {
+            return new VoskBatchTestRunner(MakeSlots(), MakeCommands(), minScore, minConfidence);
+        }
+
+        // ─── Basic pass/fail ────────────────────────────────────────────
+
+        [Test]
+        public void Run_MatchingCommand_Passes()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.AreEqual("cease_fire", result.ActualIntent);
+            Assert.IsNull(result.FailureReason);
+        }
+
+        [Test]
+        public void Run_MatchingCommandWithSlots_Passes()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "launch all missiles target hotel one",
+                expectedIntent = "launch_weapon",
+                expectedSlots = new[]
+                {
+                    new ExpectedSlot { name = "weapon", value = "missiles" },
+                    new ExpectedSlot { name = "target", value = "hotel one" },
+                    new ExpectedSlot { name = "quantity", value = "all" },
+                },
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.AreEqual("launch_weapon", result.ActualIntent);
+        }
+
+        [Test]
+        public void Run_ExpectedRejection_NoMatch_Passes()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "hello world",
+                expectedIntent = null,
+                description = "Out-of-grammar phrase should be rejected",
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.IsNull(result.ActualIntent);
+        }
+
+        // ─── Intent mismatch ────────────────────────────────────────────
+
+        [Test]
+        public void Run_WrongIntent_Fails()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "launch_weapon",
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("expected intent 'launch_weapon'", result.FailureReason);
+            StringAssert.Contains("got 'cease_fire'", result.FailureReason);
+        }
+
+        [Test]
+        public void Run_ExpectedMatch_ButNoMatch_Fails()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "hello world",
+                expectedIntent = "cease_fire",
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("no pattern matched", result.FailureReason);
+        }
+
+        // ─── Slot mismatch ──────────────────────────────────────────────
+
+        [Test]
+        public void Run_WrongSlotValue_Fails()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "launch all missiles target hotel one",
+                expectedIntent = "launch_weapon",
+                expectedSlots = new[]
+                {
+                    new ExpectedSlot { name = "target", value = "hotel two" },
+                },
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("slot 'target'", result.FailureReason);
+            StringAssert.Contains("expected 'hotel two'", result.FailureReason);
+        }
+
+        [Test]
+        public void Run_MissingExpectedSlot_Fails()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+                expectedSlots = new[]
+                {
+                    new ExpectedSlot { name = "weapon", value = "missiles" },
+                },
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("expected slot 'weapon' not found", result.FailureReason);
+        }
+
+        // ─── Threshold filtering ────────────────────────────────────────
+
+        [Test]
+        public void Run_BelowMinConfidence_RejectedCorrectly()
+        {
+            var runner = CreateRunner(minConfidence: 0.4f);
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = null,
+                wordConfidence = 0.2f,
+                description = "Low confidence should be rejected",
+            });
+
+            Assert.IsTrue(result.Passed, "Expected rejection due to low confidence");
+        }
+
+        [Test]
+        public void Run_AboveMinConfidence_AcceptedCorrectly()
+        {
+            var runner = CreateRunner(minConfidence: 0.4f);
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+                wordConfidence = 0.85f,
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.AreEqual(0.85f, result.Confidence, 1e-5f);
+        }
+
+        [Test]
+        public void Run_BelowMinScore_RejectedCorrectly()
+        {
+            // "cease xyz" against pattern "cease fire" — one hit, one miss.
+            // Normalized score = (1.0 + -0.5) / 2 = 0.25, which is below default 0.6.
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease xyz",
+                expectedIntent = null,
+                description = "Garbled phrase should be rejected by score threshold",
+            });
+
+            Assert.IsTrue(result.Passed, result.FailureReason);
+        }
+
+        [Test]
+        public void Run_ExpectedAcceptance_ButConfidenceRejects_Fails()
+        {
+            var runner = CreateRunner(minConfidence: 0.4f);
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+                wordConfidence = 0.2f,
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("rejected", result.FailureReason);
+            StringAssert.Contains("confidence", result.FailureReason);
+        }
+
+        [Test]
+        public void Run_ExpectedRejection_ButCommandAccepted_Fails()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = null,
+                description = "Incorrectly expecting rejection for a valid command",
+            });
+
+            Assert.IsFalse(result.Passed);
+            StringAssert.Contains("expected rejection", result.FailureReason);
+            StringAssert.Contains("cease_fire", result.FailureReason);
+        }
+
+        // ─── RunAll + batch results ─────────────────────────────────────
+
+        [Test]
+        public void RunAll_AllPass_AllPassedIsTrue()
+        {
+            var runner = CreateRunner();
+            var results = runner.RunAll(new[]
+            {
+                new VoskTestCase { input = "cease fire", expectedIntent = "cease_fire" },
+                new VoskTestCase { input = "hello world", expectedIntent = null },
+            });
+
+            Assert.IsTrue(results.AllPassed, results.FailureSummary);
+            Assert.AreEqual(2, results.PassCount);
+            Assert.AreEqual(0, results.FailCount);
+        }
+
+        [Test]
+        public void RunAll_OneFails_AllPassedIsFalse()
+        {
+            var runner = CreateRunner();
+            var results = runner.RunAll(new[]
+            {
+                new VoskTestCase { input = "cease fire", expectedIntent = "cease_fire" },
+                new VoskTestCase { input = "cease fire", expectedIntent = "wrong_intent" },
+            });
+
+            Assert.IsFalse(results.AllPassed);
+            Assert.AreEqual(1, results.PassCount);
+            Assert.AreEqual(1, results.FailCount);
+            Assert.IsTrue(results.FailureSummary.Length > 0);
+        }
+
+        [Test]
+        public void RunAll_EmptyArray_AllPassedIsTrue()
+        {
+            var runner = CreateRunner();
+            var results = runner.RunAll(Array.Empty<VoskTestCase>());
+
+            Assert.IsTrue(results.AllPassed);
+            Assert.AreEqual(0, results.Results.Length);
+        }
+
+        // ─── Command sets constructor ───────────────────────────────────
+
+        [Test]
+        public void CommandSetConstructor_ActiveSetOnly()
+        {
+            var sets = new[]
+            {
+                new VoskCommandSet("combat", MakeCommands()),
+                new VoskCommandSet("navigation", new[]
+                {
+                    new VoskCommandDefinition("heading", new[]
+                    {
+                        new[] { "heading", "{target}" },
+                    }),
+                }),
+            };
+
+            // Only activate "combat" — heading should not be available
+            var runner = new VoskBatchTestRunner(MakeSlots(), sets,
+                new[] { "combat" });
+
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+            });
+
+            Assert.IsTrue(result.Passed);
+        }
+
+        [Test]
+        public void CommandSetConstructor_UnknownSet_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new VoskBatchTestRunner(MakeSlots(),
+                    new[] { new VoskCommandSet("combat", MakeCommands()) },
+                    new[] { "nonexistent" });
+            });
+        }
+
+        // ─── CSV export ─────────────────────────────────────────────────
+
+        [Test]
+        public void ToCsv_ContainsHeaderAndRows()
+        {
+            var runner = CreateRunner();
+            var results = runner.RunAll(new[]
+            {
+                new VoskTestCase { input = "cease fire", expectedIntent = "cease_fire" },
+                new VoskTestCase { input = "hello world", expectedIntent = null },
+            });
+
+            string csv = VoskBatchTestRunner.ToCsv(results);
+
+            StringAssert.Contains("Input,Expected,Actual,Score,Confidence,Status,Reason", csv);
+            StringAssert.Contains("cease fire", csv);
+            StringAssert.Contains("PASS", csv);
+        }
+
+        // ─── Diagnostics ────────────────────────────────────────────────
+
+        [Test]
+        public void Run_PopulatesDiagnostics()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "cease fire",
+                expectedIntent = "cease_fire",
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.IsNotNull(result.Diagnostics.Attempts);
+            Assert.IsTrue(result.Diagnostics.Attempts.Length > 0);
+            Assert.AreEqual("cease fire", result.Diagnostics.InputText);
+        }
+
+        // ─── Edge cases ─────────────────────────────────────────────────
+
+        [Test]
+        public void Run_NullInput_NoMatch()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = null,
+                expectedIntent = null,
+            });
+
+            Assert.IsTrue(result.Passed);
+        }
+
+        [Test]
+        public void Run_EmptyInput_NoMatch()
+        {
+            var runner = CreateRunner();
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "",
+                expectedIntent = null,
+            });
+
+            Assert.IsTrue(result.Passed);
+        }
+
+        [Test]
+        public void Run_NoExpectedSlots_IgnoresActualSlots()
+        {
+            var runner = CreateRunner();
+            // Match with slots but don't assert on them
+            var result = runner.Run(new VoskTestCase
+            {
+                input = "launch all missiles target hotel one",
+                expectedIntent = "launch_weapon",
+                expectedSlots = null,
+            });
+
+            Assert.IsTrue(result.Passed);
+            Assert.IsTrue(result.ActualSlots.Length > 0, "Should still populate actual slots");
+        }
+
+        [Test]
+        public void RunAll_NullCases_Throws()
+        {
+            var runner = CreateRunner();
+            Assert.Throws<ArgumentNullException>(() => runner.RunAll(null));
+        }
+
+        [Test]
+        public void FailureSummary_ContainsIndex_And_Description()
+        {
+            var runner = CreateRunner();
+            var results = runner.RunAll(new[]
+            {
+                new VoskTestCase
+                {
+                    input = "cease fire",
+                    expectedIntent = "wrong",
+                    description = "Testing wrong intent",
+                },
+            });
+
+            StringAssert.Contains("[0]", results.FailureSummary);
+            StringAssert.Contains("Testing wrong intent", results.FailureSummary);
+        }
+    }
+}

--- a/Tests/Editor/VoskBatchTestRunnerTests.cs.meta
+++ b/Tests/Editor/VoskBatchTestRunnerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e8d2ae0893ab674db099baef25d0593

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
  ## Summary

  - **Batch test runner** — pure C# `VoskBatchTestRunner` that feeds test cases through
  `VoskCommandParser`, applies threshold filtering, and compares against expected intents and slots.
  Works in Edit Mode without Play Mode or audio hardware; CI-safe.
  - **Editor window** (Window > VOSK XR > Batch Test Runner) — visual results table with
  input/expected/actual/score/status columns, Run All and Re-run Failed buttons, per-row diagnostics
  expansion, CSV export, and JSON import/export.
  - **`VoskTestSuiteAsset`** ScriptableObject (Assets > Create > VOSK XR > Test Suite) for
  Inspector-based test case authoring with JSON portability.
  - **`VoskTestCase` / `VoskTestResult` / `VoskBatchResults`** data types — per-case pass/fail with
  failure reason, `AllPassed` and `FailureSummary` for NUnit assertion integration.
  - **`VoskBatchTestRunnerTests`** — Edit Mode meta-tests verifying pass/fail reporting for matching
  commands, intent mismatches, slot mismatches, threshold rejection, command sets, CSV export, and
  edge cases.
  - Updated README versioning table and package docs (version pins, ToC, `VoskTestSuiteAsset` API
  reference) for v0.13.0.

  ## Test plan

  - [x] Run Edit Mode tests — verify all 18 suites pass (including new `VoskBatchTestRunnerTests`)
  - [x] Open Window > VOSK XR > Batch Test Runner, assign sample assets, click Run All — verify
  results table populates
  - [x] Export CSV and JSON — verify round-trip import produces identical results
  - [x] Verify programmatic API: `new VoskBatchTestRunner(slots, commands).RunAll(cases)` returns
  correct `AllPassed` / `FailureSummary`
  - [x] Confirm no regressions in existing Play Mode tests