### PR TITLE
Refactor recogniser pipeline and add pending command system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-04-13
+
+### Changed
+
+- Extracted `VoskCommandRecogniser` responsibilities into single-purpose internal classes: `CommandDebouncer`, `CommandSetManager`, `DynamicSlotManager`, `GrammarManager`, `PendingCommandHandler`, `UtteranceBuffer`.
+- Pulled JSON result/word/alternative parsing out of `VoskSpeechRecogniser` into `VoskJsonParser`.
+- Unified `SplitSeparator` declarations — `VoskCommandAsset` and `VoskNumberParser` now use `VoskCommandParser.SplitSeparator`.
+- Simplified pending command resolution pipeline: all event dispatch goes through `InterpretResolution`; grammar drain based on outcome type instead of explicit flag.
+- `UtteranceBuffer.Flush()` returns text only; word data accessed via `GetWordsSpan()` (zero-copy `ReadOnlySpan<VoskWord>` via `CollectionsMarshal.AsSpan`).
+- `VoskCommandParser.ParseInternal()` accepts pre-split tokens and pre-built word-confidence dictionary, avoiding duplicate `string.Split` and `Dictionary` allocations per utterance.
+- Pre-allocated reusable buffers replace per-utterance `List` allocations: `_matchSlotBuf`/`_bestSlotBuf` in `TryMatchScored`, `_acceptedBuf` in the recogniser, `_followUpSlotBuf`/`_unfilledBuf` in `PendingCommandHandler`, pooled `StringBuilder` in `UtteranceBuffer` and `TryMatchNumberSequence`, pooled word-confidence dictionary in `VoskCommandParser`.
+- Pre-computed `_slotNameCache` and `_optionalSlotElements` replace runtime `ExtractSlotName`/`IsOptionalSlot` calls in the match loop.
+- `VoskJsonParser.ParseAlternativesFromJson` pre-counts depth-1 objects for exact-size array allocation, replacing `List<VoskAlternative>`.
+- Vocabulary confirm/cancel matching uses span-based `MatchPhraseAgainstTokens` instead of joining tokens into a temporary string.
+
+### Fixed
+
+- Removed unsound slot array pool (`BorrowSlotArray`/`ReturnSlotArray`) that had two escape bugs: accepted commands' slot arrays were returned to the pool after being fired via `OnCommandRecognised` (subscribers may retain references), and only two pending-slot references were tracked so a third command entering pending in one parse would silently corrupt live data.
+
 ## [0.15.0] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-04-13
+
+### Added
+
+- Pending command system for partial match, confirmation, and follow-up slot-fill:
+  - `AllowPartialMatch` on `VoskCommandDefinition` — when a command matches with unfilled required slots, it enters pending state instead of being rejected. Follow-up speech fills the missing slots.
+  - `RequiresConfirmation` on `VoskCommandDefinition` — fully-matched commands enter pending state awaiting explicit voice confirmation before firing.
+  - Commands that are both `AllowPartialMatch` and `RequiresConfirmation` go through two pending stages: first slot-fill, then confirmation.
+  - Configurable `pendingTimeout` (default 5s) and `pendingTimeoutBehavior` (`Cancel` or `FireAsIs`) on `VoskCommandRecogniser`.
+  - Custom confirm/cancel vocabulary via `confirmVocabulary` and `cancelVocabulary` Inspector arrays. Defaults: confirm = "confirm", "affirmative", "yes", "go ahead", "do it"; cancel = "cancel", "abort", "negative", "belay that", "never mind".
+  - Confirm/cancel vocabulary words are automatically merged into the VOSK grammar JSON.
+- `VoskCommandRecogniser` pending command events:
+  - `OnCommandPending` — fires when a command enters pending state (partial match or awaiting confirmation).
+  - `OnCommandConfirmed` — fires when a pending command is confirmed. Also fires `OnCommandRecognised` and `OnCommandsRecognised`.
+  - `OnCommandCancelled` — fires when a pending command is cancelled (timeout, explicit cancel, or preempted by a new complete command).
+- `VoskCommandRecogniser` pending command API:
+  - `HasPendingCommand` property — true if a command is currently in pending state.
+  - `PendingCommand` property — the currently pending `VoskCommand`, or null.
+  - `CancelPendingCommand()` — programmatically cancels the pending command.
+- `VoskCommandRecogniser.RebuildGrammar()` defers grammar rebuild while a command is pending, draining the rebuild when the pending command resolves.
+- `VoskCommandParser.TryMatchSlotByName()` — internal method for follow-up slot-fill matching against specific slot names.
+- `VoskPendingTimeoutBehavior` enum (`Cancel`, `FireAsIs`).
+- `VoskPendingCommand`, `VoskPendingReason`, `VoskFollowUpVocabulary` internal types.
+- `VoskCommandAsset` exposes `allowPartialMatch` and `requiresConfirmation` Inspector fields.
+- `VoskDebugWindow` shows pending command state: intent, reason, filled/unfilled slots, and elapsed time.
+- `VoskPendingCommandTests` — 32 Play Mode tests covering partial match entry, follow-up slot-fill, confirmation flow, cancel vocabulary, timeout behaviours, preemption by new commands, dual partial+confirmation flow, custom vocabulary, and grammar rebuild deferral.
+
+### Changed
+
+- `VoskCommandDefinition` constructor accepts optional `allowPartialMatch` and `requiresConfirmation` parameters. Existing two-parameter constructor is unchanged.
+- `VoskCommandRecogniser.Configure()` and `SetActiveSets()` cancel any active pending command before rebuilding.
+- Grammar generation includes confirm/cancel vocabulary words so VOSK recognises them in grammar mode.
+
 ## [0.14.0] - 2026-04-12
 
 ### Added

--- a/Documentation~/api/command-definitions.md
+++ b/Documentation~/api/command-definitions.md
@@ -14,6 +14,8 @@ Declares a command pattern with an intent name and one or more token arrays.
 |-------|------|-------------|
 | `Intent` | `string` | The intent name (e.g. `"launch_weapon"`) |
 | `Patterns` | `string[][]` | One or more token arrays. Each token is a literal word, `{slotName}`, or `{?slotName}` (optional). |
+| `AllowPartialMatch` | `bool` | When true, a match with unfilled required slots enters pending state instead of being rejected, allowing follow-up speech to fill the gaps. Default: `false`. |
+| `RequiresConfirmation` | `bool` | When true, a fully-matched command enters pending state awaiting explicit confirmation before firing. Default: `false`. |
 
 ### Examples
 
@@ -26,6 +28,11 @@ new VoskCommandDefinition("launch_weapon", new[] {
     new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
     new[] { "fire", "{weapon}", "at", "{target}" },
 })
+
+// Partial match + confirmation
+new VoskCommandDefinition("launch_weapon", new[] {
+    new[] { "launch", "{weapon}", "target", "{target}" },
+}, allowPartialMatch: true, requiresConfirmation: true)
 ```
 
 ## VoskSlotDefinition

--- a/Documentation~/api/command-recogniser.md
+++ b/Documentation~/api/command-recogniser.md
@@ -17,12 +17,18 @@ Subscribes to speech events and runs text through the command parser pipeline: p
 | `slotAssets` | `VoskSlotAsset[]` | -- | Slot definitions for Inspector authoring |
 | `commandSetAssets` | `VoskCommandSetAsset[]` | -- | Command set definitions for Inspector authoring |
 | `initialActiveSetNames` | `string[]` | -- | Which sets to activate on startup when using Inspector authoring |
+| `pendingTimeout` | `float` | `5.0` | Maximum seconds a pending command waits for follow-up speech before timing out |
+| `pendingTimeoutBehavior` | `VoskPendingTimeoutBehavior` | `Cancel` | What happens on timeout: `Cancel` discards the command, `FireAsIs` fires it with whatever slots were filled |
+| `confirmVocabulary` | `string[]` | -- | Phrases that confirm a pending command. Empty = defaults ("confirm", "affirmative", "yes", "go ahead", "do it"). |
+| `cancelVocabulary` | `string[]` | -- | Phrases that cancel a pending command. Empty = defaults ("cancel", "abort", "negative", "belay that", "never mind"). |
 
 ## Properties
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `ActiveSetNames` | `string[]` | Names of currently active command sets (returns a snapshot copy) |
+| `HasPendingCommand` | `bool` | True if a command is currently in pending state (partial match or awaiting confirmation) |
+| `PendingCommand` | `VoskCommand?` | The currently pending command, or null if none |
 
 ## Events
 
@@ -31,6 +37,9 @@ Subscribes to speech events and runs text through the command parser pipeline: p
 | `OnCommandRecognised` | `Action<VoskCommand>` | Fired for each successfully recognised command that passes threshold and debounce filters |
 | `OnCommandsRecognised` | `Action<VoskCommand[]>` | Fired with the full batch of commands extracted from a single utterance (after sequential extraction) |
 | `OnUnrecognisedSpeech` | `Action<string>` | Fired when speech does not produce any accepted command -- either no pattern matched, or all matches were rejected by score, confidence, or debounce thresholds. The `string` parameter is the full buffered transcript. See [Unrecognised Speech](../command-recognition.md#unrecognised-speech). |
+| `OnCommandPending` | `Action<VoskCommand>` | Fired when a command enters pending state (partial match with unfilled required slots, or awaiting explicit confirmation). See [Pending Commands](../command-recognition.md#pending-commands). |
+| `OnCommandConfirmed` | `Action<VoskCommand>` | Fired when a pending command is confirmed by follow-up speech or explicit confirmation. Also fires `OnCommandRecognised` and `OnCommandsRecognised`. |
+| `OnCommandCancelled` | `Action<VoskCommand>` | Fired when a pending command is cancelled by timeout, explicit cancel vocabulary, or preemption by a new complete command. |
 
 ## Methods
 
@@ -46,11 +55,12 @@ Subscribes to speech events and runs text through the command parser pipeline: p
 | `UnregisterSlotValueProvider` | `(string slotName)` | Removes a value provider. The slot reverts to its full value set on the next parser rebuild. Returns `true` if a provider was removed. |
 | `NotifySlotChanged` | `()` | Rebuilds the parser to reflect current value-provider results. Does not touch the grammar or VOSK recogniser. No-op if `Configure` has not been called. Performs a full parser rebuild -- call only when values have actually changed. |
 | `RebuildParser` | `()` | Rebuilds only the parser from current effective slots and active commands. Grammar and VOSK recogniser are untouched. Throws if `Configure` has not been called. |
-| `RebuildGrammar` | `()` | Rebuilds and re-applies the VOSK grammar from the full universe of slot values. Performs stop/set grammar/start when recognition is running. Clears the utterance buffer. Throws if `Configure` has not been called. |
+| `RebuildGrammar` | `()` | Rebuilds and re-applies the VOSK grammar from the full universe of slot values. Performs stop/set grammar/start when recognition is running. Clears the utterance buffer. Defers if a command is pending. Throws if `Configure` has not been called. |
+| `CancelPendingCommand` | `()` | Cancels the currently pending command, firing `OnCommandCancelled`. No-op when no command is pending. |
 
 ## See Also
 
-- [Command Recognition](../command-recognition.md) -- patterns, slots, matching concepts, and dynamic slot filtering
+- [Command Recognition](../command-recognition.md) -- patterns, slots, matching concepts, dynamic slot filtering, and pending commands
 - [Command Sets](../command-sets.md) -- mode-specific grammar switching
 - [Inspector Authoring](../inspector-authoring.md) -- zero-code setup via ScriptableObjects
 - [Push-to-Talk](../push-to-talk.md) -- buffer flush on release

--- a/Documentation~/api/data-types.md
+++ b/Documentation~/api/data-types.md
@@ -54,6 +54,7 @@ A parsed command with intent and extracted slots.
 | `Confidence` | `float` | Minimum word confidence across matched tokens. `-1` means no word data was available. |
 | `Score` | `float` | Pattern match quality (0.0--1.0). Higher is better. |
 | `RawText` | `string` | The original VOSK transcript text |
+| `MatchedPatternIndex` | `int` | Index into the definition's `Patterns` array identifying which pattern produced this match. `-1` when unavailable. |
 
 ### Methods
 
@@ -84,6 +85,17 @@ Parser output wrapping match/no-match.
 | `IsMatch` | `bool` | True if a command pattern matched |
 | `Command` | `VoskCommand` | The parsed command (only valid when `IsMatch` is true) |
 | `RawText` | `string` | The original VOSK transcript |
+
+## VoskPendingTimeoutBehavior
+
+`public enum VoskPendingTimeoutBehavior` -- Namespace: `VoskXR.Commands`
+
+Determines what happens when a pending command's timeout expires.
+
+| Value | Description |
+|-------|-------------|
+| `Cancel` | The pending command is cancelled and discarded. `OnCommandCancelled` fires. |
+| `FireAsIs` | The pending command fires as-is with whatever slots were filled. `OnCommandConfirmed` and `OnCommandRecognised` fire. |
 
 ## See Also
 

--- a/Documentation~/api/scriptable-objects.md
+++ b/Documentation~/api/scriptable-objects.md
@@ -42,6 +42,8 @@ Nested serializable struct for variant-to-canonical mappings.
 |-------|------|-------------|
 | `intent` | `string` | The intent name |
 | `patterns` | `string[]` | Pattern strings with space-separated tokens (e.g. `"launch {?quantity} {weapon} target {target}"`) |
+| `allowPartialMatch` | `bool` | When enabled, the command enters pending state when matched with unfilled required slots, instead of being rejected. Follow-up speech can fill the missing slots. |
+| `requiresConfirmation` | `bool` | When enabled, the command enters pending state even when fully matched, requiring explicit confirmation before firing. |
 
 Each pattern string is split on whitespace into a token array at runtime. Tokens can be literal words, `{slotName}`, or `{?slotName}` (optional).
 

--- a/Documentation~/command-recognition.md
+++ b/Documentation~/command-recognition.md
@@ -31,11 +31,17 @@ Sequential Extraction
 Threshold Filter
     |  rejects commands below minScore or minConfidence
     |  confidence of -1 (no data) bypasses the minConfidence check
+    |  partial matches with allowPartialMatch enter pending state
+    v
+Pending Command Check
+    |  commands with requiresConfirmation enter pending state
+    |  follow-up speech fills missing slots or confirms/cancels
     v
 Debounce
     |  suppresses duplicate intents within commandCooldown seconds
     v
 Events: OnCommandRecognised, OnCommandsRecognised, OnUnrecognisedSpeech
+        OnCommandPending, OnCommandConfirmed, OnCommandCancelled
 ```
 
 Each stage is configurable. The most common tuning points are `bufferWindow` (how long to wait for split speech), `minScore` / `minConfidence` (quality thresholds), and `commandCooldown` (debounce window).
@@ -230,6 +236,72 @@ commandRecogniser.commandCooldown = 0.3f; // Default: 0.3s
 ```
 
 If the user says the same command twice quickly (or VOSK produces overlapping results), the second firing is suppressed.
+
+---
+
+## Pending Commands
+
+Sometimes a command partially matches (some required slots are unfilled) or needs explicit confirmation before a high-consequence action fires. The pending command system handles both cases by holding the command in a "pending" state and listening for follow-up speech.
+
+### Partial Match with Follow-Up Slot-Fill
+
+Set `allowPartialMatch: true` on a command definition to let it enter pending state when matched with unfilled required slots, instead of being rejected by the score threshold.
+
+```csharp
+var launchCmd = new VoskCommandDefinition("launch_weapon",
+    new[] { new[] { "launch", "{weapon}", "target", "{target}" } },
+    allowPartialMatch: true);
+```
+
+If the user says "launch missiles" without specifying a target, the command enters pending state and `OnCommandPending` fires. The system then listens for follow-up speech. If the user says "hotel one" within the `pendingTimeout` window, the target slot is filled and the command fires normally via `OnCommandConfirmed` and `OnCommandRecognised`.
+
+```csharp
+commandRecogniser.OnCommandPending += cmd =>
+    Debug.Log($"Waiting for: {cmd.Intent}");
+
+commandRecogniser.OnCommandConfirmed += cmd =>
+    Debug.Log($"Confirmed: {cmd.Intent} target={cmd.GetSlot("target")}");
+
+commandRecogniser.OnCommandCancelled += cmd =>
+    Debug.Log($"Cancelled: {cmd.Intent}");
+```
+
+### Explicit Confirmation
+
+Set `requiresConfirmation: true` to require the user to say a confirmation phrase before the command fires, even when fully matched.
+
+```csharp
+var selfDestruct = new VoskCommandDefinition("self_destruct",
+    new[] { new[] { "self", "destruct" } },
+    requiresConfirmation: true);
+```
+
+After saying "self destruct", the command enters pending state. The user must say "confirm" (or another confirm phrase) to fire it, or "cancel" to discard it.
+
+Default confirm vocabulary: "confirm", "affirmative", "yes", "go ahead", "do it". Default cancel vocabulary: "cancel", "abort", "negative", "belay that", "never mind". Override these with the `confirmVocabulary` and `cancelVocabulary` Inspector arrays on `VoskCommandRecogniser`.
+
+### Combined Partial + Confirmation
+
+A command with both `allowPartialMatch` and `requiresConfirmation` goes through two pending stages: first, follow-up speech fills missing slots; then, the user confirms before the command fires.
+
+### Timeout Behaviour
+
+Configure `pendingTimeout` (default 5s) and `pendingTimeoutBehavior` on `VoskCommandRecogniser`:
+
+- **Cancel** (default) -- the pending command is discarded and `OnCommandCancelled` fires.
+- **FireAsIs** -- the pending command fires with whatever slots were filled, even if some are still missing.
+
+### Preemption
+
+If a new complete command is recognised while a command is pending, the pending command is cancelled and the new command fires normally. This prevents stale pending commands from blocking normal operation.
+
+### Grammar Integration
+
+Confirm and cancel vocabulary words are automatically included in the VOSK grammar JSON, so they are recognised reliably in grammar mode. Custom vocabulary phrases are also merged into the grammar.
+
+### Programmatic Control
+
+Call `CancelPendingCommand()` to cancel the pending command from code (e.g. on a scene transition or mode switch). Check `HasPendingCommand` and `PendingCommand` to inspect the current pending state.
 
 ---
 

--- a/Documentation~/editor-testing.md
+++ b/Documentation~/editor-testing.md
@@ -19,6 +19,7 @@ Open **Window > VOSK XR > Command Debug** during Play Mode to inspect the full c
 ### Right Panel (command matching)
 
 - **Active command sets** -- which sets are currently loaded in the parser.
+- **Pending command** -- when a command is in pending state, shows the intent, reason (partial match or awaiting confirmation), filled slots, unfilled slots, and elapsed time since entering pending state.
 - **Last match breakdown** -- for each command definition attempted: intent, score, confidence, threshold pass/fail, and reject reason (if any). Accepted commands are highlighted in green.
 - **Slot details** -- matched slot word positions (start/end indices) with per-slot confidence.
 - **Match history** -- scrolling list of the last 20 match results with timestamps.

--- a/Documentation~/getting-started.md
+++ b/Documentation~/getting-started.md
@@ -15,7 +15,7 @@ Everything you need to install the SDK, set up a VOSK model, and get your first 
 To pin a specific version (recommended):
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0
 ```
 
 ### Via manifest.json
@@ -25,7 +25,7 @@ Add to `Packages/manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0"
   }
 }
 ```

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -7,7 +7,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 ## Getting Started
 
 - [Getting Started](getting-started.md) -- Installation, model setup, quick start examples, and the recognition lifecycle
-- [Command Recognition](command-recognition.md) -- How utterances become commands: the full parsing pipeline from audio to events
+- [Command Recognition](command-recognition.md) -- How utterances become commands: the full parsing pipeline from audio to events, including pending commands
 
 ## Guides
 

--- a/Editor/VoskBatchTestWindow.cs
+++ b/Editor/VoskBatchTestWindow.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  IMGUI EditorWindow for running batch test suites with results table and CSV export
+// Layer:    Editor
+// Owns:     VoskBatchTestWindow (public EditorWindow)
+// Depends:  VoskBatchTestRunner, VoskTestSuiteAsset, VoskSlotAsset, VoskCommandSetAsset, VoskTestResult
+// ============================================================================
 using System;
 using System.IO;
 using UnityEditor;
@@ -435,12 +441,6 @@ namespace VoskXR.Editor
             return value.Length <= maxLen ? value : value.Substring(0, maxLen - 3) + "...";
         }
 
-        static void DrawHorizontalSeparator()
-        {
-            EditorGUILayout.Space(1);
-            var rect = EditorGUILayout.GetControlRect(false, 1);
-            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
-            EditorGUILayout.Space(1);
-        }
+        static void DrawHorizontalSeparator() => VoskEditorGUI.DrawHorizontalSeparator();
     }
 }

--- a/Editor/VoskBatchTestWindow.cs
+++ b/Editor/VoskBatchTestWindow.cs
@@ -13,11 +13,6 @@ using VoskXR.Testing;
 
 namespace VoskXR.Editor
 {
-    /// <summary>
-    /// EditorWindow for visually running batch test suites against command definitions.
-    /// Displays a results table with pass/fail, score, per-row diagnostics expansion,
-    /// and CSV export.
-    /// </summary>
     public class VoskBatchTestWindow : EditorWindow
     {
         [SerializeField] VoskTestSuiteAsset testSuite;

--- a/Editor/VoskDebugWindow.cs
+++ b/Editor/VoskDebugWindow.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  IMGUI EditorWindow showing live command recognition diagnostics in Play Mode
+// Layer:    Editor
+// Owns:     VoskDebugWindow (public EditorWindow)
+// Depends:  VoskSpeechRecogniser, VoskCommandRecogniser, VoskMatchDiagnostics, VoskResult
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -548,21 +554,9 @@ namespace VoskXR.Editor
 
         // ─── Helpers ────────────────────────────────────────────────────
 
-        static void DrawSectionHeader(string title)
-        {
-            EditorGUILayout.Space(2);
-            var rect = EditorGUILayout.GetControlRect(false, 1);
-            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
-            EditorGUILayout.LabelField(title, EditorStyles.miniBoldLabel);
-        }
+        static void DrawSectionHeader(string title) => VoskEditorGUI.DrawSectionHeader(title);
 
-        static void DrawHorizontalSeparator()
-        {
-            EditorGUILayout.Space(2);
-            var rect = EditorGUILayout.GetControlRect(false, 1);
-            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
-            EditorGUILayout.Space(2);
-        }
+        static void DrawHorizontalSeparator() => VoskEditorGUI.DrawHorizontalSeparator();
 
         void DrawVerticalSeparator()
         {

--- a/Editor/VoskDebugWindow.cs
+++ b/Editor/VoskDebugWindow.cs
@@ -327,6 +327,8 @@ namespace VoskXR.Editor
 
             DrawActiveSets();
             EditorGUILayout.Space(4);
+            DrawPendingCommand();
+            EditorGUILayout.Space(4);
             DrawLastMatchBreakdown();
             EditorGUILayout.Space(8);
             DrawHistory();
@@ -343,6 +345,37 @@ namespace VoskXR.Editor
             {
                 EditorGUILayout.LabelField($"Active Sets: {string.Join(", ", setNames)}");
             }
+        }
+
+        void DrawPendingCommand()
+        {
+            var pending = _commandRecogniser.EditorPendingCommand;
+            if (!pending.HasValue)
+                return;
+
+            DrawSectionHeader("Pending Command");
+
+            var p = pending.Value;
+            EditorGUILayout.LabelField($"Intent: {p.Command.Intent}", EditorStyles.boldLabel);
+
+            string reason = p.Reason == VoskPendingReason.PartialMatch
+                ? "Partial match \u2014 waiting for follow-up"
+                : "Awaiting confirmation";
+            EditorGUILayout.LabelField($"Reason: {reason}");
+
+            if (p.Command.Slots.Length > 0)
+            {
+                EditorGUILayout.LabelField("Filled slots:", EditorStyles.miniLabel);
+                foreach (var slot in p.Command.Slots)
+                    EditorGUILayout.LabelField($"  {slot.Name} = \"{slot.Value}\"");
+            }
+
+            if (p.UnfilledSlots != null && p.UnfilledSlots.Length > 0)
+                EditorGUILayout.LabelField(
+                    $"Unfilled: {string.Join(", ", p.UnfilledSlots)}");
+
+            float elapsed = Time.time - p.CreatedTime;
+            EditorGUILayout.LabelField($"Elapsed: {elapsed:F1}s");
         }
 
         void DrawLastMatchBreakdown()

--- a/Editor/VoskDebugWindow.cs
+++ b/Editor/VoskDebugWindow.cs
@@ -13,10 +13,6 @@ using VoskXR.Commands;
 
 namespace VoskXR.Editor
 {
-    /// <summary>
-    /// IMGUI EditorWindow showing the VOSK command recognition pipeline state in real time.
-    /// Pull model: polls runtime components every repaint during Play Mode.
-    /// </summary>
     public class VoskDebugWindow : EditorWindow
     {
         const int MaxHistoryEntries = 20;

--- a/Editor/VoskEditorGUI.cs
+++ b/Editor/VoskEditorGUI.cs
@@ -1,0 +1,30 @@
+// ============================================================================
+// Purpose:  Shared IMGUI drawing helpers used by editor windows
+// Layer:    Editor
+// Owns:     VoskEditorGUI (internal static class)
+// Depends:  (none)
+// ============================================================================
+using UnityEditor;
+using UnityEngine;
+
+namespace VoskXR.Editor
+{
+    internal static class VoskEditorGUI
+    {
+        internal static void DrawSectionHeader(string title)
+        {
+            EditorGUILayout.Space(2);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+            EditorGUILayout.LabelField(title, EditorStyles.miniBoldLabel);
+        }
+
+        internal static void DrawHorizontalSeparator()
+        {
+            EditorGUILayout.Space(2);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, new Color(0.3f, 0.3f, 0.3f));
+            EditorGUILayout.Space(2);
+        }
+    }
+}

--- a/Editor/VoskEditorGUI.cs.meta
+++ b/Editor/VoskEditorGUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18d5f05b5d2d1d0428a76aef016387dd

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 - Utterance buffer merges split speech across VOSK VAD boundaries
 - Sequential command extraction (multiple commands per utterance)
 - Per-intent debounce to suppress rapid duplicate firings
+- Pending command system: partial match with follow-up slot-fill, and explicit confirmation before firing
 - Configurable `minConfidence` and `minScore` thresholds
 - Free-speech mode toggle for unconstrained vocabulary with best-effort matching
 
@@ -35,7 +36,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 - Batch test runner for regression-testing command definitions -- visual results table, CSV export, CI-safe Edit Mode API
 - Text injection API for Editor testing, CI, and replay without audio hardware
 - Live microphone in the Windows Editor -- speak into your PC mic, see commands fire in the Console
-- 18 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, batch testing, and asset conversion
+- 20 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, batch testing, asset conversion, and pending commands
 - Extensively tested on Quest 3 with published test matrices for every release
 
 ## Requirements
@@ -55,7 +56,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 **Pinned version:**
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0
 ```
 
 **Via manifest.json:**
@@ -63,7 +64,7 @@ https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.13.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0"
   }
 }
 ```
@@ -158,7 +159,7 @@ public class CommandDemo : MonoBehaviour
 For full documentation, see the [documentation index](Documentation~/index.md).
 
 - [Getting Started](Documentation~/getting-started.md) -- installation, model setup, quick start, lifecycle
-- [Command Recognition](Documentation~/command-recognition.md) -- pipeline concepts, patterns, slots, scoring
+- [Command Recognition](Documentation~/command-recognition.md) -- pipeline concepts, patterns, slots, scoring, pending commands
 - [Command Sets](Documentation~/command-sets.md) -- named sets, runtime mode switching
 - [Inspector Authoring](Documentation~/inspector-authoring.md) -- zero-code ScriptableObject setup
 - [Editor Testing](Documentation~/editor-testing.md) -- debug window, live mic, text injection, batch runner
@@ -177,7 +178,7 @@ Import samples via **Package Manager > VOSK XR Speech Recognition > Samples**.
 
 ## Running Tests
 
-The package includes 18 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model. Add `"testables": ["com.jinwoo1601.vosk-xr"]` to your project's `Packages/manifest.json`, then open **Window > General > Test Runner**. See [Getting Started](Documentation~/getting-started.md) for details.
+The package includes 20 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model. Add `"testables": ["com.jinwoo1601.vosk-xr"]` to your project's `Packages/manifest.json`, then open **Window > General > Test Runner**. See [Getting Started](Documentation~/getting-started.md) for details.
 
 ## Architecture
 
@@ -226,6 +227,8 @@ This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.
 
 | Version | Milestone |
 |---|---|
+| 0.15.0 | Pending commands: partial match, confirmation, follow-up slot-fill |
+| 0.14.0 | Dynamic slot value providers for runtime parser filtering |
 | 0.13.0 | Batch test runner for regression-testing command definitions |
 | 0.12.0 | Editor command debug window with live diagnostics |
 | 0.11.0 | Windows Editor live microphone backend |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.
 
 | Version | Milestone |
 |---|---|
+| 0.16.0 | Internal refactoring and per-utterance allocation reduction |
 | 0.15.0 | Pending commands: partial match, confirmation, follow-up slot-fill |
 | 0.14.0 | Dynamic slot value providers for runtime parser filtering |
 | 0.13.0 | Batch test runner for regression-testing command definitions |

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  InternalsVisibleTo declarations for test and editor assemblies
+// Layer:    Runtime
+// Owns:     (assembly-level attributes)
+// Depends:  (none)
+// ============================================================================
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Jinwoo1601.VoskXR.Tests.Runtime")]

--- a/Runtime/Commands/CommandDebouncer.cs
+++ b/Runtime/Commands/CommandDebouncer.cs
@@ -9,34 +9,22 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Tracks the last fire time per intent and provides cooldown checks.
-    /// </summary>
     internal sealed class CommandDebouncer
     {
         readonly Dictionary<string, float> _lastFireTime =
             new Dictionary<string, float>(StringComparer.Ordinal);
 
-        /// <summary>
-        /// Returns true if the intent was fired within the last <paramref name="cooldownSeconds"/>.
-        /// </summary>
         internal bool IsOnCooldown(string intent, float currentTime, float cooldownSeconds)
         {
             return _lastFireTime.TryGetValue(intent, out float lastTime)
                 && currentTime - lastTime < cooldownSeconds;
         }
 
-        /// <summary>
-        /// Records a fire event for the intent at the given time.
-        /// </summary>
         internal void RecordFire(string intent, float currentTime)
         {
             _lastFireTime[intent] = currentTime;
         }
 
-        /// <summary>
-        /// Clears all recorded fire times.
-        /// </summary>
         internal void Clear()
         {
             _lastFireTime.Clear();

--- a/Runtime/Commands/CommandDebouncer.cs
+++ b/Runtime/Commands/CommandDebouncer.cs
@@ -1,0 +1,45 @@
+// ============================================================================
+// Purpose:  Per-intent cooldown tracking to prevent duplicate command fires
+// Layer:    Runtime.Commands
+// Owns:     CommandDebouncer (internal sealed class)
+// Depends:  (none)
+// ============================================================================
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Tracks the last fire time per intent and provides cooldown checks.
+    /// </summary>
+    internal sealed class CommandDebouncer
+    {
+        readonly Dictionary<string, float> _lastFireTime =
+            new Dictionary<string, float>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Returns true if the intent was fired within the last <paramref name="cooldownSeconds"/>.
+        /// </summary>
+        internal bool IsOnCooldown(string intent, float currentTime, float cooldownSeconds)
+        {
+            return _lastFireTime.TryGetValue(intent, out float lastTime)
+                && currentTime - lastTime < cooldownSeconds;
+        }
+
+        /// <summary>
+        /// Records a fire event for the intent at the given time.
+        /// </summary>
+        internal void RecordFire(string intent, float currentTime)
+        {
+            _lastFireTime[intent] = currentTime;
+        }
+
+        /// <summary>
+        /// Clears all recorded fire times.
+        /// </summary>
+        internal void Clear()
+        {
+            _lastFireTime.Clear();
+        }
+    }
+}

--- a/Runtime/Commands/CommandDebouncer.cs.meta
+++ b/Runtime/Commands/CommandDebouncer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63a1bd3e6d828eb498d09c116e8fac75

--- a/Runtime/Commands/CommandSetManager.cs
+++ b/Runtime/Commands/CommandSetManager.cs
@@ -9,26 +9,16 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Manages named command sets and provides the active command definitions
-    /// after set activation. Also maintains a lookup from intent name to
-    /// definition for partial-match and confirmation checks.
-    /// </summary>
     internal sealed class CommandSetManager
     {
         Dictionary<string, VoskCommandSet> _sets;
         string[] _activeSetNames = Array.Empty<string>();
         Dictionary<string, VoskCommandDefinition> _commandLookup;
 
-        /// <summary>Names of the currently active command sets (defensive copy).</summary>
         internal string[] ActiveSetNames => _activeSetNames;
 
-        /// <summary>True when sets have been configured.</summary>
         internal bool HasSets => _sets != null;
 
-        /// <summary>
-        /// Registers named command sets. Does not activate any set.
-        /// </summary>
         internal void Configure(VoskCommandSet[] sets)
         {
             _sets = new Dictionary<string, VoskCommandSet>(sets.Length, StringComparer.Ordinal);
@@ -44,10 +34,6 @@ namespace VoskXR.Commands
             _commandLookup = null;
         }
 
-        /// <summary>
-        /// Activates the named command sets and returns the aggregated command definitions.
-        /// Also rebuilds the intent-to-definition lookup.
-        /// </summary>
         internal VoskCommandDefinition[] Activate(params string[] setNames)
         {
             if (_sets == null)
@@ -93,10 +79,6 @@ namespace VoskXR.Commands
             return commands;
         }
 
-        /// <summary>
-        /// Builds or rebuilds the intent-to-definition lookup from a flat command array.
-        /// Also used by the flat <c>Configure(slots, commands)</c> path.
-        /// </summary>
         internal void BuildLookup(VoskCommandDefinition[] commands)
         {
             if (_commandLookup == null)
@@ -109,10 +91,6 @@ namespace VoskXR.Commands
                 _commandLookup[commands[i].Intent] = commands[i];
         }
 
-        /// <summary>
-        /// Looks up a command definition by intent name.
-        /// Returns true if found; false otherwise.
-        /// </summary>
         internal bool TryLookupCommand(string intent, out VoskCommandDefinition definition)
         {
             if (_commandLookup != null)
@@ -122,9 +100,6 @@ namespace VoskXR.Commands
             return false;
         }
 
-        /// <summary>
-        /// Resets all state — sets, active names, and lookup.
-        /// </summary>
         internal void Reset()
         {
             _sets = null;

--- a/Runtime/Commands/CommandSetManager.cs
+++ b/Runtime/Commands/CommandSetManager.cs
@@ -1,0 +1,135 @@
+// ============================================================================
+// Purpose:  Registers named command sets and aggregates active definitions on activation
+// Layer:    Runtime.Commands
+// Owns:     CommandSetManager (internal sealed class)
+// Depends:  VoskCommandSet, VoskCommandDefinition
+// ============================================================================
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Manages named command sets and provides the active command definitions
+    /// after set activation. Also maintains a lookup from intent name to
+    /// definition for partial-match and confirmation checks.
+    /// </summary>
+    internal sealed class CommandSetManager
+    {
+        Dictionary<string, VoskCommandSet> _sets;
+        string[] _activeSetNames = Array.Empty<string>();
+        Dictionary<string, VoskCommandDefinition> _commandLookup;
+
+        /// <summary>Names of the currently active command sets (snapshot copy).</summary>
+        internal string[] ActiveSetNames => (string[])_activeSetNames.Clone();
+
+        /// <summary>True when sets have been configured.</summary>
+        internal bool HasSets => _sets != null;
+
+        /// <summary>
+        /// Registers named command sets. Does not activate any set.
+        /// </summary>
+        internal void Configure(VoskCommandSet[] sets)
+        {
+            _sets = new Dictionary<string, VoskCommandSet>(sets.Length, StringComparer.Ordinal);
+
+            for (int i = 0; i < sets.Length; i++)
+            {
+                if (_sets.ContainsKey(sets[i].Name))
+                    throw new ArgumentException($"Duplicate command set name: '{sets[i].Name}'.");
+                _sets[sets[i].Name] = sets[i];
+            }
+
+            _activeSetNames = Array.Empty<string>();
+            _commandLookup = null;
+        }
+
+        /// <summary>
+        /// Activates the named command sets and returns the aggregated command definitions.
+        /// Also rebuilds the intent-to-definition lookup.
+        /// </summary>
+        internal VoskCommandDefinition[] Activate(params string[] setNames)
+        {
+            if (_sets == null)
+                throw new InvalidOperationException(
+                    "Configure(sets) must be called before Activate().");
+
+            if (setNames == null)
+                setNames = Array.Empty<string>();
+
+            for (int i = 0; i < setNames.Length; i++)
+            {
+                if (!_sets.ContainsKey(setNames[i]))
+                    throw new ArgumentException(
+                        $"Unknown command set name: '{setNames[i]}'.", nameof(setNames));
+            }
+
+            int total = 0;
+            for (int i = 0; i < setNames.Length; i++)
+                total += _sets[setNames[i]].Commands.Length;
+
+            VoskCommandDefinition[] commands;
+            if (total == 0)
+            {
+                commands = Array.Empty<VoskCommandDefinition>();
+            }
+            else
+            {
+                commands = new VoskCommandDefinition[total];
+                int offset = 0;
+                for (int i = 0; i < setNames.Length; i++)
+                {
+                    var c = _sets[setNames[i]].Commands;
+                    Array.Copy(c, 0, commands, offset, c.Length);
+                    offset += c.Length;
+                }
+            }
+
+            _activeSetNames = setNames.Length > 0
+                ? (string[])setNames.Clone()
+                : Array.Empty<string>();
+
+            BuildLookup(commands);
+            return commands;
+        }
+
+        /// <summary>
+        /// Builds or rebuilds the intent-to-definition lookup from a flat command array.
+        /// Also used by the flat <c>Configure(slots, commands)</c> path.
+        /// </summary>
+        internal void BuildLookup(VoskCommandDefinition[] commands)
+        {
+            if (_commandLookup == null)
+                _commandLookup = new Dictionary<string, VoskCommandDefinition>(
+                    commands.Length, StringComparer.Ordinal);
+            else
+                _commandLookup.Clear();
+
+            for (int i = 0; i < commands.Length; i++)
+                _commandLookup[commands[i].Intent] = commands[i];
+        }
+
+        /// <summary>
+        /// Looks up a command definition by intent name.
+        /// Returns true if found; false otherwise.
+        /// </summary>
+        internal bool TryLookupCommand(string intent, out VoskCommandDefinition definition)
+        {
+            if (_commandLookup != null)
+                return _commandLookup.TryGetValue(intent, out definition);
+
+            definition = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Resets all state — sets, active names, and lookup.
+        /// </summary>
+        internal void Reset()
+        {
+            _sets = null;
+            _activeSetNames = Array.Empty<string>();
+            _commandLookup = null;
+        }
+    }
+}

--- a/Runtime/Commands/CommandSetManager.cs
+++ b/Runtime/Commands/CommandSetManager.cs
@@ -20,8 +20,8 @@ namespace VoskXR.Commands
         string[] _activeSetNames = Array.Empty<string>();
         Dictionary<string, VoskCommandDefinition> _commandLookup;
 
-        /// <summary>Names of the currently active command sets (snapshot copy).</summary>
-        internal string[] ActiveSetNames => (string[])_activeSetNames.Clone();
+        /// <summary>Names of the currently active command sets (defensive copy).</summary>
+        internal string[] ActiveSetNames => _activeSetNames;
 
         /// <summary>True when sets have been configured.</summary>
         internal bool HasSets => _sets != null;

--- a/Runtime/Commands/CommandSetManager.cs.meta
+++ b/Runtime/Commands/CommandSetManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b906e8c41685095418a16440fbed07b5

--- a/Runtime/Commands/DynamicSlotManager.cs
+++ b/Runtime/Commands/DynamicSlotManager.cs
@@ -1,0 +1,113 @@
+// ============================================================================
+// Purpose:  Manages runtime slot value providers that filter which values the parser accepts
+// Layer:    Runtime.Commands
+// Owns:     DynamicSlotManager (internal sealed class)
+// Depends:  VoskSlotDefinition, VoskSlotType
+// ============================================================================
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Maintains a registry of slot value providers (functions returning active values)
+    /// and builds effective slot arrays by filtering base slots against provider results.
+    /// </summary>
+    internal sealed class DynamicSlotManager
+    {
+        Dictionary<string, Func<string[]>> _providers;
+
+        /// <summary>True when at least one provider is registered.</summary>
+        internal bool HasProviders => _providers != null && _providers.Count > 0;
+
+        /// <summary>
+        /// Registers a function that controls which values of the named slot
+        /// the parser will accept.
+        /// </summary>
+        internal void Register(string slotName, Func<string[]> provider)
+        {
+            if (slotName == null) throw new ArgumentNullException(nameof(slotName));
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
+            if (_providers == null)
+                _providers = new Dictionary<string, Func<string[]>>(StringComparer.Ordinal);
+
+            _providers[slotName] = provider;
+        }
+
+        /// <summary>
+        /// Removes a previously registered value provider.
+        /// </summary>
+        internal bool Unregister(string slotName)
+        {
+            if (slotName == null) throw new ArgumentNullException(nameof(slotName));
+            return _providers != null && _providers.Remove(slotName);
+        }
+
+        /// <summary>
+        /// Builds an effective slot array by filtering <paramref name="baseSlots"/>
+        /// against registered provider results. Returns the original array if no
+        /// providers are registered or none produce a filter.
+        /// </summary>
+        internal VoskSlotDefinition[] BuildEffectiveSlots(VoskSlotDefinition[] baseSlots)
+        {
+            if (_providers == null || _providers.Count == 0)
+                return baseSlots;
+
+            VoskSlotDefinition[] effective = null;
+
+            for (int i = 0; i < baseSlots.Length; i++)
+            {
+                var slot = baseSlots[i];
+
+                if (slot.Type == VoskSlotType.NumberSequence ||
+                    !_providers.TryGetValue(slot.Name, out var provider))
+                {
+                    if (effective != null)
+                        effective[i] = slot;
+                    continue;
+                }
+
+                var activeValues = provider();
+                if (activeValues == null)
+                {
+                    if (effective != null)
+                        effective[i] = slot;
+                    continue;
+                }
+
+                if (effective == null)
+                {
+                    effective = new VoskSlotDefinition[baseSlots.Length];
+                    Array.Copy(baseSlots, effective, i);
+                }
+
+                if (activeValues.Length == 0)
+                {
+                    effective[i] = new VoskSlotDefinition(slot.Name, Array.Empty<string>(), null);
+                    continue;
+                }
+
+                var activeSet = new HashSet<string>(activeValues, StringComparer.Ordinal);
+
+                Dictionary<string, string> filteredAliases = null;
+                if (slot.Aliases != null)
+                {
+                    foreach (var kvp in slot.Aliases)
+                    {
+                        if (activeSet.Contains(kvp.Value))
+                        {
+                            if (filteredAliases == null)
+                                filteredAliases = new Dictionary<string, string>(StringComparer.Ordinal);
+                            filteredAliases[kvp.Key] = kvp.Value;
+                        }
+                    }
+                }
+
+                effective[i] = new VoskSlotDefinition(slot.Name, activeValues, filteredAliases);
+            }
+
+            return effective ?? baseSlots;
+        }
+    }
+}

--- a/Runtime/Commands/DynamicSlotManager.cs
+++ b/Runtime/Commands/DynamicSlotManager.cs
@@ -9,21 +9,12 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Maintains a registry of slot value providers (functions returning active values)
-    /// and builds effective slot arrays by filtering base slots against provider results.
-    /// </summary>
     internal sealed class DynamicSlotManager
     {
         Dictionary<string, Func<string[]>> _providers;
 
-        /// <summary>True when at least one provider is registered.</summary>
         internal bool HasProviders => _providers != null && _providers.Count > 0;
 
-        /// <summary>
-        /// Registers a function that controls which values of the named slot
-        /// the parser will accept.
-        /// </summary>
         internal void Register(string slotName, Func<string[]> provider)
         {
             if (slotName == null) throw new ArgumentNullException(nameof(slotName));
@@ -35,20 +26,12 @@ namespace VoskXR.Commands
             _providers[slotName] = provider;
         }
 
-        /// <summary>
-        /// Removes a previously registered value provider.
-        /// </summary>
         internal bool Unregister(string slotName)
         {
             if (slotName == null) throw new ArgumentNullException(nameof(slotName));
             return _providers != null && _providers.Remove(slotName);
         }
 
-        /// <summary>
-        /// Builds an effective slot array by filtering <paramref name="baseSlots"/>
-        /// against registered provider results. Returns the original array if no
-        /// providers are registered or none produce a filter.
-        /// </summary>
         internal VoskSlotDefinition[] BuildEffectiveSlots(VoskSlotDefinition[] baseSlots)
         {
             if (_providers == null || _providers.Count == 0)

--- a/Runtime/Commands/DynamicSlotManager.cs.meta
+++ b/Runtime/Commands/DynamicSlotManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ddc0b1a29d544842944922f491ced9f

--- a/Runtime/Commands/GrammarManager.cs
+++ b/Runtime/Commands/GrammarManager.cs
@@ -8,29 +8,14 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Manages grammar JSON generation, application, and the deferred-rebuild flag.
-    /// The recogniser delegates grammar operations here to keep grammar lifecycle
-    /// separate from command matching and event dispatch.
-    /// </summary>
     internal sealed class GrammarManager
     {
-        /// <summary>The current grammar JSON string, or null if not yet generated.</summary>
         internal string CurrentJson { get; private set; }
 
-        /// <summary>True when the grammar has been applied to the speech recogniser.</summary>
         internal bool IsApplied { get; set; }
 
-        /// <summary>
-        /// True when a grammar rebuild was requested while a pending command was active.
-        /// The recogniser drains this after the pending command resolves.
-        /// </summary>
         internal bool GrammarRebuildDeferred { get; set; }
 
-        /// <summary>
-        /// Generates grammar JSON from the given slots and commands.
-        /// Does not apply it to the speech recogniser.
-        /// </summary>
         internal void Rebuild(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands,
             string[] followUpWords)
         {
@@ -38,10 +23,6 @@ namespace VoskXR.Commands
             IsApplied = false;
         }
 
-        /// <summary>
-        /// Applies the current grammar if the model is ready and free-speech mode is off.
-        /// Used when the model becomes ready after grammar was generated.
-        /// </summary>
         internal void ApplyIfReady(VoskSpeechRecogniser recogniser, bool freeSpeechMode)
         {
             if (freeSpeechMode || IsApplied || CurrentJson == null)
@@ -54,10 +35,6 @@ namespace VoskXR.Commands
             IsApplied = true;
         }
 
-        /// <summary>
-        /// Performs the stop → set grammar → start cycle. Used when grammar changes
-        /// while recognition is running.
-        /// </summary>
         internal void ForceApply(VoskSpeechRecogniser recogniser, bool freeSpeechMode)
         {
             if (freeSpeechMode || recogniser == null || !recogniser.IsModelReady)
@@ -75,9 +52,6 @@ namespace VoskXR.Commands
                 recogniser.StartRecognition();
         }
 
-        /// <summary>
-        /// Resets grammar state — clears JSON, applied flag, and deferred flag.
-        /// </summary>
         internal void Reset()
         {
             CurrentJson = null;

--- a/Runtime/Commands/GrammarManager.cs
+++ b/Runtime/Commands/GrammarManager.cs
@@ -1,0 +1,88 @@
+// ============================================================================
+// Purpose:  Generates VOSK grammar JSON and coordinates stop/set/start lifecycle
+// Layer:    Runtime.Commands
+// Owns:     GrammarManager (internal sealed class)
+// Depends:  VoskCommandParser, VoskSpeechRecogniser, VoskSlotDefinition, VoskCommandDefinition
+// ============================================================================
+using System;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Manages grammar JSON generation, application, and the deferred-rebuild flag.
+    /// The recogniser delegates grammar operations here to keep grammar lifecycle
+    /// separate from command matching and event dispatch.
+    /// </summary>
+    internal sealed class GrammarManager
+    {
+        /// <summary>The current grammar JSON string, or null if not yet generated.</summary>
+        internal string CurrentJson { get; private set; }
+
+        /// <summary>True when the grammar has been applied to the speech recogniser.</summary>
+        internal bool IsApplied { get; set; }
+
+        /// <summary>
+        /// True when a grammar rebuild was requested while a pending command was active.
+        /// The recogniser drains this after the pending command resolves.
+        /// </summary>
+        internal bool GrammarRebuildDeferred { get; set; }
+
+        /// <summary>
+        /// Generates grammar JSON from the given slots and commands.
+        /// Does not apply it to the speech recogniser.
+        /// </summary>
+        internal void Rebuild(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands,
+            string[] followUpWords)
+        {
+            CurrentJson = VoskCommandParser.GenerateGrammarJson(slots, commands, followUpWords);
+            IsApplied = false;
+        }
+
+        /// <summary>
+        /// Applies the current grammar if the model is ready and free-speech mode is off.
+        /// Used when the model becomes ready after grammar was generated.
+        /// </summary>
+        internal void ApplyIfReady(VoskSpeechRecogniser recogniser, bool freeSpeechMode)
+        {
+            if (freeSpeechMode || IsApplied || CurrentJson == null)
+                return;
+
+            if (recogniser == null || !recogniser.IsModelReady)
+                return;
+
+            recogniser.SetGrammar(CurrentJson);
+            IsApplied = true;
+        }
+
+        /// <summary>
+        /// Performs the stop → set grammar → start cycle. Used when grammar changes
+        /// while recognition is running.
+        /// </summary>
+        internal void ForceApply(VoskSpeechRecogniser recogniser, bool freeSpeechMode)
+        {
+            if (freeSpeechMode || recogniser == null || !recogniser.IsModelReady)
+                return;
+
+            bool wasRunning = recogniser.IsRecognising;
+
+            if (wasRunning)
+                recogniser.StopRecognition();
+
+            recogniser.SetGrammar(CurrentJson);
+            IsApplied = true;
+
+            if (wasRunning)
+                recogniser.StartRecognition();
+        }
+
+        /// <summary>
+        /// Resets grammar state — clears JSON, applied flag, and deferred flag.
+        /// </summary>
+        internal void Reset()
+        {
+            CurrentJson = null;
+            IsApplied = false;
+            GrammarRebuildDeferred = false;
+        }
+    }
+}

--- a/Runtime/Commands/GrammarManager.cs.meta
+++ b/Runtime/Commands/GrammarManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f71493aa7df688b4ba930d3714401129

--- a/Runtime/Commands/PendingCommandHandler.cs
+++ b/Runtime/Commands/PendingCommandHandler.cs
@@ -1,0 +1,276 @@
+// ============================================================================
+// Purpose:  State machine for partial-match follow-up, confirmation, cancellation, and timeout
+// Layer:    Runtime.Commands
+// Owns:     PendingCommandHandler (internal sealed class), PendingOutcome (internal enum), PendingResolution (internal readonly struct)
+// Depends:  VoskCommand, VoskCommandDefinition, VoskPendingCommand, VoskFollowUpVocabulary, VoskCommandParser
+// ============================================================================
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    internal enum PendingOutcome
+    {
+        None,
+        Confirmed,
+        Cancelled,
+        Entered,
+        ReEnteredPending,
+    }
+
+    internal readonly struct PendingResolution
+    {
+        internal readonly PendingOutcome Outcome;
+        internal readonly VoskCommand Command;
+
+        PendingResolution(PendingOutcome outcome, VoskCommand command)
+        {
+            Outcome = outcome;
+            Command = command;
+        }
+
+        internal static PendingResolution Confirmed(VoskCommand cmd)
+            => new PendingResolution(PendingOutcome.Confirmed, cmd);
+
+        internal static PendingResolution Cancelled(VoskCommand cmd)
+            => new PendingResolution(PendingOutcome.Cancelled, cmd);
+
+        internal static PendingResolution Entered(VoskCommand cmd)
+            => new PendingResolution(PendingOutcome.Entered, cmd);
+
+        internal static PendingResolution ReEntered(VoskCommand cmd)
+            => new PendingResolution(PendingOutcome.ReEnteredPending, cmd);
+
+        internal static PendingResolution NoAction()
+            => new PendingResolution(PendingOutcome.None, default);
+    }
+
+    /// <summary>
+    /// Manages the pending command state machine. Returns <see cref="PendingResolution"/>
+    /// structs that the recogniser interprets to dispatch events, record debounce times,
+    /// and drain deferred grammar rebuilds.
+    /// </summary>
+    internal sealed class PendingCommandHandler
+    {
+        VoskPendingCommand? _pendingCommand;
+
+        internal bool HasPending => _pendingCommand.HasValue;
+        internal VoskPendingCommand? Current => _pendingCommand;
+        internal VoskCommand? PendingCommand => _pendingCommand?.Command;
+
+        /// <summary>
+        /// Enters pending state for the given command. Cancels any existing pending first.
+        /// Returns two resolutions: <paramref name="cancelledPrevious"/> for the displaced
+        /// command (may be <c>NoAction</c>), and the return value for the newly entered command.
+        /// </summary>
+        internal PendingResolution EnterPending(VoskCommand command,
+            VoskCommandDefinition definition, string[] unfilledSlots,
+            VoskPendingReason reason, float currentTime,
+            out PendingResolution cancelledPrevious)
+        {
+            cancelledPrevious = _pendingCommand.HasValue
+                ? Cancel()
+                : PendingResolution.NoAction();
+
+            _pendingCommand = new VoskPendingCommand
+            {
+                Command = command,
+                Definition = definition,
+                UnfilledSlots = unfilledSlots,
+                Reason = reason,
+                CreatedTime = currentTime,
+            };
+
+            return PendingResolution.Entered(command);
+        }
+
+        /// <summary>
+        /// Checks if the pre-split tokens match confirm or cancel vocabulary.
+        /// Returns a resolution describing what happened.
+        /// </summary>
+        internal PendingResolution TryHandleConfirmCancel(string[] tokens,
+            string[] confirmVocab, string[] cancelVocab)
+        {
+            if (tokens.Length == 0)
+                return PendingResolution.NoAction();
+
+            string normalized = tokens.Length == 1 ? tokens[0] : string.Join(" ", tokens);
+
+            string[] effectiveCancel = cancelVocab != null && cancelVocab.Length > 0
+                ? cancelVocab : VoskFollowUpVocabulary.DefaultCancel;
+            string[] effectiveConfirm = confirmVocab != null && confirmVocab.Length > 0
+                ? confirmVocab : VoskFollowUpVocabulary.DefaultConfirm;
+
+            if (IsVocabularyMatch(normalized, effectiveCancel))
+                return Cancel();
+
+            if (IsVocabularyMatch(normalized, effectiveConfirm))
+            {
+                var confirmed = _pendingCommand.Value;
+                _pendingCommand = null;
+                return PendingResolution.Confirmed(confirmed.Command);
+            }
+
+            return PendingResolution.NoAction();
+        }
+
+        /// <summary>
+        /// Attempts to fill unfilled slots from follow-up speech.
+        /// Returns the completed command if any new slots were filled, null otherwise.
+        /// </summary>
+        internal VoskCommand? TryFollowUpSlotFill(string text, string[] tokens,
+            Dictionary<string, float> wordConfidence, VoskCommandParser parser)
+        {
+            var pending = _pendingCommand.Value;
+            if (pending.UnfilledSlots == null || pending.UnfilledSlots.Length == 0)
+                return null;
+
+            if (tokens.Length == 0)
+                return null;
+
+            var newSlots = new List<VoskSlotMatch>(pending.Command.Slots);
+            int tokenIdx = 0;
+
+            foreach (string slotName in pending.UnfilledSlots)
+            {
+                bool found = false;
+                for (int startIdx = tokenIdx; startIdx < tokens.Length; startIdx++)
+                {
+                    if (tokens[startIdx] == VoskCommandParser.UnkToken)
+                        continue;
+
+                    string value = parser.TryMatchSlotByName(
+                        tokens, startIdx, slotName, out int consumed);
+                    if (value != null)
+                    {
+                        newSlots.Add(new VoskSlotMatch(slotName, value));
+                        tokenIdx = startIdx + consumed;
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    break;
+            }
+
+            // Must have filled at least one new slot
+            if (newSlots.Count == pending.Command.Slots.Length)
+                return null;
+
+            float followUpConf = VoskCommandParser.ComputeConfidence(
+                tokens, 0, tokens.Length, wordConfidence);
+
+            float mergedConfidence = pending.Command.Confidence >= 0f && followUpConf >= 0f
+                ? Math.Min(pending.Command.Confidence, followUpConf)
+                : pending.Command.Confidence >= 0f ? pending.Command.Confidence : followUpConf;
+
+            return new VoskCommand(
+                pending.Command.Intent,
+                newSlots.ToArray(),
+                mergedConfidence,
+                pending.Command.Score,
+                pending.Command.RawText + " " + text,
+                null,
+                pending.Command.MatchedPatternIndex);
+        }
+
+        /// <summary>
+        /// Completes a pending command. Handles re-entry for partial-match commands
+        /// that also require confirmation.
+        /// </summary>
+        internal PendingResolution Complete(VoskCommand completed)
+        {
+            var pending = _pendingCommand.Value;
+            _pendingCommand = null;
+
+            // If the definition also requires confirmation and we were pending
+            // for partial match, re-enter pending for confirmation
+            if (pending.Definition.RequiresConfirmation &&
+                pending.Reason == VoskPendingReason.PartialMatch)
+            {
+                _pendingCommand = new VoskPendingCommand
+                {
+                    Command = completed,
+                    Definition = pending.Definition,
+                    UnfilledSlots = Array.Empty<string>(),
+                    Reason = VoskPendingReason.AwaitingConfirmation,
+                    CreatedTime = pending.CreatedTime,
+                };
+                return PendingResolution.ReEntered(completed);
+            }
+
+            return PendingResolution.Confirmed(completed);
+        }
+
+        /// <summary>
+        /// Handles pending timeout based on the configured behavior.
+        /// </summary>
+        internal PendingResolution HandleTimeout(VoskPendingTimeoutBehavior behavior)
+        {
+            var pending = _pendingCommand.Value;
+            _pendingCommand = null;
+
+            if (behavior == VoskPendingTimeoutBehavior.FireAsIs)
+                return PendingResolution.Confirmed(pending.Command);
+
+            return PendingResolution.Cancelled(pending.Command);
+        }
+
+        /// <summary>
+        /// Cancels the pending command if one is active.
+        /// </summary>
+        internal PendingResolution Cancel()
+        {
+            if (!_pendingCommand.HasValue)
+                return PendingResolution.NoAction();
+
+            var cancelled = _pendingCommand.Value;
+            _pendingCommand = null;
+            return PendingResolution.Cancelled(cancelled.Command);
+        }
+
+        /// <summary>
+        /// Computes which required slots in the matched pattern are unfilled.
+        /// </summary>
+        internal static string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
+        {
+            if (cmd.MatchedPatternIndex < 0 ||
+                cmd.MatchedPatternIndex >= def.Patterns.Length)
+                return Array.Empty<string>();
+
+            var pattern = def.Patterns[cmd.MatchedPatternIndex];
+            List<string> unfilled = null;
+
+            foreach (string element in pattern)
+            {
+                string slotName = VoskCommandParser.ExtractSlotName(element);
+                if (slotName != null && !VoskCommandParser.IsOptionalSlot(element)
+                    && !cmd.HasSlot(slotName))
+                {
+                    if (unfilled == null)
+                        unfilled = new List<string>();
+                    unfilled.Add(slotName);
+                }
+            }
+
+            return unfilled?.ToArray() ?? Array.Empty<string>();
+        }
+
+        static bool IsVocabularyMatch(string normalized, string[] vocabulary)
+        {
+            for (int i = 0; i < vocabulary.Length; i++)
+            {
+                if (string.Equals(normalized, vocabulary[i], StringComparison.Ordinal))
+                    return true;
+            }
+            return false;
+        }
+
+        // Test-only: force-set the pending command state for timeout testing.
+        internal void ForceSetForTest(VoskPendingCommand pending)
+        {
+            _pendingCommand = pending;
+        }
+    }
+}

--- a/Runtime/Commands/PendingCommandHandler.cs
+++ b/Runtime/Commands/PendingCommandHandler.cs
@@ -45,11 +45,6 @@ namespace VoskXR.Commands
             => new PendingResolution(PendingOutcome.None, default);
     }
 
-    /// <summary>
-    /// Manages the pending command state machine. Returns <see cref="PendingResolution"/>
-    /// structs that the recogniser interprets to dispatch events, record debounce times,
-    /// and drain deferred grammar rebuilds.
-    /// </summary>
     internal sealed class PendingCommandHandler
     {
         VoskPendingCommand? _pendingCommand;
@@ -61,11 +56,6 @@ namespace VoskXR.Commands
         internal VoskPendingCommand? Current => _pendingCommand;
         internal VoskCommand? PendingCommand => _pendingCommand?.Command;
 
-        /// <summary>
-        /// Enters pending state for the given command. Cancels any existing pending first.
-        /// Returns two resolutions: <paramref name="cancelledPrevious"/> for the displaced
-        /// command (may be <c>NoAction</c>), and the return value for the newly entered command.
-        /// </summary>
         internal PendingResolution EnterPending(VoskCommand command,
             VoskCommandDefinition definition, string[] unfilledSlots,
             VoskPendingReason reason, float currentTime,
@@ -87,10 +77,6 @@ namespace VoskXR.Commands
             return PendingResolution.Entered(command);
         }
 
-        /// <summary>
-        /// Checks if the pre-split tokens match confirm or cancel vocabulary.
-        /// Returns a resolution describing what happened.
-        /// </summary>
         internal PendingResolution TryHandleConfirmCancel(string[] tokens,
             string[] confirmVocab, string[] cancelVocab)
         {
@@ -115,10 +101,6 @@ namespace VoskXR.Commands
             return PendingResolution.NoAction();
         }
 
-        /// <summary>
-        /// Attempts to fill unfilled slots from follow-up speech.
-        /// Returns the completed command if any new slots were filled, null otherwise.
-        /// </summary>
         internal VoskCommand? TryFollowUpSlotFill(string text, string[] tokens,
             Dictionary<string, float> wordConfidence, VoskCommandParser parser)
         {
@@ -178,20 +160,23 @@ namespace VoskXR.Commands
             for (int i = 0; i < slotCount; i++)
                 slotsArray[i] = _followUpSlotBuf[i];
 
+            // Re-score against the matched pattern now that slots are filled.
+            // The original partial-match score penalised missing elements; with
+            // follow-up data the score should reflect the completed match.
+            float mergedScore = parser.ScoreFollowUp(
+                pending.Command.Intent, pending.Command.MatchedPatternIndex,
+                _followUpSlotBuf);
+
             return new VoskCommand(
                 pending.Command.Intent,
                 slotsArray,
                 mergedConfidence,
-                pending.Command.Score,
+                mergedScore,
                 pending.Command.RawText + " " + text,
                 null,
                 pending.Command.MatchedPatternIndex);
         }
 
-        /// <summary>
-        /// Completes a pending command. Handles re-entry for partial-match commands
-        /// that also require confirmation.
-        /// </summary>
         internal PendingResolution Complete(VoskCommand completed)
         {
             var pending = _pendingCommand.Value;
@@ -216,9 +201,6 @@ namespace VoskXR.Commands
             return PendingResolution.Confirmed(completed);
         }
 
-        /// <summary>
-        /// Handles pending timeout based on the configured behavior.
-        /// </summary>
         internal PendingResolution HandleTimeout(VoskPendingTimeoutBehavior behavior)
         {
             var pending = _pendingCommand.Value;
@@ -230,9 +212,6 @@ namespace VoskXR.Commands
             return PendingResolution.Cancelled(pending.Command);
         }
 
-        /// <summary>
-        /// Cancels the pending command if one is active.
-        /// </summary>
         internal PendingResolution Cancel()
         {
             if (!_pendingCommand.HasValue)
@@ -243,9 +222,6 @@ namespace VoskXR.Commands
             return PendingResolution.Cancelled(cancelled.Command);
         }
 
-        /// <summary>
-        /// Computes which required slots in the matched pattern are unfilled.
-        /// </summary>
         internal string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
         {
             if (cmd.MatchedPatternIndex < 0 ||
@@ -268,12 +244,6 @@ namespace VoskXR.Commands
             return _unfilledBuf.Count > 0 ? _unfilledBuf.ToArray() : Array.Empty<string>();
         }
 
-        /// <summary>
-        /// Matches vocabulary phrases directly against the token array without
-        /// joining tokens or splitting phrases. Walks each phrase span
-        /// word-by-word and compares against consecutive tokens.
-        /// A match requires all phrase words to correspond 1:1 with all tokens.
-        /// </summary>
         static bool IsVocabularyMatchTokens(string[] tokens, string[] vocabulary)
         {
             for (int v = 0; v < vocabulary.Length; v++)

--- a/Runtime/Commands/PendingCommandHandler.cs
+++ b/Runtime/Commands/PendingCommandHandler.cs
@@ -54,6 +54,9 @@ namespace VoskXR.Commands
     {
         VoskPendingCommand? _pendingCommand;
 
+        readonly List<VoskSlotMatch> _followUpSlotBuf = new List<VoskSlotMatch>();
+        readonly List<string> _unfilledBuf = new List<string>();
+
         internal bool HasPending => _pendingCommand.HasValue;
         internal VoskPendingCommand? Current => _pendingCommand;
         internal VoskCommand? PendingCommand => _pendingCommand?.Command;
@@ -94,17 +97,15 @@ namespace VoskXR.Commands
             if (tokens.Length == 0)
                 return PendingResolution.NoAction();
 
-            string normalized = tokens.Length == 1 ? tokens[0] : string.Join(" ", tokens);
-
             string[] effectiveCancel = cancelVocab != null && cancelVocab.Length > 0
                 ? cancelVocab : VoskFollowUpVocabulary.DefaultCancel;
             string[] effectiveConfirm = confirmVocab != null && confirmVocab.Length > 0
                 ? confirmVocab : VoskFollowUpVocabulary.DefaultConfirm;
 
-            if (IsVocabularyMatch(normalized, effectiveCancel))
+            if (IsVocabularyMatchTokens(tokens, effectiveCancel))
                 return Cancel();
 
-            if (IsVocabularyMatch(normalized, effectiveConfirm))
+            if (IsVocabularyMatchTokens(tokens, effectiveConfirm))
             {
                 var confirmed = _pendingCommand.Value;
                 _pendingCommand = null;
@@ -128,7 +129,11 @@ namespace VoskXR.Commands
             if (tokens.Length == 0)
                 return null;
 
-            var newSlots = new List<VoskSlotMatch>(pending.Command.Slots);
+            _followUpSlotBuf.Clear();
+            var existingSlots = pending.Command.Slots;
+            for (int i = 0; i < existingSlots.Length; i++)
+                _followUpSlotBuf.Add(existingSlots[i]);
+
             int tokenIdx = 0;
 
             foreach (string slotName in pending.UnfilledSlots)
@@ -143,7 +148,7 @@ namespace VoskXR.Commands
                         tokens, startIdx, slotName, out int consumed);
                     if (value != null)
                     {
-                        newSlots.Add(new VoskSlotMatch(slotName, value));
+                        _followUpSlotBuf.Add(new VoskSlotMatch(slotName, value));
                         tokenIdx = startIdx + consumed;
                         found = true;
                         break;
@@ -155,7 +160,7 @@ namespace VoskXR.Commands
             }
 
             // Must have filled at least one new slot
-            if (newSlots.Count == pending.Command.Slots.Length)
+            if (_followUpSlotBuf.Count == existingSlots.Length)
                 return null;
 
             float followUpConf = VoskCommandParser.ComputeConfidence(
@@ -165,9 +170,17 @@ namespace VoskXR.Commands
                 ? Math.Min(pending.Command.Confidence, followUpConf)
                 : pending.Command.Confidence >= 0f ? pending.Command.Confidence : followUpConf;
 
+            // Allocate a fresh array — this command crosses into public events
+            // (OnCommandConfirmed/OnCommandRecognised) where subscribers may retain it,
+            // so it must not be pool-borrowed.
+            int slotCount = _followUpSlotBuf.Count;
+            var slotsArray = new VoskSlotMatch[slotCount];
+            for (int i = 0; i < slotCount; i++)
+                slotsArray[i] = _followUpSlotBuf[i];
+
             return new VoskCommand(
                 pending.Command.Intent,
-                newSlots.ToArray(),
+                slotsArray,
                 mergedConfidence,
                 pending.Command.Score,
                 pending.Command.RawText + " " + text,
@@ -233,14 +246,14 @@ namespace VoskXR.Commands
         /// <summary>
         /// Computes which required slots in the matched pattern are unfilled.
         /// </summary>
-        internal static string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
+        internal string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
         {
             if (cmd.MatchedPatternIndex < 0 ||
                 cmd.MatchedPatternIndex >= def.Patterns.Length)
                 return Array.Empty<string>();
 
             var pattern = def.Patterns[cmd.MatchedPatternIndex];
-            List<string> unfilled = null;
+            _unfilledBuf.Clear();
 
             foreach (string element in pattern)
             {
@@ -248,23 +261,56 @@ namespace VoskXR.Commands
                 if (slotName != null && !VoskCommandParser.IsOptionalSlot(element)
                     && !cmd.HasSlot(slotName))
                 {
-                    if (unfilled == null)
-                        unfilled = new List<string>();
-                    unfilled.Add(slotName);
+                    _unfilledBuf.Add(slotName);
                 }
             }
 
-            return unfilled?.ToArray() ?? Array.Empty<string>();
+            return _unfilledBuf.Count > 0 ? _unfilledBuf.ToArray() : Array.Empty<string>();
         }
 
-        static bool IsVocabularyMatch(string normalized, string[] vocabulary)
+        /// <summary>
+        /// Matches vocabulary phrases directly against the token array without
+        /// joining tokens or splitting phrases. Walks each phrase span
+        /// word-by-word and compares against consecutive tokens.
+        /// A match requires all phrase words to correspond 1:1 with all tokens.
+        /// </summary>
+        static bool IsVocabularyMatchTokens(string[] tokens, string[] vocabulary)
         {
-            for (int i = 0; i < vocabulary.Length; i++)
+            for (int v = 0; v < vocabulary.Length; v++)
             {
-                if (string.Equals(normalized, vocabulary[i], StringComparison.Ordinal))
+                if (MatchPhraseAgainstTokens(tokens, vocabulary[v].AsSpan()))
                     return true;
             }
             return false;
+        }
+
+        static bool MatchPhraseAgainstTokens(string[] tokens, ReadOnlySpan<char> phrase)
+        {
+            int tokenIdx = 0;
+            int pos = 0;
+
+            while (pos < phrase.Length)
+            {
+                // Skip spaces.
+                if (phrase[pos] == ' ') { pos++; continue; }
+
+                // Find word end.
+                int wordStart = pos;
+                while (pos < phrase.Length && phrase[pos] != ' ') pos++;
+
+                if (tokenIdx >= tokens.Length)
+                    return false;
+
+                // Compare phrase word span against token.
+                if (!phrase.Slice(wordStart, pos - wordStart)
+                        .SequenceEqual(tokens[tokenIdx].AsSpan()))
+                    return false;
+
+                tokenIdx++;
+            }
+
+            // All tokens must be consumed.
+            return tokenIdx == tokens.Length;
         }
 
         // Test-only: force-set the pending command state for timeout testing.

--- a/Runtime/Commands/PendingCommandHandler.cs.meta
+++ b/Runtime/Commands/PendingCommandHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 27cbe04efa9be6a44967dd4f693d6670

--- a/Runtime/Commands/UtteranceBuffer.cs
+++ b/Runtime/Commands/UtteranceBuffer.cs
@@ -6,6 +6,7 @@
 // ============================================================================
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace VoskXR.Commands
 {
@@ -19,6 +20,7 @@ namespace VoskXR.Commands
     {
         readonly List<string> _texts = new List<string>();
         readonly List<VoskWord> _words = new List<VoskWord>();
+        readonly System.Text.StringBuilder _sb = new System.Text.StringBuilder();
         float _lastResultTime;
 
         /// <summary>True when the buffer holds at least one result.</summary>
@@ -46,23 +48,55 @@ namespace VoskXR.Commands
         }
 
         /// <summary>
-        /// Concatenates buffered texts and words, clears the buffer, and returns the result.
+        /// Concatenates buffered texts, clears text buffer, and returns the joined text.
+        /// Call <see cref="GetWordsSpan"/> before <see cref="ClearWords"/> to read word data
+        /// without copying. Both must happen synchronously in the same <c>Update</c> tick.
         /// </summary>
-        internal (string Text, VoskWord[] Words) Flush()
+        internal string Flush()
         {
             IsActive = false;
 
             if (_texts.Count == 0)
-                return (string.Empty, Array.Empty<VoskWord>());
+                return string.Empty;
 
-            // Fast path: single entry avoids string.Join allocation.
-            string text = _texts.Count == 1 ? _texts[0] : string.Join(" ", _texts);
-            var words = _words.Count > 0 ? _words.ToArray() : Array.Empty<VoskWord>();
-
+            // Fast path: single entry avoids StringBuilder overhead.
+            string text;
+            if (_texts.Count == 1)
+            {
+                text = _texts[0];
+            }
+            else
+            {
+                _sb.Clear();
+                for (int i = 0; i < _texts.Count; i++)
+                {
+                    if (i > 0) _sb.Append(' ');
+                    _sb.Append(_texts[i]);
+                }
+                text = _sb.ToString();
+            }
             _texts.Clear();
-            _words.Clear();
+            return text;
+        }
 
-            return (text, words);
+        /// <summary>
+        /// Returns a span over the buffered word data without copying.
+        /// Valid only until <see cref="ClearWords"/> is called.
+        /// </summary>
+        internal ReadOnlySpan<VoskWord> GetWordsSpan()
+        {
+            return _words.Count > 0
+                ? CollectionsMarshal.AsSpan(_words)
+                : ReadOnlySpan<VoskWord>.Empty;
+        }
+
+        /// <summary>
+        /// Clears the word list. Must be called after <see cref="GetWordsSpan"/>
+        /// has been fully consumed.
+        /// </summary>
+        internal void ClearWords()
+        {
+            _words.Clear();
         }
 
         /// <summary>

--- a/Runtime/Commands/UtteranceBuffer.cs
+++ b/Runtime/Commands/UtteranceBuffer.cs
@@ -1,0 +1,78 @@
+// ============================================================================
+// Purpose:  Accumulates split VOSK results into a single utterance before parsing
+// Layer:    Runtime.Commands
+// Owns:     UtteranceBuffer (internal sealed class)
+// Depends:  VoskWord
+// ============================================================================
+using System;
+using System.Collections.Generic;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Collects speech fragments across multiple VOSK final results and
+    /// concatenates them into a single utterance for the command parser.
+    /// The recogniser checks <see cref="ShouldFlush"/> each frame and calls
+    /// <see cref="Flush"/> when the buffer window has elapsed.
+    /// </summary>
+    internal sealed class UtteranceBuffer
+    {
+        readonly List<string> _texts = new List<string>();
+        readonly List<VoskWord> _words = new List<VoskWord>();
+        float _lastResultTime;
+
+        /// <summary>True when the buffer holds at least one result.</summary>
+        internal bool IsActive { get; private set; }
+
+        /// <summary>
+        /// Appends a speech result to the buffer and records the time.
+        /// </summary>
+        internal void Append(string text, VoskWord[] words, float currentTime)
+        {
+            _texts.Add(text);
+            if (words != null && words.Length > 0)
+                _words.AddRange(words);
+
+            _lastResultTime = currentTime;
+            IsActive = true;
+        }
+
+        /// <summary>
+        /// Returns true when enough time has passed since the last result to flush.
+        /// </summary>
+        internal bool ShouldFlush(float currentTime, float bufferWindow)
+        {
+            return currentTime - _lastResultTime >= bufferWindow;
+        }
+
+        /// <summary>
+        /// Concatenates buffered texts and words, clears the buffer, and returns the result.
+        /// </summary>
+        internal (string Text, VoskWord[] Words) Flush()
+        {
+            IsActive = false;
+
+            if (_texts.Count == 0)
+                return (string.Empty, Array.Empty<VoskWord>());
+
+            // Fast path: single entry avoids string.Join allocation.
+            string text = _texts.Count == 1 ? _texts[0] : string.Join(" ", _texts);
+            var words = _words.Count > 0 ? _words.ToArray() : Array.Empty<VoskWord>();
+
+            _texts.Clear();
+            _words.Clear();
+
+            return (text, words);
+        }
+
+        /// <summary>
+        /// Discards all buffered data without processing.
+        /// </summary>
+        internal void Reset()
+        {
+            _texts.Clear();
+            _words.Clear();
+            IsActive = false;
+        }
+    }
+}

--- a/Runtime/Commands/UtteranceBuffer.cs
+++ b/Runtime/Commands/UtteranceBuffer.cs
@@ -6,52 +6,40 @@
 // ============================================================================
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Collects speech fragments across multiple VOSK final results and
-    /// concatenates them into a single utterance for the command parser.
-    /// The recogniser checks <see cref="ShouldFlush"/> each frame and calls
-    /// <see cref="Flush"/> when the buffer window has elapsed.
-    /// </summary>
     internal sealed class UtteranceBuffer
     {
         readonly List<string> _texts = new List<string>();
-        readonly List<VoskWord> _words = new List<VoskWord>();
+        VoskWord[] _wordBuf = new VoskWord[32];
+        int _wordCount;
         readonly System.Text.StringBuilder _sb = new System.Text.StringBuilder();
         float _lastResultTime;
 
-        /// <summary>True when the buffer holds at least one result.</summary>
         internal bool IsActive { get; private set; }
 
-        /// <summary>
-        /// Appends a speech result to the buffer and records the time.
-        /// </summary>
         internal void Append(string text, VoskWord[] words, float currentTime)
         {
             _texts.Add(text);
             if (words != null && words.Length > 0)
-                _words.AddRange(words);
+            {
+                int needed = _wordCount + words.Length;
+                if (needed > _wordBuf.Length)
+                    Array.Resize(ref _wordBuf, Math.Max(needed, _wordBuf.Length * 2));
+                Array.Copy(words, 0, _wordBuf, _wordCount, words.Length);
+                _wordCount += words.Length;
+            }
 
             _lastResultTime = currentTime;
             IsActive = true;
         }
 
-        /// <summary>
-        /// Returns true when enough time has passed since the last result to flush.
-        /// </summary>
         internal bool ShouldFlush(float currentTime, float bufferWindow)
         {
             return currentTime - _lastResultTime >= bufferWindow;
         }
 
-        /// <summary>
-        /// Concatenates buffered texts, clears text buffer, and returns the joined text.
-        /// Call <see cref="GetWordsSpan"/> before <see cref="ClearWords"/> to read word data
-        /// without copying. Both must happen synchronously in the same <c>Update</c> tick.
-        /// </summary>
         internal string Flush()
         {
             IsActive = false;
@@ -79,33 +67,22 @@ namespace VoskXR.Commands
             return text;
         }
 
-        /// <summary>
-        /// Returns a span over the buffered word data without copying.
-        /// Valid only until <see cref="ClearWords"/> is called.
-        /// </summary>
         internal ReadOnlySpan<VoskWord> GetWordsSpan()
         {
-            return _words.Count > 0
-                ? CollectionsMarshal.AsSpan(_words)
+            return _wordCount > 0
+                ? new ReadOnlySpan<VoskWord>(_wordBuf, 0, _wordCount)
                 : ReadOnlySpan<VoskWord>.Empty;
         }
 
-        /// <summary>
-        /// Clears the word list. Must be called after <see cref="GetWordsSpan"/>
-        /// has been fully consumed.
-        /// </summary>
         internal void ClearWords()
         {
-            _words.Clear();
+            _wordCount = 0;
         }
 
-        /// <summary>
-        /// Discards all buffered data without processing.
-        /// </summary>
         internal void Reset()
         {
             _texts.Clear();
-            _words.Clear();
+            _wordCount = 0;
             IsActive = false;
         }
     }

--- a/Runtime/Commands/UtteranceBuffer.cs.meta
+++ b/Runtime/Commands/UtteranceBuffer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b66215d38ba81d409014096faee6c8d

--- a/Runtime/Commands/VoskCommand.cs
+++ b/Runtime/Commands/VoskCommand.cs
@@ -42,17 +42,24 @@ namespace VoskXR.Commands
         /// <summary>The original VOSK output text.</summary>
         public readonly string RawText;
 
+        /// <summary>
+        /// Index into <see cref="VoskCommandDefinition.Patterns"/> identifying which
+        /// pattern produced this match. -1 when unavailable (e.g. manually constructed).
+        /// </summary>
+        public readonly int MatchedPatternIndex;
+
         /// <summary>Names of all registered slots, used for debug validation in GetSlot. Null in release builds.</summary>
         readonly string[] _registeredSlotNames;
 
         public VoskCommand(string intent, VoskSlotMatch[] slots, float confidence, float score,
-            string rawText, string[] registeredSlotNames = null)
+            string rawText, string[] registeredSlotNames = null, int matchedPatternIndex = -1)
         {
             Intent = intent;
             Slots = slots ?? Array.Empty<VoskSlotMatch>();
             Confidence = confidence;
             Score = score;
             RawText = rawText;
+            MatchedPatternIndex = matchedPatternIndex;
             _registeredSlotNames = registeredSlotNames;
         }
 

--- a/Runtime/Commands/VoskCommand.cs
+++ b/Runtime/Commands/VoskCommand.cs
@@ -8,15 +8,10 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// A single matched slot within a parsed command.
-    /// </summary>
     public readonly struct VoskSlotMatch
     {
-        /// <summary>The slot name, e.g. "weapon".</summary>
         public readonly string Name;
 
-        /// <summary>The matched value, e.g. "missiles".</summary>
         public readonly string Value;
 
         public VoskSlotMatch(string name, string value)
@@ -28,33 +23,20 @@ namespace VoskXR.Commands
         public override string ToString() => $"{Name}={Value}";
     }
 
-    /// <summary>
-    /// A successfully parsed command with its intent, matched slots, and confidence.
-    /// </summary>
     public readonly struct VoskCommand
     {
-        /// <summary>The matched command intent, e.g. "launch_weapon".</summary>
         public readonly string Intent;
 
-        /// <summary>Matched slot name/value pairs.</summary>
         public readonly VoskSlotMatch[] Slots;
 
-        /// <summary>Minimum word confidence across matched tokens. -1 when word data is unavailable.</summary>
         public readonly float Confidence;
 
-        /// <summary>Match quality score (0.0–1.0). Higher is better.</summary>
         public readonly float Score;
 
-        /// <summary>The original VOSK output text.</summary>
         public readonly string RawText;
 
-        /// <summary>
-        /// Index into <see cref="VoskCommandDefinition.Patterns"/> identifying which
-        /// pattern produced this match. -1 when unavailable (e.g. manually constructed).
-        /// </summary>
         public readonly int MatchedPatternIndex;
 
-        /// <summary>Names of all registered slots, used for debug validation in GetSlot. Null in release builds.</summary>
         readonly string[] _registeredSlotNames;
 
         public VoskCommand(string intent, VoskSlotMatch[] slots, float confidence, float score,
@@ -69,10 +51,6 @@ namespace VoskXR.Commands
             _registeredSlotNames = registeredSlotNames;
         }
 
-        /// <summary>
-        /// Returns the value of the named slot, or <see cref="string.Empty"/> if the slot was not matched.
-        /// In debug builds, logs a warning if the name doesn't match any registered slot.
-        /// </summary>
         public string GetSlot(string name)
         {
             int idx = FindSlotIndex(name);
@@ -103,9 +81,6 @@ namespace VoskXR.Commands
             return string.Empty;
         }
 
-        /// <summary>
-        /// Returns true if the named slot was matched.
-        /// </summary>
         public bool HasSlot(string name) => FindSlotIndex(name) >= 0;
 
         int FindSlotIndex(string name)
@@ -121,21 +96,14 @@ namespace VoskXR.Commands
         public override string ToString() => $"{Intent} ({Slots.Length} slots, score={Score:F2})";
     }
 
-    /// <summary>
-    /// Wraps a command parse attempt. Check <see cref="IsMatch"/> before accessing <see cref="Command"/>.
-    /// </summary>
     public readonly struct VoskCommandResult
     {
-        /// <summary>True if a command pattern matched the input.</summary>
         public readonly bool IsMatch;
 
-        /// <summary>The parsed command. Only valid when <see cref="IsMatch"/> is true.</summary>
         public readonly VoskCommand Command;
 
-        /// <summary>The original VOSK output text.</summary>
         public readonly string RawText;
 
-        /// <summary>Creates a successful match result.</summary>
         public VoskCommandResult(VoskCommand command)
         {
             IsMatch = true;
@@ -143,7 +111,6 @@ namespace VoskXR.Commands
             RawText = command.RawText;
         }
 
-        /// <summary>Creates a no-match result.</summary>
         public VoskCommandResult(string rawText)
         {
             IsMatch = false;

--- a/Runtime/Commands/VoskCommand.cs
+++ b/Runtime/Commands/VoskCommand.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Data types for parsed command results (slot match, command, command result)
+// Layer:    Runtime.Commands
+// Owns:     VoskSlotMatch, VoskCommand, VoskCommandResult (public readonly structs)
+// Depends:  (none)
+// ============================================================================
 using System;
 
 namespace VoskXR.Commands

--- a/Runtime/Commands/VoskCommandAsset.cs
+++ b/Runtime/Commands/VoskCommandAsset.cs
@@ -9,12 +9,6 @@ using UnityEngine;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// ScriptableObject for defining a command in the Inspector.
-    /// Create via Assets > Create > VOSK XR > Command Definition.
-    /// Patterns are authored as single strings (e.g. "launch {?quantity} {weapon} target {target}")
-    /// and split on whitespace by <see cref="ToDefinition"/>.
-    /// </summary>
     [CreateAssetMenu(menuName = "VOSK XR/Command Definition")]
     public class VoskCommandAsset : ScriptableObject
     {
@@ -33,10 +27,6 @@ namespace VoskXR.Commands
                  "requiring explicit confirmation before firing.")]
         public bool requiresConfirmation;
 
-        /// <summary>
-        /// Converts this asset to the runtime <see cref="VoskCommandDefinition"/> struct.
-        /// Each pattern string is split on whitespace to produce the token array the parser expects.
-        /// </summary>
         public VoskCommandDefinition ToDefinition()
         {
             var patternArrays = patterns != null

--- a/Runtime/Commands/VoskCommandAsset.cs
+++ b/Runtime/Commands/VoskCommandAsset.cs
@@ -20,6 +20,15 @@ namespace VoskXR.Commands
                  "Use {slot} for required slots, {?slot} for optional, ?word for optional literals.")]
         public string[] patterns;
 
+        [Tooltip("When enabled, this command enters pending state when matched with " +
+                 "unfilled required slots, instead of being rejected. Follow-up speech " +
+                 "can fill the missing slots.")]
+        public bool allowPartialMatch;
+
+        [Tooltip("When enabled, this command enters pending state even when fully matched, " +
+                 "requiring explicit confirmation before firing.")]
+        public bool requiresConfirmation;
+
         /// <summary>
         /// Converts this asset to the runtime <see cref="VoskCommandDefinition"/> struct.
         /// Each pattern string is split on whitespace to produce the token array the parser expects.
@@ -37,7 +46,8 @@ namespace VoskXR.Commands
                     : patterns[i].Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
             }
 
-            return new VoskCommandDefinition(intent, patternArrays);
+            return new VoskCommandDefinition(intent, patternArrays,
+                allowPartialMatch, requiresConfirmation);
         }
     }
 }

--- a/Runtime/Commands/VoskCommandAsset.cs
+++ b/Runtime/Commands/VoskCommandAsset.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  ScriptableObject for Inspector-authored command definitions
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandAsset (public ScriptableObject)
+// Depends:  VoskCommandDefinition, VoskCommandParser (SplitSeparator)
+// ============================================================================
 using System;
 using UnityEngine;
 
@@ -12,8 +18,6 @@ namespace VoskXR.Commands
     [CreateAssetMenu(menuName = "VOSK XR/Command Definition")]
     public class VoskCommandAsset : ScriptableObject
     {
-        static readonly char[] SplitSeparator = { ' ' };
-
         public string intent;
 
         [Tooltip("Each element is one pattern. Tokens separated by spaces. " +
@@ -43,7 +47,7 @@ namespace VoskXR.Commands
             {
                 patternArrays[i] = string.IsNullOrEmpty(patterns[i])
                     ? Array.Empty<string>()
-                    : patterns[i].Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+                    : patterns[i].Split(VoskCommandParser.SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
             }
 
             return new VoskCommandDefinition(intent, patternArrays,

--- a/Runtime/Commands/VoskCommandDefinition.cs
+++ b/Runtime/Commands/VoskCommandDefinition.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Immutable command intent definition with phrase patterns and behavioral flags
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandDefinition (public readonly struct)
+// Depends:  (none)
+// ============================================================================
 using System;
 
 namespace VoskXR.Commands

--- a/Runtime/Commands/VoskCommandDefinition.cs
+++ b/Runtime/Commands/VoskCommandDefinition.cs
@@ -8,32 +8,14 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Defines a command intent with one or more phrase patterns.
-    /// Each pattern is an array of literal words and slot references
-    /// (<c>{slot}</c> for required, <c>{?slot}</c> for optional).
-    /// </summary>
     public readonly struct VoskCommandDefinition
     {
-        /// <summary>The intent name, e.g. "launch_weapon".</summary>
         public readonly string Intent;
 
-        /// <summary>
-        /// Phrase templates for this command. Each inner array is one pattern
-        /// containing literal tokens and slot references.
-        /// </summary>
         public readonly string[][] Patterns;
 
-        /// <summary>
-        /// When true, a match with unfilled required slots enters pending state
-        /// instead of being rejected, allowing follow-up speech to fill the gaps.
-        /// </summary>
         public readonly bool AllowPartialMatch;
 
-        /// <summary>
-        /// When true, a fully-matched command enters pending state awaiting
-        /// explicit confirmation ("confirm" / "cancel") before firing.
-        /// </summary>
         public readonly bool RequiresConfirmation;
 
         public VoskCommandDefinition(string intent, string[][] patterns)

--- a/Runtime/Commands/VoskCommandDefinition.cs
+++ b/Runtime/Commands/VoskCommandDefinition.cs
@@ -18,7 +18,25 @@ namespace VoskXR.Commands
         /// </summary>
         public readonly string[][] Patterns;
 
+        /// <summary>
+        /// When true, a match with unfilled required slots enters pending state
+        /// instead of being rejected, allowing follow-up speech to fill the gaps.
+        /// </summary>
+        public readonly bool AllowPartialMatch;
+
+        /// <summary>
+        /// When true, a fully-matched command enters pending state awaiting
+        /// explicit confirmation ("confirm" / "cancel") before firing.
+        /// </summary>
+        public readonly bool RequiresConfirmation;
+
         public VoskCommandDefinition(string intent, string[][] patterns)
+            : this(intent, patterns, false, false)
+        {
+        }
+
+        public VoskCommandDefinition(string intent, string[][] patterns,
+            bool allowPartialMatch = false, bool requiresConfirmation = false)
         {
             Intent = intent ?? throw new ArgumentNullException(nameof(intent));
 
@@ -37,6 +55,8 @@ namespace VoskXR.Commands
             }
 
             Patterns = outerCopy;
+            AllowPartialMatch = allowPartialMatch;
+            RequiresConfirmation = requiresConfirmation;
         }
     }
 }

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Pure C# pattern matcher: scores tokenized VOSK output against command patterns
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandParser (internal class)
+// Depends:  VoskSlotDefinition, VoskCommandDefinition, VoskSlotMatch, VoskCommand, VoskCommandResult, VoskNumberParser
+// ============================================================================
 using System;
 using System.Collections.Generic;
 
@@ -205,16 +211,7 @@ namespace VoskXR.Commands
                 return Array.Empty<VoskCommandResult>();
             }
 
-            Dictionary<string, float> wordConfidence = null;
-            if (words != null && words.Length > 0)
-            {
-                wordConfidence = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
-                foreach (var w in words)
-                {
-                    if (!string.IsNullOrEmpty(w.Text) && !wordConfidence.ContainsKey(w.Text))
-                        wordConfidence[w.Text] = w.Confidence;
-                }
-            }
+            Dictionary<string, float> wordConfidence = BuildWordConfidence(words);
 
             var results = new List<VoskCommandResult>();
             int searchStart = 0;
@@ -646,6 +643,22 @@ namespace VoskXR.Commands
                     _slots[slotIdx].MinWords, _slots[slotIdx].MaxWords, out consumed);
 
             return TryMatchSlot(tokens, startIdx, slotIdx, out consumed);
+        }
+
+        /// <summary>
+        /// Builds a word → confidence lookup from a <see cref="VoskWord"/> array.
+        /// Returns null when <paramref name="words"/> is null or empty.
+        /// </summary>
+        internal static Dictionary<string, float> BuildWordConfidence(VoskWord[] words)
+        {
+            if (words == null || words.Length == 0)
+                return null;
+
+            var d = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
+            foreach (var w in words)
+                if (!string.IsNullOrEmpty(w.Text) && !d.ContainsKey(w.Text))
+                    d[w.Text] = w.Confidence;
+            return d;
         }
 
         internal static float ComputeConfidence(string[] tokens, int startIdx, int endIdx,

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -38,6 +38,12 @@ namespace VoskXR.Commands
         // Cached stripped forms of optional literals (pattern element -> literal without '?')
         readonly Dictionary<string, string> _optionalLiteralCache;
 
+        // Pre-computed slot name cache: pattern element (e.g. "{weapon}") -> slot name ("weapon").
+        readonly Dictionary<string, string> _slotNameCache;
+
+        // Pre-computed set of optional slot elements (e.g. "{?target}").
+        readonly HashSet<string> _optionalSlotElements;
+
         // Pre-allocated slot match buffers — avoids per-call List allocations in TryMatchScored/Parse.
         readonly int _maxSlotsPerPattern;
         readonly VoskSlotMatch[] _matchSlotBuf;   // TryMatchScored writes here
@@ -49,6 +55,17 @@ namespace VoskXR.Commands
         readonly int[] _bestSlotStartBuf;
         readonly int[] _bestSlotEndBuf;
 #endif
+
+        // Pooled word-confidence dictionary — cleared and reused each utterance.
+        readonly Dictionary<string, float> _wordConfidencePool =
+            new Dictionary<string, float>(32, StringComparer.Ordinal);
+
+        // Pre-allocated result buffer — sized to _commands.Length.
+        readonly VoskCommandResult[] _resultBuf;
+        int _resultCount;
+
+        // Pooled StringBuilder for TryMatchNumberSequence.
+        readonly System.Text.StringBuilder _numberSb = new System.Text.StringBuilder();
 
         struct SlotValueEntry
         {
@@ -117,6 +134,8 @@ namespace VoskXR.Commands
 
             // Cache optional literal stripped forms
             _optionalLiteralCache = new Dictionary<string, string>(StringComparer.Ordinal);
+            _slotNameCache = new Dictionary<string, string>(StringComparer.Ordinal);
+            _optionalSlotElements = new HashSet<string>(StringComparer.Ordinal);
             foreach (var command in commands)
             {
                 foreach (var pattern in command.Patterns)
@@ -125,6 +144,15 @@ namespace VoskXR.Commands
                     {
                         if (IsOptionalLiteral(element) && !_optionalLiteralCache.ContainsKey(element))
                             _optionalLiteralCache[element] = element.Substring(1);
+
+                        string slotName = ExtractSlotName(element);
+                        if (slotName != null)
+                        {
+                            if (!_slotNameCache.ContainsKey(element))
+                                _slotNameCache[element] = slotName;
+                            if (IsOptionalSlot(element))
+                                _optionalSlotElements.Add(element);
+                        }
                     }
                 }
             }
@@ -150,6 +178,8 @@ namespace VoskXR.Commands
             _bestSlotStartBuf = new int[_maxSlotsPerPattern];
             _bestSlotEndBuf = new int[_maxSlotsPerPattern];
 #endif
+
+            _resultBuf = new VoskCommandResult[Math.Max(commands.Length, 1)];
 
             RunValidationWarnings(slots);
         }
@@ -245,9 +275,37 @@ namespace VoskXR.Commands
                 return Array.Empty<VoskCommandResult>();
             }
 
-            Dictionary<string, float> wordConfidence = BuildWordConfidence(words);
+            var wordConfidence = InstanceBuildWordConfidence(words);
+            int count = ParseInternal(tokens, text, wordConfidence);
 
-            var results = new List<VoskCommandResult>();
+            if (count == 0)
+                return Array.Empty<VoskCommandResult>();
+
+            // Public API returns a fresh copy — callers own the array indefinitely.
+            var result = new VoskCommandResult[count];
+            Array.Copy(_resultBuf, result, count);
+            return result;
+        }
+
+        /// <summary>
+        /// Internal overload used by the recogniser. Accepts pre-split tokens and a
+        /// pre-built word-confidence dictionary to avoid duplicate work. Writes results
+        /// into <see cref="_resultBuf"/> and returns the count. Callers iterate by count
+        /// and must not hold references to the buffer across calls.
+        /// </summary>
+        internal int ParseInternal(string[] tokens, string text,
+            Dictionary<string, float> wordConfidence)
+        {
+            _resultCount = 0;
+
+            if (tokens.Length == 0)
+            {
+#if UNITY_EDITOR
+                LastParseDiagnostics = Array.Empty<ParseDiagnosticEntry>();
+#endif
+                return 0;
+            }
+
             int searchStart = 0;
 #if UNITY_EDITOR
             var diagnosticEntries = new List<ParseDiagnosticEntry>();
@@ -332,7 +390,9 @@ namespace VoskXR.Commands
                     _slotNames,
                     bestPatternIdx);
 
-                results.Add(new VoskCommandResult(command));
+                if (_resultCount >= _resultBuf.Length)
+                    break; // Buffer full — stop extracting.
+                _resultBuf[_resultCount++] = new VoskCommandResult(command);
 #if UNITY_EDITOR
                 int[] diagStartWords = null;
                 int[] diagEndWords = null;
@@ -358,8 +418,14 @@ namespace VoskXR.Commands
                 ? diagnosticEntries.ToArray()
                 : Array.Empty<ParseDiagnosticEntry>();
 #endif
-            return results.Count > 0 ? results.ToArray() : Array.Empty<VoskCommandResult>();
+            return _resultCount;
         }
+
+        /// <summary>
+        /// Provides access to the internal result buffer. Valid only up to the count
+        /// returned by <see cref="ParseInternal"/>. Do not hold references across calls.
+        /// </summary>
+        internal VoskCommandResult[] ResultBuffer => _resultBuf;
 
         /// <summary>
         /// Parses input text without word confidence data.
@@ -513,10 +579,10 @@ namespace VoskXR.Commands
                 while (tokenIdx < tokens.Length && tokens[tokenIdx] == UnkToken)
                     tokenIdx++;
 
-                string slotName = ExtractSlotName(element);
-                if (slotName != null)
+                bool isSlot = _slotNameCache.TryGetValue(element, out string slotName);
+                if (isSlot)
                 {
-                    bool isOptional = IsOptionalSlot(element);
+                    bool isOptional = _optionalSlotElements.Contains(element);
 
                     if (!_slotIndex.TryGetValue(slotName, out int slotIdx))
                         return default;
@@ -650,13 +716,13 @@ namespace VoskXR.Commands
             if (count == 1)
                 return tokens[matchStart];
 
-            var sb = new System.Text.StringBuilder();
+            _numberSb.Clear();
             for (int i = 0; i < count; i++)
             {
-                if (i > 0) sb.Append(' ');
-                sb.Append(tokens[matchStart + i]);
+                if (i > 0) _numberSb.Append(' ');
+                _numberSb.Append(tokens[matchStart + i]);
             }
-            return sb.ToString();
+            return _numberSb.ToString();
         }
 
         /// <summary>
@@ -692,6 +758,34 @@ namespace VoskXR.Commands
                 if (!string.IsNullOrEmpty(w.Text) && !d.ContainsKey(w.Text))
                     d[w.Text] = w.Confidence;
             return d;
+        }
+
+        /// <summary>
+        /// Instance version that reuses a pooled dictionary. Returns null when words
+        /// is null or empty. The returned dictionary is owned by this parser instance —
+        /// callers must not hold references across <see cref="ParseInternal"/> calls.
+        /// </summary>
+        internal Dictionary<string, float> InstanceBuildWordConfidence(VoskWord[] words)
+        {
+            if (words == null || words.Length == 0)
+                return null;
+            return InstanceBuildWordConfidence((ReadOnlySpan<VoskWord>)words);
+        }
+
+        /// <summary>
+        /// Instance version that reuses a pooled dictionary, accepting a
+        /// <see cref="ReadOnlySpan{VoskWord}"/>. Returns null when the span is empty.
+        /// </summary>
+        internal Dictionary<string, float> InstanceBuildWordConfidence(ReadOnlySpan<VoskWord> words)
+        {
+            if (words.Length == 0)
+                return null;
+
+            _wordConfidencePool.Clear();
+            foreach (var w in words)
+                if (!string.IsNullOrEmpty(w.Text) && !_wordConfidencePool.ContainsKey(w.Text))
+                    _wordConfidencePool[w.Text] = w.Confidence;
+            return _wordConfidencePool;
         }
 
         internal static float ComputeConfidence(string[] tokens, int startIdx, int endIdx,

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -38,6 +38,18 @@ namespace VoskXR.Commands
         // Cached stripped forms of optional literals (pattern element -> literal without '?')
         readonly Dictionary<string, string> _optionalLiteralCache;
 
+        // Pre-allocated slot match buffers — avoids per-call List allocations in TryMatchScored/Parse.
+        readonly int _maxSlotsPerPattern;
+        readonly VoskSlotMatch[] _matchSlotBuf;   // TryMatchScored writes here
+        readonly VoskSlotMatch[] _bestSlotBuf;    // copy-on-best in Parse
+        int _matchSlotCount;                      // set by TryMatchScored
+#if UNITY_EDITOR
+        readonly int[] _matchSlotStartBuf;
+        readonly int[] _matchSlotEndBuf;
+        readonly int[] _bestSlotStartBuf;
+        readonly int[] _bestSlotEndBuf;
+#endif
+
         struct SlotValueEntry
         {
             public string CanonicalValue;
@@ -116,6 +128,28 @@ namespace VoskXR.Commands
                     }
                 }
             }
+
+            // Compute max slots per pattern to size reusable buffers.
+            int maxSlots = 0;
+            foreach (var command in commands)
+            {
+                foreach (var pattern in command.Patterns)
+                {
+                    int count = 0;
+                    foreach (string element in pattern)
+                        if (ExtractSlotName(element) != null) count++;
+                    if (count > maxSlots) maxSlots = count;
+                }
+            }
+            _maxSlotsPerPattern = maxSlots > 0 ? maxSlots : 1;
+            _matchSlotBuf = new VoskSlotMatch[_maxSlotsPerPattern];
+            _bestSlotBuf = new VoskSlotMatch[_maxSlotsPerPattern];
+#if UNITY_EDITOR
+            _matchSlotStartBuf = new int[_maxSlotsPerPattern];
+            _matchSlotEndBuf = new int[_maxSlotsPerPattern];
+            _bestSlotStartBuf = new int[_maxSlotsPerPattern];
+            _bestSlotEndBuf = new int[_maxSlotsPerPattern];
+#endif
 
             RunValidationWarnings(slots);
         }
@@ -227,11 +261,7 @@ namespace VoskXR.Commands
                 int bestPatternIdx = -1;
                 int bestStartIdx = int.MaxValue;
                 int bestEndIdx = 0;
-                List<VoskSlotMatch> bestSlots = null;
-#if UNITY_EDITOR
-                List<int> bestSlotStartWords = null;
-                List<int> bestSlotEndWords = null;
-#endif
+                int bestSlotCount = 0;
 
                 for (int ci = 0; ci < _commands.Length; ci++)
                 {
@@ -258,11 +288,16 @@ namespace VoskXR.Commands
                                 bestPatternIdx = pi;
                                 bestStartIdx = startIdx;
                                 bestEndIdx = matchResult.EndIdx;
-                                bestSlots = matchResult.Slots;
+                                bestSlotCount = matchResult.SlotCount;
+                                // Copy current match buffer into best buffer
+                                if (matchResult.SlotCount > 0)
+                                {
+                                    Array.Copy(_matchSlotBuf, _bestSlotBuf, matchResult.SlotCount);
 #if UNITY_EDITOR
-                                bestSlotStartWords = matchResult.SlotStartWords;
-                                bestSlotEndWords = matchResult.SlotEndWords;
+                                    Array.Copy(_matchSlotStartBuf, _bestSlotStartBuf, matchResult.SlotCount);
+                                    Array.Copy(_matchSlotEndBuf, _bestSlotEndBuf, matchResult.SlotCount);
 #endif
+                                }
                             }
                         }
                     }
@@ -277,9 +312,16 @@ namespace VoskXR.Commands
 
                 float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
 
-                var slotsArray = bestSlots != null && bestSlots.Count > 0
-                    ? bestSlots.ToArray()
-                    : Array.Empty<VoskSlotMatch>();
+                VoskSlotMatch[] slotsArray;
+                if (bestSlotCount > 0)
+                {
+                    slotsArray = new VoskSlotMatch[bestSlotCount];
+                    Array.Copy(_bestSlotBuf, slotsArray, bestSlotCount);
+                }
+                else
+                {
+                    slotsArray = Array.Empty<VoskSlotMatch>();
+                }
 
                 var command = new VoskCommand(
                     _commands[bestCommandIdx].Intent,
@@ -292,11 +334,20 @@ namespace VoskXR.Commands
 
                 results.Add(new VoskCommandResult(command));
 #if UNITY_EDITOR
+                int[] diagStartWords = null;
+                int[] diagEndWords = null;
+                if (bestSlotCount > 0)
+                {
+                    diagStartWords = new int[bestSlotCount];
+                    diagEndWords = new int[bestSlotCount];
+                    Array.Copy(_bestSlotStartBuf, diagStartWords, bestSlotCount);
+                    Array.Copy(_bestSlotEndBuf, diagEndWords, bestSlotCount);
+                }
                 diagnosticEntries.Add(new ParseDiagnosticEntry
                 {
                     PatternString = string.Join(" ", _commands[bestCommandIdx].Patterns[bestPatternIdx]),
-                    SlotStartWords = bestSlotStartWords?.ToArray(),
-                    SlotEndWords = bestSlotEndWords?.ToArray(),
+                    SlotStartWords = diagStartWords,
+                    SlotEndWords = diagEndWords,
                 });
 #endif
                 searchStart = bestEndIdx;
@@ -428,12 +479,8 @@ namespace VoskXR.Commands
         {
             public float Score;
             public int LiteralCount;
-            public List<VoskSlotMatch> Slots;
+            public int SlotCount;
             public int EndIdx;
-#if UNITY_EDITOR
-            public List<int> SlotStartWords;
-            public List<int> SlotEndWords;
-#endif
         }
 
 #if UNITY_EDITOR
@@ -457,11 +504,7 @@ namespace VoskXR.Commands
             float rawScore = 0f;
             int patternLength = pattern.Length;
             int literalCount = 0;
-            List<VoskSlotMatch> slots = null;
-#if UNITY_EDITOR
-            List<int> slotStartWords = null;
-            List<int> slotEndWords = null;
-#endif
+            int slotCount = 0;
 
             for (int patIdx = 0; patIdx < pattern.Length; patIdx++)
             {
@@ -488,18 +531,11 @@ namespace VoskXR.Commands
 
                     if (matchedValue != null)
                     {
-                        if (slots == null)
-                            slots = new List<VoskSlotMatch>();
 #if UNITY_EDITOR
-                        if (slotStartWords == null)
-                        {
-                            slotStartWords = new List<int>();
-                            slotEndWords = new List<int>();
-                        }
-                        slotStartWords.Add(tokenIdx);
-                        slotEndWords.Add(tokenIdx + consumed);
+                        _matchSlotStartBuf[slotCount] = tokenIdx;
+                        _matchSlotEndBuf[slotCount] = tokenIdx + consumed;
 #endif
-                        slots.Add(new VoskSlotMatch(slotName, matchedValue));
+                        _matchSlotBuf[slotCount++] = new VoskSlotMatch(slotName, matchedValue);
                         tokenIdx += consumed;
                         rawScore += MatchScore;
                     }
@@ -534,18 +570,15 @@ namespace VoskXR.Commands
                 }
             }
 
+            _matchSlotCount = slotCount;
             float normalizedScore = patternLength > 0 ? rawScore / patternLength : 0f;
 
             return new MatchResult
             {
                 Score = normalizedScore,
                 LiteralCount = literalCount,
-                Slots = slots,
+                SlotCount = slotCount,
                 EndIdx = tokenIdx,
-#if UNITY_EDITOR
-                SlotStartWords = slotStartWords,
-                SlotEndWords = slotEndWords,
-#endif
             };
         }
 

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -227,11 +227,11 @@ namespace VoskXR.Commands
                 float bestScore = float.MinValue;
                 int bestLiteralCount = -1;
                 int bestCommandIdx = -1;
+                int bestPatternIdx = -1;
                 int bestStartIdx = int.MaxValue;
                 int bestEndIdx = 0;
                 List<VoskSlotMatch> bestSlots = null;
 #if UNITY_EDITOR
-                int bestPatternIdx = -1;
                 List<int> bestSlotStartWords = null;
                 List<int> bestSlotEndWords = null;
 #endif
@@ -258,11 +258,11 @@ namespace VoskXR.Commands
                                 bestScore = matchResult.Score;
                                 bestLiteralCount = matchResult.LiteralCount;
                                 bestCommandIdx = ci;
+                                bestPatternIdx = pi;
                                 bestStartIdx = startIdx;
                                 bestEndIdx = matchResult.EndIdx;
                                 bestSlots = matchResult.Slots;
 #if UNITY_EDITOR
-                                bestPatternIdx = pi;
                                 bestSlotStartWords = matchResult.SlotStartWords;
                                 bestSlotEndWords = matchResult.SlotEndWords;
 #endif
@@ -290,7 +290,8 @@ namespace VoskXR.Commands
                     confidence,
                     bestScore,
                     text,
-                    _slotNames);
+                    _slotNames,
+                    bestPatternIdx);
 
                 results.Add(new VoskCommandResult(command));
 #if UNITY_EDITOR
@@ -331,7 +332,8 @@ namespace VoskXR.Commands
         /// Used by the recogniser to generate grammar from universe slots without
         /// constructing a throwaway parser.
         /// </summary>
-        internal static string GenerateGrammarJson(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands)
+        internal static string GenerateGrammarJson(VoskSlotDefinition[] slots,
+            VoskCommandDefinition[] commands, string[] additionalWords = null)
         {
             var uniqueWords = new HashSet<string>(StringComparer.Ordinal);
 
@@ -392,6 +394,16 @@ namespace VoskXR.Commands
                     foreach (string word in VoskNumberParser.DigitVocabulary)
                         uniqueWords.Add(word);
                     break;
+                }
+            }
+
+            // Add caller-supplied words (e.g. confirm/cancel vocabulary)
+            if (additionalWords != null)
+            {
+                foreach (string word in additionalWords)
+                {
+                    if (!string.IsNullOrEmpty(word))
+                        uniqueWords.Add(word);
                 }
             }
 
@@ -617,6 +629,25 @@ namespace VoskXR.Commands
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Attempts to match a slot by name against tokens at the given position.
+        /// Used by the recogniser for follow-up slot-fill matching.
+        /// </summary>
+        internal string TryMatchSlotByName(string[] tokens, int startIdx,
+            string slotName, out int consumed)
+        {
+            consumed = 0;
+
+            if (!_slotIndex.TryGetValue(slotName, out int slotIdx))
+                return null;
+
+            if (_slots[slotIdx].Type == VoskSlotType.NumberSequence)
+                return TryMatchNumberSequence(tokens, startIdx,
+                    _slots[slotIdx].MinWords, _slots[slotIdx].MaxWords, out consumed);
+
+            return TryMatchSlot(tokens, startIdx, slotIdx, out consumed);
+        }
+
         internal static float ComputeConfidence(string[] tokens, int startIdx, int endIdx,
             Dictionary<string, float> wordConfidence)
         {
@@ -646,7 +677,7 @@ namespace VoskXR.Commands
         /// Extracts the slot name from a pattern element. Returns null for literals.
         /// Handles {slot} (required), {?slot} (optional), and skips ?literal.
         /// </summary>
-        static string ExtractSlotName(string element)
+        internal static string ExtractSlotName(string element)
         {
             if (element.Length < 3 || element[0] != '{' || element[element.Length - 1] != '}')
                 return null;
@@ -661,7 +692,7 @@ namespace VoskXR.Commands
         /// <summary>
         /// Returns true if the pattern element is an optional slot reference ({?slot}).
         /// </summary>
-        static bool IsOptionalSlot(string element)
+        internal static bool IsOptionalSlot(string element)
         {
             return element.Length >= 4 && element[0] == '{' && element[1] == '?'
                 && element[element.Length - 1] == '}';

--- a/Runtime/Commands/VoskCommandParser.cs
+++ b/Runtime/Commands/VoskCommandParser.cs
@@ -9,10 +9,6 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Pure C# command parser. Matches tokenized VOSK output against registered
-    /// command patterns using scored matching with sliding start position.
-    /// </summary>
     internal class VoskCommandParser
     {
         internal const string UnkToken = "[unk]";
@@ -251,11 +247,6 @@ namespace VoskXR.Commands
             }
         }
 
-        /// <summary>
-        /// Parses input text against all registered command patterns using scored matching
-        /// with sliding start position. Performs sequential command extraction — after the
-        /// best match is found, remaining tokens are parsed again until no more matches exist.
-        /// </summary>
         public VoskCommandResult[] Parse(string text, VoskWord[] words)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -287,12 +278,6 @@ namespace VoskXR.Commands
             return result;
         }
 
-        /// <summary>
-        /// Internal overload used by the recogniser. Accepts pre-split tokens and a
-        /// pre-built word-confidence dictionary to avoid duplicate work. Writes results
-        /// into <see cref="_resultBuf"/> and returns the count. Callers iterate by count
-        /// and must not hold references to the buffer across calls.
-        /// </summary>
         internal int ParseInternal(string[] tokens, string text,
             Dictionary<string, float> wordConfidence)
         {
@@ -421,31 +406,15 @@ namespace VoskXR.Commands
             return _resultCount;
         }
 
-        /// <summary>
-        /// Provides access to the internal result buffer. Valid only up to the count
-        /// returned by <see cref="ParseInternal"/>. Do not hold references across calls.
-        /// </summary>
         internal VoskCommandResult[] ResultBuffer => _resultBuf;
 
-        /// <summary>
-        /// Parses input text without word confidence data.
-        /// </summary>
         public VoskCommandResult[] Parse(string text)
         {
             return Parse(text, Array.Empty<VoskWord>());
         }
 
-        /// <summary>
-        /// Generates a VOSK grammar JSON array containing all words from pattern
-        /// literals, slot values, aliases, and optional literals, plus [unk].
-        /// </summary>
         public string GenerateGrammarJson() => GenerateGrammarJson(_slots, _commands);
 
-        /// <summary>
-        /// Generates a VOSK grammar JSON array from explicit slot and command arrays.
-        /// Used by the recogniser to generate grammar from universe slots without
-        /// constructing a throwaway parser.
-        /// </summary>
         internal static string GenerateGrammarJson(VoskSlotDefinition[] slots,
             VoskCommandDefinition[] commands, string[] additionalWords = null)
         {
@@ -560,10 +529,6 @@ namespace VoskXR.Commands
         internal ParseDiagnosticEntry[] LastParseDiagnostics;
 #endif
 
-        /// <summary>
-        /// Scored matching from a given start position in the token array.
-        /// Returns normalized score (0.0–1.0) based on matched elements.
-        /// </summary>
         MatchResult TryMatchScored(string[] tokens, int startIdx, string[] pattern)
         {
             int tokenIdx = startIdx;
@@ -725,10 +690,6 @@ namespace VoskXR.Commands
             return _numberSb.ToString();
         }
 
-        /// <summary>
-        /// Attempts to match a slot by name against tokens at the given position.
-        /// Used by the recogniser for follow-up slot-fill matching.
-        /// </summary>
         internal string TryMatchSlotByName(string[] tokens, int startIdx,
             string slotName, out int consumed)
         {
@@ -744,10 +705,6 @@ namespace VoskXR.Commands
             return TryMatchSlot(tokens, startIdx, slotIdx, out consumed);
         }
 
-        /// <summary>
-        /// Builds a word → confidence lookup from a <see cref="VoskWord"/> array.
-        /// Returns null when <paramref name="words"/> is null or empty.
-        /// </summary>
         internal static Dictionary<string, float> BuildWordConfidence(VoskWord[] words)
         {
             if (words == null || words.Length == 0)
@@ -760,11 +717,6 @@ namespace VoskXR.Commands
             return d;
         }
 
-        /// <summary>
-        /// Instance version that reuses a pooled dictionary. Returns null when words
-        /// is null or empty. The returned dictionary is owned by this parser instance —
-        /// callers must not hold references across <see cref="ParseInternal"/> calls.
-        /// </summary>
         internal Dictionary<string, float> InstanceBuildWordConfidence(VoskWord[] words)
         {
             if (words == null || words.Length == 0)
@@ -772,10 +724,6 @@ namespace VoskXR.Commands
             return InstanceBuildWordConfidence((ReadOnlySpan<VoskWord>)words);
         }
 
-        /// <summary>
-        /// Instance version that reuses a pooled dictionary, accepting a
-        /// <see cref="ReadOnlySpan{VoskWord}"/>. Returns null when the span is empty.
-        /// </summary>
         internal Dictionary<string, float> InstanceBuildWordConfidence(ReadOnlySpan<VoskWord> words)
         {
             if (words.Length == 0)
@@ -813,10 +761,6 @@ namespace VoskXR.Commands
             return anyMatch ? minConf : -1f;
         }
 
-        /// <summary>
-        /// Extracts the slot name from a pattern element. Returns null for literals.
-        /// Handles {slot} (required), {?slot} (optional), and skips ?literal.
-        /// </summary>
         internal static string ExtractSlotName(string element)
         {
             if (element.Length < 3 || element[0] != '{' || element[element.Length - 1] != '}')
@@ -829,22 +773,73 @@ namespace VoskXR.Commands
             return inner;
         }
 
-        /// <summary>
-        /// Returns true if the pattern element is an optional slot reference ({?slot}).
-        /// </summary>
         internal static bool IsOptionalSlot(string element)
         {
             return element.Length >= 4 && element[0] == '{' && element[1] == '?'
                 && element[element.Length - 1] == '}';
         }
 
-        /// <summary>
-        /// Returns true if the pattern element is an optional literal (?word).
-        /// Distinguished from {?slot} by not starting with '{'.
-        /// </summary>
         static bool IsOptionalLiteral(string element)
         {
             return element.Length >= 2 && element[0] == '?' && element[1] != '{';
+        }
+
+        internal float ScoreFollowUp(string intent, int patternIdx,
+            IReadOnlyList<VoskSlotMatch> filledSlots)
+        {
+            // Find the command by intent
+            string[] pattern = null;
+            for (int ci = 0; ci < _commands.Length; ci++)
+            {
+                if (string.Equals(_commands[ci].Intent, intent, StringComparison.Ordinal))
+                {
+                    var patterns = _commands[ci].Patterns;
+                    if (patternIdx >= 0 && patternIdx < patterns.Length)
+                        pattern = patterns[patternIdx];
+                    break;
+                }
+            }
+
+            if (pattern == null || pattern.Length == 0)
+                return 1f; // Fallback — don't block the command
+
+            float rawScore = 0f;
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                string element = pattern[i];
+                string slotName = ExtractSlotName(element);
+
+                if (slotName != null)
+                {
+                    bool filled = false;
+                    for (int s = 0; s < filledSlots.Count; s++)
+                    {
+                        if (string.Equals(filledSlots[s].Name, slotName, StringComparison.Ordinal))
+                        {
+                            filled = true;
+                            break;
+                        }
+                    }
+
+                    if (filled)
+                        rawScore += MatchScore;
+                    else if (!IsOptionalSlot(element))
+                        rawScore += RequiredSlotMissPenalty;
+                    // Optional slots that are unfilled contribute 0
+                }
+                else if (IsOptionalLiteral(element))
+                {
+                    // Optional literals may or may not have been spoken — give no credit
+                }
+                else
+                {
+                    // Required literal — the original parse matched initial literals,
+                    // and follow-up implies the remaining ones. Credit them.
+                    rawScore += MatchScore;
+                }
+            }
+
+            return pattern.Length > 0 ? rawScore / pattern.Length : 0f;
         }
     }
 }

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -109,6 +109,9 @@ namespace VoskXR.Commands
         // Pending command state
         readonly PendingCommandHandler _pending = new PendingCommandHandler();
 
+        // Pre-allocated buffer for accepted commands (avoids per-utterance List allocation)
+        VoskCommand[] _acceptedBuf;
+
         /// <summary>Names of the currently active command sets (snapshot copy).</summary>
         public string[] ActiveSetNames => _setManager.ActiveSetNames;
 
@@ -135,6 +138,7 @@ namespace VoskXR.Commands
             _setManager.Reset();
             _activeCommands = commands;
             _setManager.BuildLookup(commands);
+            EnsureAcceptedBuffer(commands.Length);
 
             _parser = new VoskCommandParser(_slotManager.BuildEffectiveSlots(_slots), commands);
             _grammar.Rebuild(_slots, commands, GetFollowUpGrammarWords());
@@ -181,6 +185,7 @@ namespace VoskXR.Commands
 
             var commands = _setManager.Activate(setNames);
             _activeCommands = commands;
+            EnsureAcceptedBuffer(commands.Length);
             _debouncer.Clear();
             RebuildParserAndGrammar();
         }
@@ -362,6 +367,12 @@ namespace VoskXR.Commands
 #endif
                 }
             }
+        }
+
+        void EnsureAcceptedBuffer(int commandCount)
+        {
+            if (_acceptedBuf == null || _acceptedBuf.Length < commandCount)
+                _acceptedBuf = new VoskCommand[Math.Max(commandCount, 1)];
         }
 
         void RebuildParserAndGrammar()
@@ -591,7 +602,7 @@ namespace VoskXR.Commands
 
             // ---- Step 7: Process results with pending-aware logic ----
             float now = Time.time;
-            var accepted = new List<VoskCommand>();
+            int acceptedCount = 0;
 #if UNITY_EDITOR
             var attempts = new List<VoskMatchAttempt>(results.Length);
 #endif
@@ -669,7 +680,7 @@ namespace VoskXR.Commands
                 }
 
                 _debouncer.RecordFire(cmd.Intent, now);
-                accepted.Add(cmd);
+                _acceptedBuf[acceptedCount++] = cmd;
 #if UNITY_EDITOR
                 attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf, null, true));
 #endif
@@ -680,19 +691,26 @@ namespace VoskXR.Commands
                 text, words, attempts.ToArray(), Time.frameCount);
 #endif
 
-            if (accepted.Count == 0)
+            if (acceptedCount == 0)
             {
                 OnUnrecognisedSpeech?.Invoke(text);
                 return;
             }
 
             // Fire per-command events in order
-            for (int i = 0; i < accepted.Count; i++)
-                OnCommandRecognised?.Invoke(accepted[i]);
+            for (int i = 0; i < acceptedCount; i++)
+                OnCommandRecognised?.Invoke(_acceptedBuf[i]);
 
             // Fire batch event
             if (OnCommandsRecognised != null)
-                OnCommandsRecognised.Invoke(accepted.ToArray());
+            {
+                var batch = new VoskCommand[acceptedCount];
+                Array.Copy(_acceptedBuf, batch, acceptedCount);
+                OnCommandsRecognised.Invoke(batch);
+            }
+
+            // Clear stale references
+            Array.Clear(_acceptedBuf, 0, acceptedCount);
         }
 
         // -------- Pending resolution interpreter --------

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  MonoBehaviour facade: speech-to-command pipeline with buffer, debounce, pending, grammar
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandRecogniser (public MonoBehaviour)
+// Depends:  VoskSpeechRecogniser, VoskCommandParser, VoskCommand, VoskCommandDefinition, VoskSlotDefinition, VoskPendingCommand, VoskMatchDiagnostics
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -86,38 +92,31 @@ namespace VoskXR.Commands
 #endif
 
         VoskCommandParser _parser;
-        string _grammarJson;
-        bool _grammarApplied;
+        readonly GrammarManager _grammar = new GrammarManager();
 
-        // Utterance buffer state
-        readonly List<string> _bufferedTexts = new List<string>();
-        readonly List<VoskWord> _bufferedWords = new List<VoskWord>();
-        float _lastResultTime;
-        bool _bufferActive;
+        // Utterance buffer
+        readonly UtteranceBuffer _buffer = new UtteranceBuffer();
 
-        // Per-intent debounce state
-        readonly Dictionary<string, float> _lastFireTime = new Dictionary<string, float>(StringComparer.Ordinal);
+        // Per-intent debounce
+        readonly CommandDebouncer _debouncer = new CommandDebouncer();
 
-        // Command set state
+        // Command set and slot state
         VoskSlotDefinition[] _slots;
-        Dictionary<string, VoskCommandSet> _sets;
-        string[] _activeSetNames = Array.Empty<string>();
         VoskCommandDefinition[] _activeCommands;
-        Dictionary<string, Func<string[]>> _valueProviders;
-        Dictionary<string, VoskCommandDefinition> _commandLookup;
+        readonly CommandSetManager _setManager = new CommandSetManager();
+        readonly DynamicSlotManager _slotManager = new DynamicSlotManager();
 
         // Pending command state
-        VoskPendingCommand? _pendingCommand;
-        bool _grammarRebuildDeferred;
+        readonly PendingCommandHandler _pending = new PendingCommandHandler();
 
         /// <summary>Names of the currently active command sets (snapshot copy).</summary>
-        public string[] ActiveSetNames => (string[])_activeSetNames.Clone();
+        public string[] ActiveSetNames => _setManager.ActiveSetNames;
 
         /// <summary>True if a command is currently in pending state.</summary>
-        public bool HasPendingCommand => _pendingCommand.HasValue;
+        public bool HasPendingCommand => _pending.HasPending;
 
         /// <summary>The currently pending command, or null if none.</summary>
-        public VoskCommand? PendingCommand => _pendingCommand?.Command;
+        public VoskCommand? PendingCommand => _pending.PendingCommand;
 
         /// <summary>
         /// Builds the command parser from the given slot and command definitions.
@@ -129,24 +128,21 @@ namespace VoskXR.Commands
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (commands == null) throw new ArgumentNullException(nameof(commands));
 
-            CancelPendingIfActive();
+            InterpretResolution(_pending.Cancel());
 
-            _lastFireTime.Clear();
+            _debouncer.Clear();
             _slots = slots;
-            _sets = null;
-            _activeSetNames = Array.Empty<string>();
+            _setManager.Reset();
             _activeCommands = commands;
-            BuildCommandLookup(commands);
+            _setManager.BuildLookup(commands);
 
-            _parser = new VoskCommandParser(BuildEffectiveSlots(), commands);
-            _grammarJson = VoskCommandParser.GenerateGrammarJson(
-                _slots, commands, GetFollowUpGrammarWords());
-            _grammarApplied = false;
+            _parser = new VoskCommandParser(_slotManager.BuildEffectiveSlots(_slots), commands);
+            _grammar.Rebuild(_slots, commands, GetFollowUpGrammarWords());
 
             if (!freeSpeechMode && speechRecogniser != null && speechRecogniser.IsModelReady)
             {
-                speechRecogniser.SetGrammar(_grammarJson);
-                _grammarApplied = true;
+                speechRecogniser.SetGrammar(_grammar.CurrentJson);
+                _grammar.IsApplied = true;
             }
         }
 
@@ -159,25 +155,15 @@ namespace VoskXR.Commands
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (sets == null) throw new ArgumentNullException(nameof(sets));
 
-            CancelPendingIfActive();
+            InterpretResolution(_pending.Cancel());
 
-            _lastFireTime.Clear();
+            _debouncer.Clear();
             _slots = slots;
-            _sets = new Dictionary<string, VoskCommandSet>(sets.Length, StringComparer.Ordinal);
-
-            for (int i = 0; i < sets.Length; i++)
-            {
-                if (_sets.ContainsKey(sets[i].Name))
-                    throw new ArgumentException($"Duplicate command set name: '{sets[i].Name}'.");
-                _sets[sets[i].Name] = sets[i];
-            }
+            _setManager.Configure(sets);
 
             _parser = null;
-            _grammarJson = null;
-            _grammarApplied = false;
-            _activeSetNames = Array.Empty<string>();
+            _grammar.Reset();
             _activeCommands = null;
-            _commandLookup = null;
         }
 
         /// <summary>
@@ -187,50 +173,16 @@ namespace VoskXR.Commands
         /// </summary>
         public void SetActiveSets(params string[] setNames)
         {
-            if (_sets == null)
+            if (!_setManager.HasSets)
                 throw new InvalidOperationException(
                     "Configure(slots, sets) must be called before SetActiveSets().");
 
-            CancelPendingIfActive();
+            InterpretResolution(_pending.Cancel());
 
-            if (setNames == null)
-                setNames = Array.Empty<string>();
-
-            for (int i = 0; i < setNames.Length; i++)
-            {
-                if (!_sets.ContainsKey(setNames[i]))
-                    throw new ArgumentException(
-                        $"Unknown command set name: '{setNames[i]}'.", nameof(setNames));
-            }
-
-            int total = 0;
-            for (int i = 0; i < setNames.Length; i++)
-                total += _sets[setNames[i]].Commands.Length;
-
-            VoskCommandDefinition[] commands;
-            if (total == 0)
-            {
-                commands = Array.Empty<VoskCommandDefinition>();
-            }
-            else
-            {
-                commands = new VoskCommandDefinition[total];
-                int offset = 0;
-                for (int i = 0; i < setNames.Length; i++)
-                {
-                    var c = _sets[setNames[i]].Commands;
-                    Array.Copy(c, 0, commands, offset, c.Length);
-                    offset += c.Length;
-                }
-            }
-
-            _activeSetNames = setNames.Length > 0
-                ? (string[])setNames.Clone()
-                : Array.Empty<string>();
-
-            _lastFireTime.Clear();
-            RebuildParserAndGrammar(commands);
-            BuildCommandLookup(commands);
+            var commands = _setManager.Activate(setNames);
+            _activeCommands = commands;
+            _debouncer.Clear();
+            RebuildParserAndGrammar();
         }
 
         /// <summary>
@@ -281,7 +233,7 @@ namespace VoskXR.Commands
             Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
                 "FlushPendingBuffer must be called from the Unity main thread.");
 
-            if (_bufferActive)
+            if (_buffer.IsActive)
                 FlushBuffer();
         }
 
@@ -289,7 +241,7 @@ namespace VoskXR.Commands
         /// Cancels the currently pending command, if any. Fires <see cref="OnCommandCancelled"/>.
         /// No-op when no command is pending.
         /// </summary>
-        public void CancelPendingCommand() => CancelPendingIfActive();
+        public void CancelPendingCommand() => InterpretResolution(_pending.Cancel());
 
         // -------- Dynamic slot value providers --------
 
@@ -302,13 +254,7 @@ namespace VoskXR.Commands
         /// </summary>
         public void RegisterSlotValueProvider(string slotName, Func<string[]> valueProvider)
         {
-            if (slotName == null) throw new ArgumentNullException(nameof(slotName));
-            if (valueProvider == null) throw new ArgumentNullException(nameof(valueProvider));
-
-            if (_valueProviders == null)
-                _valueProviders = new Dictionary<string, Func<string[]>>(StringComparer.Ordinal);
-
-            _valueProviders[slotName] = valueProvider;
+            _slotManager.Register(slotName, valueProvider);
         }
 
         /// <summary>
@@ -317,8 +263,7 @@ namespace VoskXR.Commands
         /// </summary>
         public bool UnregisterSlotValueProvider(string slotName)
         {
-            if (slotName == null) throw new ArgumentNullException(nameof(slotName));
-            return _valueProviders != null && _valueProviders.Remove(slotName);
+            return _slotManager.Unregister(slotName);
         }
 
         /// <summary>
@@ -346,7 +291,7 @@ namespace VoskXR.Commands
                 throw new InvalidOperationException(
                     "Configure must be called before RebuildParser().");
 
-            _parser = new VoskCommandParser(BuildEffectiveSlots(), _activeCommands);
+            _parser = new VoskCommandParser(_slotManager.BuildEffectiveSlots(_slots), _activeCommands);
         }
 
         /// <summary>
@@ -362,9 +307,9 @@ namespace VoskXR.Commands
                 throw new InvalidOperationException(
                     "Configure must be called before RebuildGrammar().");
 
-            if (_pendingCommand.HasValue)
+            if (_pending.HasPending)
             {
-                _grammarRebuildDeferred = true;
+                _grammar.GrammarRebuildDeferred = true;
                 return;
             }
 
@@ -373,100 +318,18 @@ namespace VoskXR.Commands
 
         void RebuildGrammarInternal()
         {
-            if (_bufferActive)
-            {
-                _bufferedTexts.Clear();
-                _bufferedWords.Clear();
-                _bufferActive = false;
-            }
-
-            _grammarJson = VoskCommandParser.GenerateGrammarJson(
-                _slots, _activeCommands, GetFollowUpGrammarWords());
-            _grammarApplied = false;
-
-            if (freeSpeechMode || speechRecogniser == null || !speechRecogniser.IsModelReady)
-                return;
-
-            bool wasRunning = speechRecogniser.IsRecognising;
-
-            if (wasRunning)
-                speechRecogniser.StopRecognition();
-
-            speechRecogniser.SetGrammar(_grammarJson);
-            _grammarApplied = true;
-
-            if (wasRunning)
-                speechRecogniser.StartRecognition();
+            _buffer.Reset();
+            _grammar.Rebuild(_slots, _activeCommands, GetFollowUpGrammarWords());
+            _grammar.ForceApply(speechRecogniser, freeSpeechMode);
         }
 
         void DrainDeferredGrammarRebuild()
         {
-            if (!_grammarRebuildDeferred)
+            if (!_grammar.GrammarRebuildDeferred)
                 return;
 
-            _grammarRebuildDeferred = false;
+            _grammar.GrammarRebuildDeferred = false;
             RebuildGrammarInternal();
-        }
-
-        VoskSlotDefinition[] BuildEffectiveSlots()
-        {
-            if (_valueProviders == null || _valueProviders.Count == 0)
-                return _slots;
-
-            VoskSlotDefinition[] effective = null;
-
-            for (int i = 0; i < _slots.Length; i++)
-            {
-                var slot = _slots[i];
-
-                if (slot.Type == VoskSlotType.NumberSequence ||
-                    !_valueProviders.TryGetValue(slot.Name, out var provider))
-                {
-                    if (effective != null)
-                        effective[i] = slot;
-                    continue;
-                }
-
-                var activeValues = provider();
-                if (activeValues == null)
-                {
-                    if (effective != null)
-                        effective[i] = slot;
-                    continue;
-                }
-
-                if (effective == null)
-                {
-                    effective = new VoskSlotDefinition[_slots.Length];
-                    Array.Copy(_slots, effective, i);
-                }
-
-                if (activeValues.Length == 0)
-                {
-                    effective[i] = new VoskSlotDefinition(slot.Name, Array.Empty<string>(), null);
-                    continue;
-                }
-
-                var activeSet = new HashSet<string>(activeValues, StringComparer.Ordinal);
-
-                Dictionary<string, string> filteredAliases = null;
-                if (slot.Aliases != null)
-                {
-                    foreach (var kvp in slot.Aliases)
-                    {
-                        if (activeSet.Contains(kvp.Value))
-                        {
-                            if (filteredAliases == null)
-                                filteredAliases = new Dictionary<string, string>(StringComparer.Ordinal);
-                            filteredAliases[kvp.Key] = kvp.Value;
-                        }
-                    }
-                }
-
-                effective[i] = new VoskSlotDefinition(slot.Name, activeValues, filteredAliases);
-            }
-
-            return effective ?? _slots;
         }
 
         // Test-only setters. Production callers configure via the Inspector.
@@ -501,9 +364,8 @@ namespace VoskXR.Commands
             }
         }
 
-        void RebuildParserAndGrammar(VoskCommandDefinition[] commands)
+        void RebuildParserAndGrammar()
         {
-            _activeCommands = commands;
             RebuildParser();
             RebuildGrammarInternal();
         }
@@ -580,33 +442,30 @@ namespace VoskXR.Commands
 
             // Suppress deferred grammar rebuild — grammar will be re-evaluated on next enable/configure.
             // CancelPendingIfActive would drain the rebuild, which is unsafe during disable.
-            _grammarRebuildDeferred = false;
-            CancelPendingIfActive();
+            _grammar.GrammarRebuildDeferred = false;
+            InterpretResolution(_pending.Cancel());
 
             // Flush any pending buffer on disable
-            if (_bufferActive)
+            if (_buffer.IsActive)
                 FlushBuffer();
         }
 
         void Update()
         {
-            if (_bufferActive && Time.time - _lastResultTime >= bufferWindow)
+            if (_buffer.IsActive && _buffer.ShouldFlush(Time.time, bufferWindow))
                 FlushBuffer();
 
-            if (_pendingCommand.HasValue &&
-                Time.time - _pendingCommand.Value.CreatedTime >= pendingTimeout)
+            if (_pending.HasPending &&
+                Time.time - _pending.Current.Value.CreatedTime >= pendingTimeout)
             {
-                HandlePendingTimeout();
+                var resolution = _pending.HandleTimeout(pendingTimeoutBehavior);
+                InterpretResolution(resolution);
             }
         }
 
         void HandleModelReady()
         {
-            if (!freeSpeechMode && !_grammarApplied && _grammarJson != null)
-            {
-                speechRecogniser.SetGrammar(_grammarJson);
-                _grammarApplied = true;
-            }
+            _grammar.ApplyIfReady(speechRecogniser, freeSpeechMode);
         }
 
         void HandleResult(VoskResult result)
@@ -624,64 +483,62 @@ namespace VoskXR.Commands
             }
 
             // Append to buffer and reset timer
-            _bufferedTexts.Add(result.Text);
-            if (result.Words != null && result.Words.Length > 0)
-                _bufferedWords.AddRange(result.Words);
-
-            _lastResultTime = Time.time;
-            _bufferActive = true;
+            _buffer.Append(result.Text, result.Words, Time.time);
         }
 
         void FlushBuffer()
         {
-            _bufferActive = false;
-
-            if (_bufferedTexts.Count == 0)
+            var (text, words) = _buffer.Flush();
+            if (text.Length == 0)
                 return;
-
-            string text = string.Join(" ", _bufferedTexts);
-            var words = _bufferedWords.Count > 0 ? _bufferedWords.ToArray() : Array.Empty<VoskWord>();
-
-            _bufferedTexts.Clear();
-            _bufferedWords.Clear();
 
             ProcessParsedResults(text, words);
         }
 
         void ProcessParsedResults(string text, VoskWord[] words)
         {
-            // ---- Step 1: Confirm/cancel check (before parsing) ----
-            if (_pendingCommand.HasValue && TryHandleConfirmCancel(text))
-            {
-#if UNITY_EDITOR
-                LastMatchDiagnostics = new VoskMatchDiagnostics(
-                    text, words,
-                    new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
-                        null, "handled as confirm/cancel", false) },
-                    Time.frameCount);
-#endif
+            // Split once — shared by pending handlers, diagnostics, and (indirectly) the parser.
+            string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
+                StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
                 return;
+
+            Dictionary<string, float> wordConfidence = _pending.HasPending
+                ? VoskCommandParser.BuildWordConfidence(words)
+                : null;
+
+            // ---- Step 1: Confirm/cancel check (before parsing) ----
+            if (_pending.HasPending)
+            {
+                var ccResolution = _pending.TryHandleConfirmCancel(
+                    tokens, confirmVocabulary, cancelVocabulary);
+                if (ccResolution.Outcome != PendingOutcome.None)
+                {
+                    InterpretResolution(ccResolution);
+#if UNITY_EDITOR
+                    LastMatchDiagnostics = new VoskMatchDiagnostics(
+                        text, words,
+                        new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
+                            null, "handled as confirm/cancel", false) },
+                        Time.frameCount);
+#endif
+                    return;
+                }
             }
 
             // ---- Step 2: Follow-up slot-fill attempt (before parsing) ----
             VoskCommand? followUpResult = null;
-            if (_pendingCommand.HasValue)
-                followUpResult = TryFollowUpSlotFill(text, words);
+            if (_pending.HasPending)
+                followUpResult = _pending.TryFollowUpSlotFill(
+                    text, tokens, wordConfidence, _parser);
 
             // ---- Step 3: Normal parse ----
             var results = _parser.Parse(text, words);
 
 #if UNITY_EDITOR
             var parseDiag = _parser.LastParseDiagnostics;
-            string[] diagTokens = text.Split(VoskCommandParser.SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
-            Dictionary<string, float> diagWordConf = null;
-            if (words != null && words.Length > 0)
-            {
-                diagWordConf = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
-                foreach (var w in words)
-                    if (!string.IsNullOrEmpty(w.Text) && !diagWordConf.ContainsKey(w.Text))
-                        diagWordConf[w.Text] = w.Confidence;
-            }
+            Dictionary<string, float> diagWordConf = wordConfidence
+                ?? VoskCommandParser.BuildWordConfidence(words);
 #endif
 
             // ---- Step 4: Determine if any normal result passes standard thresholds ----
@@ -700,7 +557,8 @@ namespace VoskXR.Commands
             // ---- Step 5: Arbitrate follow-up vs new command ----
             if (followUpResult.HasValue && !hasCompleteNewCommand)
             {
-                CompletePendingCommand(followUpResult.Value);
+                var completeRes = _pending.Complete(followUpResult.Value);
+                InterpretResolution(completeRes);
 #if UNITY_EDITOR
                 LastMatchDiagnostics = new VoskMatchDiagnostics(
                     text, words,
@@ -714,8 +572,8 @@ namespace VoskXR.Commands
             }
 
             // If new complete command preempts a pending, cancel the pending
-            if (_pendingCommand.HasValue && hasCompleteNewCommand)
-                CancelPendingIfActive();
+            if (_pending.HasPending && hasCompleteNewCommand)
+                InterpretResolution(_pending.Cancel());
 
             // ---- Step 6: No parse results ----
             if (results.Length == 0)
@@ -745,17 +603,20 @@ namespace VoskXR.Commands
                 // Below score threshold — check AllowPartialMatch before rejecting
                 if (cmd.Score < minScore)
                 {
-                    if (cmd.Score > 0f && _commandLookup != null &&
-                        _commandLookup.TryGetValue(cmd.Intent, out var partialDef) &&
+                    if (cmd.Score > 0f &&
+                        _setManager.TryLookupCommand(cmd.Intent, out var partialDef) &&
                         partialDef.AllowPartialMatch)
                     {
-                        var unfilled = ComputeUnfilledSlots(cmd, partialDef);
+                        var unfilled = PendingCommandHandler.ComputeUnfilledSlots(cmd, partialDef);
                         if (unfilled.Length > 0)
                         {
-                            EnterPendingState(cmd, partialDef, unfilled,
-                                VoskPendingReason.PartialMatch);
+                            var enterRes = _pending.EnterPending(cmd, partialDef, unfilled,
+                                VoskPendingReason.PartialMatch, Time.time,
+                                out var cancelRes);
+                            InterpretResolution(cancelRes);
+                            InterpretResolution(enterRes);
 #if UNITY_EDITOR
-                            attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                            attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                                 $"entered pending (partial: unfilled [{string.Join(", ", unfilled)}])",
                                 false));
 #endif
@@ -764,7 +625,7 @@ namespace VoskXR.Commands
                     }
 
 #if UNITY_EDITOR
-                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         $"score {cmd.Score:F2} < minScore {minScore:F2}", false));
 #endif
                     continue;
@@ -774,7 +635,7 @@ namespace VoskXR.Commands
                 if (cmd.Confidence >= 0f && cmd.Confidence < minConfidence)
                 {
 #if UNITY_EDITOR
-                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         $"confidence {cmd.Confidence:F2} < minConfidence {minConfidence:F2}", false));
 #endif
                     continue;
@@ -782,34 +643,35 @@ namespace VoskXR.Commands
 
                 // Per-intent debounce
                 if (commandCooldown > 0f &&
-                    _lastFireTime.TryGetValue(cmd.Intent, out float lastTime) &&
-                    now - lastTime < commandCooldown)
+                    _debouncer.IsOnCooldown(cmd.Intent, now, commandCooldown))
                 {
 #if UNITY_EDITOR
-                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         $"debounced ({commandCooldown:F1}s cooldown)", false));
 #endif
                     continue;
                 }
 
                 // Check RequiresConfirmation — enter pending instead of firing
-                if (_commandLookup != null &&
-                    _commandLookup.TryGetValue(cmd.Intent, out var confirmDef) &&
+                if (_setManager.TryLookupCommand(cmd.Intent, out var confirmDef) &&
                     confirmDef.RequiresConfirmation)
                 {
-                    EnterPendingState(cmd, confirmDef, Array.Empty<string>(),
-                        VoskPendingReason.AwaitingConfirmation);
+                    var enterConfRes = _pending.EnterPending(cmd, confirmDef,
+                        Array.Empty<string>(), VoskPendingReason.AwaitingConfirmation, Time.time,
+                        out var cancelConfRes);
+                    InterpretResolution(cancelConfRes);
+                    InterpretResolution(enterConfRes);
 #if UNITY_EDITOR
-                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         "entered pending (awaiting confirmation)", false));
 #endif
                     continue;
                 }
 
-                _lastFireTime[cmd.Intent] = now;
+                _debouncer.RecordFire(cmd.Intent, now);
                 accepted.Add(cmd);
 #if UNITY_EDITOR
-                attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf, null, true));
+                attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf, null, true));
 #endif
             }
 
@@ -833,230 +695,34 @@ namespace VoskXR.Commands
                 OnCommandsRecognised.Invoke(accepted.ToArray());
         }
 
-        // -------- Pending command helpers --------
+        // -------- Pending resolution interpreter --------
 
-        bool TryHandleConfirmCancel(string text)
+        void InterpretResolution(PendingResolution resolution)
         {
-            string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
-                StringSplitOptions.RemoveEmptyEntries);
-            if (tokens.Length == 0)
-                return false;
-
-            string normalized = string.Join(" ", tokens);
-
-            string[] effectiveCancel = cancelVocabulary != null && cancelVocabulary.Length > 0
-                ? cancelVocabulary : VoskFollowUpVocabulary.DefaultCancel;
-            string[] effectiveConfirm = confirmVocabulary != null && confirmVocabulary.Length > 0
-                ? confirmVocabulary : VoskFollowUpVocabulary.DefaultConfirm;
-
-            if (IsVocabularyMatch(normalized, effectiveCancel))
+            switch (resolution.Outcome)
             {
-                CancelPendingIfActive();
-                return true;
-            }
+                case PendingOutcome.None:
+                    return;
 
-            if (IsVocabularyMatch(normalized, effectiveConfirm))
-            {
-                var confirmed = _pendingCommand.Value;
-                _pendingCommand = null;
-                FireConfirmedCommand(confirmed.Command);
-                return true;
-            }
+                case PendingOutcome.Confirmed:
+                    _debouncer.RecordFire(resolution.Command.Intent, Time.time);
+                    OnCommandConfirmed?.Invoke(resolution.Command);
+                    OnCommandRecognised?.Invoke(resolution.Command);
+                    if (OnCommandsRecognised != null)
+                        OnCommandsRecognised.Invoke(new[] { resolution.Command });
+                    DrainDeferredGrammarRebuild();
+                    break;
 
-            return false;
-        }
+                case PendingOutcome.Cancelled:
+                    OnCommandCancelled?.Invoke(resolution.Command);
+                    DrainDeferredGrammarRebuild();
+                    break;
 
-        VoskCommand? TryFollowUpSlotFill(string text, VoskWord[] words)
-        {
-            var pending = _pendingCommand.Value;
-            if (pending.UnfilledSlots == null || pending.UnfilledSlots.Length == 0)
-                return null;
-
-            string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
-                StringSplitOptions.RemoveEmptyEntries);
-            if (tokens.Length == 0)
-                return null;
-
-            var newSlots = new List<VoskSlotMatch>(pending.Command.Slots);
-            int tokenIdx = 0;
-
-            foreach (string slotName in pending.UnfilledSlots)
-            {
-                // Try each token position (sliding start) for this slot
-                bool found = false;
-                for (int startIdx = tokenIdx; startIdx < tokens.Length; startIdx++)
-                {
-                    if (tokens[startIdx] == VoskCommandParser.UnkToken)
-                        continue;
-
-                    string value = _parser.TryMatchSlotByName(
-                        tokens, startIdx, slotName, out int consumed);
-                    if (value != null)
-                    {
-                        newSlots.Add(new VoskSlotMatch(slotName, value));
-                        tokenIdx = startIdx + consumed;
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
+                case PendingOutcome.Entered:
+                case PendingOutcome.ReEnteredPending:
+                    OnCommandPending?.Invoke(resolution.Command);
                     break;
             }
-
-            // Must have filled at least one new slot
-            if (newSlots.Count == pending.Command.Slots.Length)
-                return null;
-
-            // Compute updated confidence from follow-up words
-            Dictionary<string, float> wordConfidence = null;
-            if (words != null && words.Length > 0)
-            {
-                wordConfidence = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
-                foreach (var w in words)
-                    if (!string.IsNullOrEmpty(w.Text) && !wordConfidence.ContainsKey(w.Text))
-                        wordConfidence[w.Text] = w.Confidence;
-            }
-            float followUpConf = VoskCommandParser.ComputeConfidence(
-                tokens, 0, tokens.Length, wordConfidence);
-
-            float mergedConfidence = pending.Command.Confidence >= 0f && followUpConf >= 0f
-                ? Math.Min(pending.Command.Confidence, followUpConf)
-                : pending.Command.Confidence >= 0f ? pending.Command.Confidence : followUpConf;
-
-            return new VoskCommand(
-                pending.Command.Intent,
-                newSlots.ToArray(),
-                mergedConfidence,
-                pending.Command.Score,
-                pending.Command.RawText + " " + text,
-                null,
-                pending.Command.MatchedPatternIndex);
-        }
-
-        void EnterPendingState(VoskCommand command, VoskCommandDefinition definition,
-            string[] unfilledSlots, VoskPendingReason reason)
-        {
-            CancelPendingIfActive();
-
-            _pendingCommand = new VoskPendingCommand
-            {
-                Command = command,
-                Definition = definition,
-                UnfilledSlots = unfilledSlots,
-                Reason = reason,
-                CreatedTime = Time.time,
-            };
-
-            OnCommandPending?.Invoke(command);
-        }
-
-        void CompletePendingCommand(VoskCommand completed)
-        {
-            var pending = _pendingCommand.Value;
-            _pendingCommand = null;
-
-            // If the definition also requires confirmation and we were pending
-            // for partial match, re-enter pending for confirmation
-            if (pending.Definition.RequiresConfirmation &&
-                pending.Reason == VoskPendingReason.PartialMatch)
-            {
-                _pendingCommand = new VoskPendingCommand
-                {
-                    Command = completed,
-                    Definition = pending.Definition,
-                    UnfilledSlots = Array.Empty<string>(),
-                    Reason = VoskPendingReason.AwaitingConfirmation,
-                    CreatedTime = Time.time,
-                };
-                OnCommandPending?.Invoke(completed);
-                return;
-            }
-
-            FireConfirmedCommand(completed);
-        }
-
-        void HandlePendingTimeout()
-        {
-            var pending = _pendingCommand.Value;
-            _pendingCommand = null;
-
-            if (pendingTimeoutBehavior == VoskPendingTimeoutBehavior.FireAsIs)
-            {
-                FireConfirmedCommand(pending.Command);
-            }
-            else
-            {
-                OnCommandCancelled?.Invoke(pending.Command);
-                DrainDeferredGrammarRebuild();
-            }
-        }
-
-        void FireConfirmedCommand(VoskCommand command)
-        {
-            _lastFireTime[command.Intent] = Time.time;
-            OnCommandConfirmed?.Invoke(command);
-            OnCommandRecognised?.Invoke(command);
-            if (OnCommandsRecognised != null)
-                OnCommandsRecognised.Invoke(new[] { command });
-            DrainDeferredGrammarRebuild();
-        }
-
-        void CancelPendingIfActive()
-        {
-            if (!_pendingCommand.HasValue)
-                return;
-
-            var cancelled = _pendingCommand.Value;
-            _pendingCommand = null;
-            OnCommandCancelled?.Invoke(cancelled.Command);
-            DrainDeferredGrammarRebuild();
-        }
-
-        static bool IsVocabularyMatch(string normalized, string[] vocabulary)
-        {
-            for (int i = 0; i < vocabulary.Length; i++)
-            {
-                if (string.Equals(normalized, vocabulary[i], StringComparison.Ordinal))
-                    return true;
-            }
-            return false;
-        }
-
-        string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
-        {
-            if (cmd.MatchedPatternIndex < 0 ||
-                cmd.MatchedPatternIndex >= def.Patterns.Length)
-                return Array.Empty<string>();
-
-            var pattern = def.Patterns[cmd.MatchedPatternIndex];
-            List<string> unfilled = null;
-
-            foreach (string element in pattern)
-            {
-                string slotName = VoskCommandParser.ExtractSlotName(element);
-                if (slotName != null && !VoskCommandParser.IsOptionalSlot(element)
-                    && !cmd.HasSlot(slotName))
-                {
-                    if (unfilled == null)
-                        unfilled = new List<string>();
-                    unfilled.Add(slotName);
-                }
-            }
-
-            return unfilled?.ToArray() ?? Array.Empty<string>();
-        }
-
-        void BuildCommandLookup(VoskCommandDefinition[] commands)
-        {
-            if (_commandLookup == null)
-                _commandLookup = new Dictionary<string, VoskCommandDefinition>(
-                    commands.Length, StringComparer.Ordinal);
-            else
-                _commandLookup.Clear();
-
-            for (int i = 0; i < commands.Length; i++)
-                _commandLookup[commands[i].Intent] = commands[i];
         }
 
         string[] GetFollowUpGrammarWords()
@@ -1076,7 +742,7 @@ namespace VoskXR.Commands
             return result;
         }
 
-        // Test-only setters
+        // Test-only setters/getters
         internal float PendingTimeout { set => pendingTimeout = value; }
         internal VoskPendingTimeoutBehavior PendingTimeoutBehavior
         {
@@ -1084,9 +750,20 @@ namespace VoskXR.Commands
         }
         internal string[] ConfirmVocabulary { set => confirmVocabulary = value; }
         internal string[] CancelVocabulary { set => cancelVocabulary = value; }
+        internal string TestGrammarJson => _grammar.CurrentJson;
+        internal bool TestGrammarRebuildDeferred => _grammar.GrammarRebuildDeferred;
+
+        internal void TestForceTimeoutNow()
+        {
+            if (!_pending.HasPending) return;
+            var current = _pending.Current.Value;
+            current.CreatedTime = -1000f;
+            _pending.ForceSetForTest(current);
+            SendMessage("Update", SendMessageOptions.DontRequireReceiver);
+        }
 
 #if UNITY_EDITOR
-        internal VoskPendingCommand? EditorPendingCommand => _pendingCommand;
+        internal VoskPendingCommand? EditorPendingCommand => _pending.Current;
 
         void HandlePartialResult(string text)
         {

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -10,12 +10,6 @@ using UnityEngine;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Subscribes to <see cref="VoskSpeechRecogniser.OnResult"/> and parses
-    /// recognised speech into structured <see cref="VoskCommand"/> events.
-    /// Supports utterance buffering for split commands, sequential command
-    /// extraction, and per-intent debounce.
-    /// </summary>
     [AddComponentMenu("VOSK XR/Command Recogniser")]
     public class VoskCommandRecogniser : MonoBehaviour
     {
@@ -71,23 +65,15 @@ namespace VoskXR.Commands
         public event Action<VoskCommand[]> OnCommandsRecognised;
         public event Action<string> OnUnrecognisedSpeech;
 
-        /// <summary>Fires when a command enters pending state (partial match or awaiting confirmation).</summary>
         public event Action<VoskCommand> OnCommandPending;
 
-        /// <summary>Fires when a pending command is confirmed (by follow-up speech or explicit confirmation).</summary>
         public event Action<VoskCommand> OnCommandConfirmed;
 
-        /// <summary>Fires when a pending command is cancelled (timeout, explicit cancel, or preempted by a new command).</summary>
         public event Action<VoskCommand> OnCommandCancelled;
 
 #if UNITY_EDITOR
-        /// <summary>
-        /// Diagnostic snapshot of the last utterance processed through the command pipeline.
-        /// The debug window polls this via the <see cref="VoskMatchDiagnostics.Frame"/> field.
-        /// </summary>
         internal VoskMatchDiagnostics LastMatchDiagnostics { get; private set; }
 
-        /// <summary>Last partial result text from VOSK (updates as the user speaks).</summary>
         internal string LastPartialResult { get; private set; }
 #endif
 
@@ -112,20 +98,12 @@ namespace VoskXR.Commands
         // Pre-allocated buffer for accepted commands (avoids per-utterance List allocation)
         VoskCommand[] _acceptedBuf;
 
-        /// <summary>Names of the currently active command sets (snapshot copy).</summary>
         public string[] ActiveSetNames => _setManager.ActiveSetNames;
 
-        /// <summary>True if a command is currently in pending state.</summary>
         public bool HasPendingCommand => _pending.HasPending;
 
-        /// <summary>The currently pending command, or null if none.</summary>
         public VoskCommand? PendingCommand => _pending.PendingCommand;
 
-        /// <summary>
-        /// Builds the command parser from the given slot and command definitions.
-        /// If the speech recogniser model is already loaded and free-speech mode is off,
-        /// applies the grammar immediately. All commands are active.
-        /// </summary>
         public void Configure(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands)
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
@@ -150,10 +128,6 @@ namespace VoskXR.Commands
             }
         }
 
-        /// <summary>
-        /// Registers shared slots and named command sets. Does not activate any set —
-        /// call <see cref="SetActiveSets"/> to activate one or more sets.
-        /// </summary>
         public void Configure(VoskSlotDefinition[] slots, VoskCommandSet[] sets)
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
@@ -170,11 +144,6 @@ namespace VoskXR.Commands
             _activeCommands = null;
         }
 
-        /// <summary>
-        /// Activates the named command sets. Rebuilds the parser and grammar from
-        /// only the commands in the active sets. If recognition is running, performs
-        /// stop → set grammar → start.
-        /// </summary>
         public void SetActiveSets(params string[] setNames)
         {
             if (!_setManager.HasSets)
@@ -190,23 +159,11 @@ namespace VoskXR.Commands
             RebuildParserAndGrammar();
         }
 
-        /// <summary>
-        /// Activates a single command set by name.
-        /// </summary>
         public void SetActiveSet(string setName)
         {
             SetActiveSets(setName);
         }
 
-        /// <summary>
-        /// Injects text into the command pipeline as if it had arrived from VOSK, exercising
-        /// the same <see cref="HandleResult"/> path (parser, threshold filter, buffer, debounce)
-        /// as real audio.
-        /// When <c>bufferWindow &gt; 0</c> the result is queued and events fire later from
-        /// <see cref="Update"/>; call <see cref="FlushPendingBuffer"/> for synchronous events.
-        /// Requires one of the <c>Configure</c> overloads (and <see cref="SetActiveSets"/> when
-        /// using command sets) to have been called first. Main thread only.
-        /// </summary>
         public void InjectText(string text, VoskWord[] words = null)
         {
             Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
@@ -228,11 +185,6 @@ namespace VoskXR.Commands
                 Array.Empty<VoskAlternative>()));
         }
 
-        /// <summary>
-        /// Flushes any speech currently held in the utterance buffer, firing command events
-        /// synchronously. Useful for push-to-talk release and scene transitions. No-op when
-        /// the buffer is empty. Main thread only.
-        /// </summary>
         public void FlushPendingBuffer()
         {
             Debug.Assert(System.Threading.Thread.CurrentThread.ManagedThreadId == 1,
@@ -242,42 +194,20 @@ namespace VoskXR.Commands
                 FlushBuffer();
         }
 
-        /// <summary>
-        /// Cancels the currently pending command, if any. Fires <see cref="OnCommandCancelled"/>.
-        /// No-op when no command is pending.
-        /// </summary>
         public void CancelPendingCommand() => InterpretResolution(_pending.Cancel());
 
         // -------- Dynamic slot value providers --------
 
-        /// <summary>
-        /// Registers a function that controls which values of the named slot the
-        /// parser will accept. Call <see cref="NotifySlotChanged"/> after the
-        /// provider's return set changes to rebuild the parser.
-        /// The grammar (VOSK vocabulary) is not affected — it always reflects the
-        /// full universe of slot values registered via <see cref="Configure"/>.
-        /// </summary>
         public void RegisterSlotValueProvider(string slotName, Func<string[]> valueProvider)
         {
             _slotManager.Register(slotName, valueProvider);
         }
 
-        /// <summary>
-        /// Removes a previously registered value provider. The slot reverts to its
-        /// full universe of values on the next parser rebuild.
-        /// </summary>
         public bool UnregisterSlotValueProvider(string slotName)
         {
             return _slotManager.Unregister(slotName);
         }
 
-        /// <summary>
-        /// Rebuilds the parser to reflect current value-provider results.
-        /// Does not touch the grammar or VOSK recogniser. No-op if
-        /// <see cref="Configure"/> has not been called or no commands are active.
-        /// Performs a full parser rebuild — call only when provider values have
-        /// actually changed, not every frame.
-        /// </summary>
         public void NotifySlotChanged()
         {
             if (_activeCommands == null)
@@ -286,10 +216,6 @@ namespace VoskXR.Commands
             RebuildParser();
         }
 
-        /// <summary>
-        /// Rebuilds only the parser from the current effective slots and active
-        /// commands. The grammar and VOSK recogniser are untouched.
-        /// </summary>
         public void RebuildParser()
         {
             if (_activeCommands == null)
@@ -299,13 +225,6 @@ namespace VoskXR.Commands
             _parser = new VoskCommandParser(_slotManager.BuildEffectiveSlots(_slots), _activeCommands);
         }
 
-        /// <summary>
-        /// Rebuilds and re-applies the VOSK grammar from the full universe of slot
-        /// values. Performs the stop → set grammar → start cycle when recognition
-        /// is running. Clears the utterance buffer.
-        /// If a command is currently pending, the rebuild is deferred until the
-        /// pending command resolves.
-        /// </summary>
         public void RebuildGrammar()
         {
             if (_activeCommands == null)
@@ -617,6 +536,7 @@ namespace VoskXR.Commands
             // ---- Step 7: Process results with pending-aware logic ----
             float now = Time.time;
             int acceptedCount = 0;
+            bool anyThresholdFiltered = false;
 #if UNITY_EDITOR
             var attempts = new List<VoskMatchAttempt>(resultCount);
 #endif
@@ -659,6 +579,7 @@ namespace VoskXR.Commands
                 // Reject if below confidence threshold (skip when word data unavailable, i.e. -1)
                 if (cmd.Confidence >= 0f && cmd.Confidence < minConfidence)
                 {
+                    anyThresholdFiltered = true;
 #if UNITY_EDITOR
                     attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         $"confidence {cmd.Confidence:F2} < minConfidence {minConfidence:F2}", false));
@@ -670,6 +591,7 @@ namespace VoskXR.Commands
                 if (commandCooldown > 0f &&
                     _debouncer.IsOnCooldown(cmd.Intent, now, commandCooldown))
                 {
+                    anyThresholdFiltered = true;
 #if UNITY_EDITOR
                     attempts.Add(BuildAttempt(cmd, parseDiag, i, tokens, diagWordConf,
                         $"debounced ({commandCooldown:F1}s cooldown)", false));
@@ -707,7 +629,12 @@ namespace VoskXR.Commands
 
             if (acceptedCount == 0)
             {
-                OnUnrecognisedSpeech?.Invoke(text);
+                // Only fire OnUnrecognisedSpeech when the speech genuinely didn't match
+                // any command. Threshold-filtered results (confidence, debounce) are
+                // silently dropped — the user said a valid command, just not confidently
+                // or too soon after the last one.
+                if (!anyThresholdFiltered)
+                    OnUnrecognisedSpeech?.Invoke(text);
                 return;
             }
 

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -499,24 +499,37 @@ namespace VoskXR.Commands
 
         void FlushBuffer()
         {
-            var (text, words) = _buffer.Flush();
+            string text = _buffer.Flush();
             if (text.Length == 0)
+            {
+                _buffer.ClearWords();
                 return;
+            }
 
+            var words = _buffer.GetWordsSpan();
             ProcessParsedResults(text, words);
+            _buffer.ClearWords();
         }
 
         void ProcessParsedResults(string text, VoskWord[] words)
+            => ProcessParsedResultsCore(text, words, _parser.InstanceBuildWordConfidence(words));
+
+        void ProcessParsedResults(string text, ReadOnlySpan<VoskWord> words)
+            => ProcessParsedResultsCore(text, words, _parser.InstanceBuildWordConfidence(words));
+
+        void ProcessParsedResultsCore(string text, ReadOnlySpan<VoskWord> words,
+            Dictionary<string, float> wordConfidence)
         {
-            // Split once — shared by pending handlers, diagnostics, and (indirectly) the parser.
+            // Split once — shared by pending handlers, diagnostics, and the parser.
             string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
                 StringSplitOptions.RemoveEmptyEntries);
             if (tokens.Length == 0)
                 return;
 
-            Dictionary<string, float> wordConfidence = _pending.HasPending
-                ? VoskCommandParser.BuildWordConfidence(words)
-                : null;
+#if UNITY_EDITOR
+            // Editor diagnostics need VoskWord[] — copy once for the editor path only.
+            VoskWord[] diagWords = words.ToArray();
+#endif
 
             // ---- Step 1: Confirm/cancel check (before parsing) ----
             if (_pending.HasPending)
@@ -528,7 +541,7 @@ namespace VoskXR.Commands
                     InterpretResolution(ccResolution);
 #if UNITY_EDITOR
                     LastMatchDiagnostics = new VoskMatchDiagnostics(
-                        text, words,
+                        text, diagWords,
                         new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
                             null, "handled as confirm/cancel", false) },
                         Time.frameCount);
@@ -543,20 +556,21 @@ namespace VoskXR.Commands
                 followUpResult = _pending.TryFollowUpSlotFill(
                     text, tokens, wordConfidence, _parser);
 
-            // ---- Step 3: Normal parse ----
-            var results = _parser.Parse(text, words);
+            // ---- Step 3: Normal parse (internal path — no duplicate split/dict) ----
+            int resultCount = _parser.ParseInternal(tokens, text, wordConfidence);
 
 #if UNITY_EDITOR
             var parseDiag = _parser.LastParseDiagnostics;
-            Dictionary<string, float> diagWordConf = wordConfidence
-                ?? VoskCommandParser.BuildWordConfidence(words);
+            // wordConfidence is already built above — reuse for diagnostics.
+            Dictionary<string, float> diagWordConf = wordConfidence;
 #endif
 
             // ---- Step 4: Determine if any normal result passes standard thresholds ----
             bool hasCompleteNewCommand = false;
-            for (int i = 0; i < results.Length; i++)
+            var resultBuf = _parser.ResultBuffer;
+            for (int i = 0; i < resultCount; i++)
             {
-                var cmd = results[i].Command;
+                var cmd = resultBuf[i].Command;
                 if (cmd.Score >= minScore &&
                     (cmd.Confidence < 0f || cmd.Confidence >= minConfidence))
                 {
@@ -572,7 +586,7 @@ namespace VoskXR.Commands
                 InterpretResolution(completeRes);
 #if UNITY_EDITOR
                 LastMatchDiagnostics = new VoskMatchDiagnostics(
-                    text, words,
+                    text, diagWords,
                     new[] { new VoskMatchAttempt(
                         followUpResult.Value.Intent, null, followUpResult.Value.Score,
                         minScore, followUpResult.Value.Confidence, minConfidence,
@@ -587,11 +601,11 @@ namespace VoskXR.Commands
                 InterpretResolution(_pending.Cancel());
 
             // ---- Step 6: No parse results ----
-            if (results.Length == 0)
+            if (resultCount == 0)
             {
 #if UNITY_EDITOR
                 LastMatchDiagnostics = new VoskMatchDiagnostics(
-                    text, words,
+                    text, diagWords,
                     new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
                         null, "no match", false) },
                     Time.frameCount);
@@ -604,12 +618,12 @@ namespace VoskXR.Commands
             float now = Time.time;
             int acceptedCount = 0;
 #if UNITY_EDITOR
-            var attempts = new List<VoskMatchAttempt>(results.Length);
+            var attempts = new List<VoskMatchAttempt>(resultCount);
 #endif
 
-            for (int i = 0; i < results.Length; i++)
+            for (int i = 0; i < resultCount; i++)
             {
-                var cmd = results[i].Command;
+                var cmd = resultBuf[i].Command;
 
                 // Below score threshold — check AllowPartialMatch before rejecting
                 if (cmd.Score < minScore)
@@ -618,7 +632,7 @@ namespace VoskXR.Commands
                         _setManager.TryLookupCommand(cmd.Intent, out var partialDef) &&
                         partialDef.AllowPartialMatch)
                     {
-                        var unfilled = PendingCommandHandler.ComputeUnfilledSlots(cmd, partialDef);
+                        var unfilled = _pending.ComputeUnfilledSlots(cmd, partialDef);
                         if (unfilled.Length > 0)
                         {
                             var enterRes = _pending.EnterPending(cmd, partialDef, unfilled,
@@ -688,7 +702,7 @@ namespace VoskXR.Commands
 
 #if UNITY_EDITOR
             LastMatchDiagnostics = new VoskMatchDiagnostics(
-                text, words, attempts.ToArray(), Time.frameCount);
+                text, diagWords, attempts.ToArray(), Time.frameCount);
 #endif
 
             if (acceptedCount == 0)

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -390,6 +390,20 @@ namespace VoskXR.Commands
             {
                 var resolution = _pending.HandleTimeout(pendingTimeoutBehavior);
                 InterpretResolution(resolution);
+#if UNITY_EDITOR
+                bool timedOutConfirmed = resolution.Outcome == PendingOutcome.Confirmed;
+                string timeoutLabel = timedOutConfirmed
+                    ? "timeout — fired as-is" : "timeout — cancelled";
+                LastMatchDiagnostics = new VoskMatchDiagnostics(
+                    resolution.Command.RawText ?? "", Array.Empty<VoskWord>(),
+                    new[] { new VoskMatchAttempt(
+                        resolution.Command.Intent, null,
+                        resolution.Command.Score, minScore,
+                        resolution.Command.Confidence, minConfidence,
+                        null, timedOutConfirmed ? null : timeoutLabel,
+                        timedOutConfirmed) },
+                    Time.frameCount);
+#endif
             }
         }
 
@@ -459,10 +473,16 @@ namespace VoskXR.Commands
                 {
                     InterpretResolution(ccResolution);
 #if UNITY_EDITOR
+                    bool wasConfirmed = ccResolution.Outcome == PendingOutcome.Confirmed;
+                    string ccLabel = wasConfirmed ? "confirmed" : "cancelled";
                     LastMatchDiagnostics = new VoskMatchDiagnostics(
                         text, diagWords,
-                        new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
-                            null, "handled as confirm/cancel", false) },
+                        new[] { new VoskMatchAttempt(
+                            ccResolution.Command.Intent, null,
+                            ccResolution.Command.Score, minScore,
+                            ccResolution.Command.Confidence, minConfidence,
+                            null, wasConfirmed ? null : $"{ccLabel} via vocabulary",
+                            wasConfirmed) },
                         Time.frameCount);
 #endif
                     return;

--- a/Runtime/Commands/VoskCommandRecogniser.cs
+++ b/Runtime/Commands/VoskCommandRecogniser.cs
@@ -46,9 +46,33 @@ namespace VoskXR.Commands
         [Tooltip("Command sets to activate on startup when using Inspector authoring.")]
         [SerializeField] string[] initialActiveSetNames;
 
+        [Header("Follow-Up / Pending Commands")]
+        [Tooltip("Maximum seconds a pending command waits for follow-up speech before timing out.")]
+        [SerializeField] float pendingTimeout = 5.0f;
+
+        [Tooltip("What happens when a pending command times out.")]
+        [SerializeField] VoskPendingTimeoutBehavior pendingTimeoutBehavior = VoskPendingTimeoutBehavior.Cancel;
+
+        [Tooltip("Phrases that confirm a pending command. " +
+                 "Leave empty to use defaults (confirm, affirmative, yes, go ahead, do it).")]
+        [SerializeField] string[] confirmVocabulary;
+
+        [Tooltip("Phrases that cancel a pending command. " +
+                 "Leave empty to use defaults (cancel, abort, negative, belay that, never mind).")]
+        [SerializeField] string[] cancelVocabulary;
+
         public event Action<VoskCommand> OnCommandRecognised;
         public event Action<VoskCommand[]> OnCommandsRecognised;
         public event Action<string> OnUnrecognisedSpeech;
+
+        /// <summary>Fires when a command enters pending state (partial match or awaiting confirmation).</summary>
+        public event Action<VoskCommand> OnCommandPending;
+
+        /// <summary>Fires when a pending command is confirmed (by follow-up speech or explicit confirmation).</summary>
+        public event Action<VoskCommand> OnCommandConfirmed;
+
+        /// <summary>Fires when a pending command is cancelled (timeout, explicit cancel, or preempted by a new command).</summary>
+        public event Action<VoskCommand> OnCommandCancelled;
 
 #if UNITY_EDITOR
         /// <summary>
@@ -80,9 +104,20 @@ namespace VoskXR.Commands
         string[] _activeSetNames = Array.Empty<string>();
         VoskCommandDefinition[] _activeCommands;
         Dictionary<string, Func<string[]>> _valueProviders;
+        Dictionary<string, VoskCommandDefinition> _commandLookup;
+
+        // Pending command state
+        VoskPendingCommand? _pendingCommand;
+        bool _grammarRebuildDeferred;
 
         /// <summary>Names of the currently active command sets (snapshot copy).</summary>
         public string[] ActiveSetNames => (string[])_activeSetNames.Clone();
+
+        /// <summary>True if a command is currently in pending state.</summary>
+        public bool HasPendingCommand => _pendingCommand.HasValue;
+
+        /// <summary>The currently pending command, or null if none.</summary>
+        public VoskCommand? PendingCommand => _pendingCommand?.Command;
 
         /// <summary>
         /// Builds the command parser from the given slot and command definitions.
@@ -94,14 +129,18 @@ namespace VoskXR.Commands
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (commands == null) throw new ArgumentNullException(nameof(commands));
 
+            CancelPendingIfActive();
+
             _lastFireTime.Clear();
             _slots = slots;
             _sets = null;
             _activeSetNames = Array.Empty<string>();
             _activeCommands = commands;
+            BuildCommandLookup(commands);
 
             _parser = new VoskCommandParser(BuildEffectiveSlots(), commands);
-            _grammarJson = VoskCommandParser.GenerateGrammarJson(_slots, commands);
+            _grammarJson = VoskCommandParser.GenerateGrammarJson(
+                _slots, commands, GetFollowUpGrammarWords());
             _grammarApplied = false;
 
             if (!freeSpeechMode && speechRecogniser != null && speechRecogniser.IsModelReady)
@@ -120,6 +159,8 @@ namespace VoskXR.Commands
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (sets == null) throw new ArgumentNullException(nameof(sets));
 
+            CancelPendingIfActive();
+
             _lastFireTime.Clear();
             _slots = slots;
             _sets = new Dictionary<string, VoskCommandSet>(sets.Length, StringComparer.Ordinal);
@@ -136,6 +177,7 @@ namespace VoskXR.Commands
             _grammarApplied = false;
             _activeSetNames = Array.Empty<string>();
             _activeCommands = null;
+            _commandLookup = null;
         }
 
         /// <summary>
@@ -148,6 +190,8 @@ namespace VoskXR.Commands
             if (_sets == null)
                 throw new InvalidOperationException(
                     "Configure(slots, sets) must be called before SetActiveSets().");
+
+            CancelPendingIfActive();
 
             if (setNames == null)
                 setNames = Array.Empty<string>();
@@ -186,6 +230,7 @@ namespace VoskXR.Commands
 
             _lastFireTime.Clear();
             RebuildParserAndGrammar(commands);
+            BuildCommandLookup(commands);
         }
 
         /// <summary>
@@ -239,6 +284,12 @@ namespace VoskXR.Commands
             if (_bufferActive)
                 FlushBuffer();
         }
+
+        /// <summary>
+        /// Cancels the currently pending command, if any. Fires <see cref="OnCommandCancelled"/>.
+        /// No-op when no command is pending.
+        /// </summary>
+        public void CancelPendingCommand() => CancelPendingIfActive();
 
         // -------- Dynamic slot value providers --------
 
@@ -302,6 +353,8 @@ namespace VoskXR.Commands
         /// Rebuilds and re-applies the VOSK grammar from the full universe of slot
         /// values. Performs the stop → set grammar → start cycle when recognition
         /// is running. Clears the utterance buffer.
+        /// If a command is currently pending, the rebuild is deferred until the
+        /// pending command resolves.
         /// </summary>
         public void RebuildGrammar()
         {
@@ -309,6 +362,17 @@ namespace VoskXR.Commands
                 throw new InvalidOperationException(
                     "Configure must be called before RebuildGrammar().");
 
+            if (_pendingCommand.HasValue)
+            {
+                _grammarRebuildDeferred = true;
+                return;
+            }
+
+            RebuildGrammarInternal();
+        }
+
+        void RebuildGrammarInternal()
+        {
             if (_bufferActive)
             {
                 _bufferedTexts.Clear();
@@ -316,7 +380,8 @@ namespace VoskXR.Commands
                 _bufferActive = false;
             }
 
-            _grammarJson = VoskCommandParser.GenerateGrammarJson(_slots, _activeCommands);
+            _grammarJson = VoskCommandParser.GenerateGrammarJson(
+                _slots, _activeCommands, GetFollowUpGrammarWords());
             _grammarApplied = false;
 
             if (freeSpeechMode || speechRecogniser == null || !speechRecogniser.IsModelReady)
@@ -332,6 +397,15 @@ namespace VoskXR.Commands
 
             if (wasRunning)
                 speechRecogniser.StartRecognition();
+        }
+
+        void DrainDeferredGrammarRebuild()
+        {
+            if (!_grammarRebuildDeferred)
+                return;
+
+            _grammarRebuildDeferred = false;
+            RebuildGrammarInternal();
         }
 
         VoskSlotDefinition[] BuildEffectiveSlots()
@@ -431,7 +505,7 @@ namespace VoskXR.Commands
         {
             _activeCommands = commands;
             RebuildParser();
-            RebuildGrammar();
+            RebuildGrammarInternal();
         }
 
         void Awake()
@@ -504,6 +578,11 @@ namespace VoskXR.Commands
             speechRecogniser.OnPartialResult -= HandlePartialResult;
 #endif
 
+            // Suppress deferred grammar rebuild — grammar will be re-evaluated on next enable/configure.
+            // CancelPendingIfActive would drain the rebuild, which is unsafe during disable.
+            _grammarRebuildDeferred = false;
+            CancelPendingIfActive();
+
             // Flush any pending buffer on disable
             if (_bufferActive)
                 FlushBuffer();
@@ -513,6 +592,12 @@ namespace VoskXR.Commands
         {
             if (_bufferActive && Time.time - _lastResultTime >= bufferWindow)
                 FlushBuffer();
+
+            if (_pendingCommand.HasValue &&
+                Time.time - _pendingCommand.Value.CreatedTime >= pendingTimeout)
+            {
+                HandlePendingTimeout();
+            }
         }
 
         void HandleModelReady()
@@ -565,6 +650,25 @@ namespace VoskXR.Commands
 
         void ProcessParsedResults(string text, VoskWord[] words)
         {
+            // ---- Step 1: Confirm/cancel check (before parsing) ----
+            if (_pendingCommand.HasValue && TryHandleConfirmCancel(text))
+            {
+#if UNITY_EDITOR
+                LastMatchDiagnostics = new VoskMatchDiagnostics(
+                    text, words,
+                    new[] { new VoskMatchAttempt(null, null, 0f, minScore, 0f, minConfidence,
+                        null, "handled as confirm/cancel", false) },
+                    Time.frameCount);
+#endif
+                return;
+            }
+
+            // ---- Step 2: Follow-up slot-fill attempt (before parsing) ----
+            VoskCommand? followUpResult = null;
+            if (_pendingCommand.HasValue)
+                followUpResult = TryFollowUpSlotFill(text, words);
+
+            // ---- Step 3: Normal parse ----
             var results = _parser.Parse(text, words);
 
 #if UNITY_EDITOR
@@ -580,6 +684,40 @@ namespace VoskXR.Commands
             }
 #endif
 
+            // ---- Step 4: Determine if any normal result passes standard thresholds ----
+            bool hasCompleteNewCommand = false;
+            for (int i = 0; i < results.Length; i++)
+            {
+                var cmd = results[i].Command;
+                if (cmd.Score >= minScore &&
+                    (cmd.Confidence < 0f || cmd.Confidence >= minConfidence))
+                {
+                    hasCompleteNewCommand = true;
+                    break;
+                }
+            }
+
+            // ---- Step 5: Arbitrate follow-up vs new command ----
+            if (followUpResult.HasValue && !hasCompleteNewCommand)
+            {
+                CompletePendingCommand(followUpResult.Value);
+#if UNITY_EDITOR
+                LastMatchDiagnostics = new VoskMatchDiagnostics(
+                    text, words,
+                    new[] { new VoskMatchAttempt(
+                        followUpResult.Value.Intent, null, followUpResult.Value.Score,
+                        minScore, followUpResult.Value.Confidence, minConfidence,
+                        null, null, true) },
+                    Time.frameCount);
+#endif
+                return;
+            }
+
+            // If new complete command preempts a pending, cancel the pending
+            if (_pendingCommand.HasValue && hasCompleteNewCommand)
+                CancelPendingIfActive();
+
+            // ---- Step 6: No parse results ----
             if (results.Length == 0)
             {
 #if UNITY_EDITOR
@@ -593,6 +731,7 @@ namespace VoskXR.Commands
                 return;
             }
 
+            // ---- Step 7: Process results with pending-aware logic ----
             float now = Time.time;
             var accepted = new List<VoskCommand>();
 #if UNITY_EDITOR
@@ -603,9 +742,27 @@ namespace VoskXR.Commands
             {
                 var cmd = results[i].Command;
 
-                // Reject if below score threshold
+                // Below score threshold — check AllowPartialMatch before rejecting
                 if (cmd.Score < minScore)
                 {
+                    if (cmd.Score > 0f && _commandLookup != null &&
+                        _commandLookup.TryGetValue(cmd.Intent, out var partialDef) &&
+                        partialDef.AllowPartialMatch)
+                    {
+                        var unfilled = ComputeUnfilledSlots(cmd, partialDef);
+                        if (unfilled.Length > 0)
+                        {
+                            EnterPendingState(cmd, partialDef, unfilled,
+                                VoskPendingReason.PartialMatch);
+#if UNITY_EDITOR
+                            attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                                $"entered pending (partial: unfilled [{string.Join(", ", unfilled)}])",
+                                false));
+#endif
+                            continue;
+                        }
+                    }
+
 #if UNITY_EDITOR
                     attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
                         $"score {cmd.Score:F2} < minScore {minScore:F2}", false));
@@ -631,6 +788,20 @@ namespace VoskXR.Commands
 #if UNITY_EDITOR
                     attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
                         $"debounced ({commandCooldown:F1}s cooldown)", false));
+#endif
+                    continue;
+                }
+
+                // Check RequiresConfirmation — enter pending instead of firing
+                if (_commandLookup != null &&
+                    _commandLookup.TryGetValue(cmd.Intent, out var confirmDef) &&
+                    confirmDef.RequiresConfirmation)
+                {
+                    EnterPendingState(cmd, confirmDef, Array.Empty<string>(),
+                        VoskPendingReason.AwaitingConfirmation);
+#if UNITY_EDITOR
+                    attempts.Add(BuildAttempt(cmd, parseDiag, i, diagTokens, diagWordConf,
+                        "entered pending (awaiting confirmation)", false));
 #endif
                     continue;
                 }
@@ -662,7 +833,261 @@ namespace VoskXR.Commands
                 OnCommandsRecognised.Invoke(accepted.ToArray());
         }
 
+        // -------- Pending command helpers --------
+
+        bool TryHandleConfirmCancel(string text)
+        {
+            string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
+                StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
+                return false;
+
+            string normalized = string.Join(" ", tokens);
+
+            string[] effectiveCancel = cancelVocabulary != null && cancelVocabulary.Length > 0
+                ? cancelVocabulary : VoskFollowUpVocabulary.DefaultCancel;
+            string[] effectiveConfirm = confirmVocabulary != null && confirmVocabulary.Length > 0
+                ? confirmVocabulary : VoskFollowUpVocabulary.DefaultConfirm;
+
+            if (IsVocabularyMatch(normalized, effectiveCancel))
+            {
+                CancelPendingIfActive();
+                return true;
+            }
+
+            if (IsVocabularyMatch(normalized, effectiveConfirm))
+            {
+                var confirmed = _pendingCommand.Value;
+                _pendingCommand = null;
+                FireConfirmedCommand(confirmed.Command);
+                return true;
+            }
+
+            return false;
+        }
+
+        VoskCommand? TryFollowUpSlotFill(string text, VoskWord[] words)
+        {
+            var pending = _pendingCommand.Value;
+            if (pending.UnfilledSlots == null || pending.UnfilledSlots.Length == 0)
+                return null;
+
+            string[] tokens = text.Split(VoskCommandParser.SplitSeparator,
+                StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
+                return null;
+
+            var newSlots = new List<VoskSlotMatch>(pending.Command.Slots);
+            int tokenIdx = 0;
+
+            foreach (string slotName in pending.UnfilledSlots)
+            {
+                // Try each token position (sliding start) for this slot
+                bool found = false;
+                for (int startIdx = tokenIdx; startIdx < tokens.Length; startIdx++)
+                {
+                    if (tokens[startIdx] == VoskCommandParser.UnkToken)
+                        continue;
+
+                    string value = _parser.TryMatchSlotByName(
+                        tokens, startIdx, slotName, out int consumed);
+                    if (value != null)
+                    {
+                        newSlots.Add(new VoskSlotMatch(slotName, value));
+                        tokenIdx = startIdx + consumed;
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    break;
+            }
+
+            // Must have filled at least one new slot
+            if (newSlots.Count == pending.Command.Slots.Length)
+                return null;
+
+            // Compute updated confidence from follow-up words
+            Dictionary<string, float> wordConfidence = null;
+            if (words != null && words.Length > 0)
+            {
+                wordConfidence = new Dictionary<string, float>(words.Length, StringComparer.Ordinal);
+                foreach (var w in words)
+                    if (!string.IsNullOrEmpty(w.Text) && !wordConfidence.ContainsKey(w.Text))
+                        wordConfidence[w.Text] = w.Confidence;
+            }
+            float followUpConf = VoskCommandParser.ComputeConfidence(
+                tokens, 0, tokens.Length, wordConfidence);
+
+            float mergedConfidence = pending.Command.Confidence >= 0f && followUpConf >= 0f
+                ? Math.Min(pending.Command.Confidence, followUpConf)
+                : pending.Command.Confidence >= 0f ? pending.Command.Confidence : followUpConf;
+
+            return new VoskCommand(
+                pending.Command.Intent,
+                newSlots.ToArray(),
+                mergedConfidence,
+                pending.Command.Score,
+                pending.Command.RawText + " " + text,
+                null,
+                pending.Command.MatchedPatternIndex);
+        }
+
+        void EnterPendingState(VoskCommand command, VoskCommandDefinition definition,
+            string[] unfilledSlots, VoskPendingReason reason)
+        {
+            CancelPendingIfActive();
+
+            _pendingCommand = new VoskPendingCommand
+            {
+                Command = command,
+                Definition = definition,
+                UnfilledSlots = unfilledSlots,
+                Reason = reason,
+                CreatedTime = Time.time,
+            };
+
+            OnCommandPending?.Invoke(command);
+        }
+
+        void CompletePendingCommand(VoskCommand completed)
+        {
+            var pending = _pendingCommand.Value;
+            _pendingCommand = null;
+
+            // If the definition also requires confirmation and we were pending
+            // for partial match, re-enter pending for confirmation
+            if (pending.Definition.RequiresConfirmation &&
+                pending.Reason == VoskPendingReason.PartialMatch)
+            {
+                _pendingCommand = new VoskPendingCommand
+                {
+                    Command = completed,
+                    Definition = pending.Definition,
+                    UnfilledSlots = Array.Empty<string>(),
+                    Reason = VoskPendingReason.AwaitingConfirmation,
+                    CreatedTime = Time.time,
+                };
+                OnCommandPending?.Invoke(completed);
+                return;
+            }
+
+            FireConfirmedCommand(completed);
+        }
+
+        void HandlePendingTimeout()
+        {
+            var pending = _pendingCommand.Value;
+            _pendingCommand = null;
+
+            if (pendingTimeoutBehavior == VoskPendingTimeoutBehavior.FireAsIs)
+            {
+                FireConfirmedCommand(pending.Command);
+            }
+            else
+            {
+                OnCommandCancelled?.Invoke(pending.Command);
+                DrainDeferredGrammarRebuild();
+            }
+        }
+
+        void FireConfirmedCommand(VoskCommand command)
+        {
+            _lastFireTime[command.Intent] = Time.time;
+            OnCommandConfirmed?.Invoke(command);
+            OnCommandRecognised?.Invoke(command);
+            if (OnCommandsRecognised != null)
+                OnCommandsRecognised.Invoke(new[] { command });
+            DrainDeferredGrammarRebuild();
+        }
+
+        void CancelPendingIfActive()
+        {
+            if (!_pendingCommand.HasValue)
+                return;
+
+            var cancelled = _pendingCommand.Value;
+            _pendingCommand = null;
+            OnCommandCancelled?.Invoke(cancelled.Command);
+            DrainDeferredGrammarRebuild();
+        }
+
+        static bool IsVocabularyMatch(string normalized, string[] vocabulary)
+        {
+            for (int i = 0; i < vocabulary.Length; i++)
+            {
+                if (string.Equals(normalized, vocabulary[i], StringComparison.Ordinal))
+                    return true;
+            }
+            return false;
+        }
+
+        string[] ComputeUnfilledSlots(VoskCommand cmd, VoskCommandDefinition def)
+        {
+            if (cmd.MatchedPatternIndex < 0 ||
+                cmd.MatchedPatternIndex >= def.Patterns.Length)
+                return Array.Empty<string>();
+
+            var pattern = def.Patterns[cmd.MatchedPatternIndex];
+            List<string> unfilled = null;
+
+            foreach (string element in pattern)
+            {
+                string slotName = VoskCommandParser.ExtractSlotName(element);
+                if (slotName != null && !VoskCommandParser.IsOptionalSlot(element)
+                    && !cmd.HasSlot(slotName))
+                {
+                    if (unfilled == null)
+                        unfilled = new List<string>();
+                    unfilled.Add(slotName);
+                }
+            }
+
+            return unfilled?.ToArray() ?? Array.Empty<string>();
+        }
+
+        void BuildCommandLookup(VoskCommandDefinition[] commands)
+        {
+            if (_commandLookup == null)
+                _commandLookup = new Dictionary<string, VoskCommandDefinition>(
+                    commands.Length, StringComparer.Ordinal);
+            else
+                _commandLookup.Clear();
+
+            for (int i = 0; i < commands.Length; i++)
+                _commandLookup[commands[i].Intent] = commands[i];
+        }
+
+        string[] GetFollowUpGrammarWords()
+        {
+            var words = new HashSet<string>(StringComparer.Ordinal);
+
+            VoskFollowUpVocabulary.AddPhraseWords(words, VoskFollowUpVocabulary.DefaultConfirm);
+            VoskFollowUpVocabulary.AddPhraseWords(words, VoskFollowUpVocabulary.DefaultCancel);
+
+            if (confirmVocabulary != null)
+                VoskFollowUpVocabulary.AddPhraseWords(words, confirmVocabulary);
+            if (cancelVocabulary != null)
+                VoskFollowUpVocabulary.AddPhraseWords(words, cancelVocabulary);
+
+            var result = new string[words.Count];
+            words.CopyTo(result);
+            return result;
+        }
+
+        // Test-only setters
+        internal float PendingTimeout { set => pendingTimeout = value; }
+        internal VoskPendingTimeoutBehavior PendingTimeoutBehavior
+        {
+            set => pendingTimeoutBehavior = value;
+        }
+        internal string[] ConfirmVocabulary { set => confirmVocabulary = value; }
+        internal string[] CancelVocabulary { set => cancelVocabulary = value; }
+
 #if UNITY_EDITOR
+        internal VoskPendingCommand? EditorPendingCommand => _pendingCommand;
+
         void HandlePartialResult(string text)
         {
             LastPartialResult = text;

--- a/Runtime/Commands/VoskCommandSet.cs
+++ b/Runtime/Commands/VoskCommandSet.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Named group of command definitions for runtime activation/deactivation
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandSet (public readonly struct)
+// Depends:  VoskCommandDefinition
+// ============================================================================
 using System;
 
 namespace VoskXR.Commands

--- a/Runtime/Commands/VoskCommandSet.cs
+++ b/Runtime/Commands/VoskCommandSet.cs
@@ -8,10 +8,6 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// A named group of command definitions that can be activated or deactivated
-    /// at runtime via <see cref="VoskCommandRecogniser.SetActiveSets"/>.
-    /// </summary>
     public readonly struct VoskCommandSet
     {
         public string Name { get; }

--- a/Runtime/Commands/VoskCommandSetAsset.cs
+++ b/Runtime/Commands/VoskCommandSetAsset.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  ScriptableObject grouping VoskCommandAssets into a named set
+// Layer:    Runtime.Commands
+// Owns:     VoskCommandSetAsset (public ScriptableObject)
+// Depends:  VoskCommandAsset, VoskCommandSet
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Runtime/Commands/VoskCommandSetAsset.cs
+++ b/Runtime/Commands/VoskCommandSetAsset.cs
@@ -10,21 +10,12 @@ using UnityEngine;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// ScriptableObject for grouping commands into a named set.
-    /// Create via Assets > Create > VOSK XR > Command Set.
-    /// Use <see cref="ToSet"/> to convert to the runtime struct.
-    /// </summary>
     [CreateAssetMenu(menuName = "VOSK XR/Command Set")]
     public class VoskCommandSetAsset : ScriptableObject
     {
         public string setName;
         public VoskCommandAsset[] commands;
 
-        /// <summary>
-        /// Converts this asset to the runtime <see cref="VoskCommandSet"/> struct.
-        /// Null entries in the commands array are skipped with a warning.
-        /// </summary>
         public VoskCommandSet ToSet()
         {
             if (commands == null || commands.Length == 0)

--- a/Runtime/Commands/VoskMatchDiagnostics.cs
+++ b/Runtime/Commands/VoskMatchDiagnostics.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Editor-only diagnostic structs capturing per-utterance match attempts
+// Layer:    Runtime.Commands (UNITY_EDITOR only)
+// Owns:     VoskMatchDiagnostics, VoskMatchAttempt, VoskDiagnosticSlotMatch (internal readonly structs)
+// Depends:  VoskWord
+// ============================================================================
 #if UNITY_EDITOR
 using System;
 

--- a/Runtime/Commands/VoskMatchDiagnostics.cs
+++ b/Runtime/Commands/VoskMatchDiagnostics.cs
@@ -9,30 +9,14 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Diagnostic snapshot of a single utterance's journey through the command pipeline.
-    /// Populated by <see cref="VoskCommandRecogniser"/> at the end of each parse cycle.
-    /// The Editor debug window polls <see cref="Frame"/> to detect new data.
-    /// </summary>
     internal readonly struct VoskMatchDiagnostics
     {
-        /// <summary>The raw text that entered the parser.</summary>
         public readonly string InputText;
 
-        /// <summary>Per-word confidence data from VOSK (may be empty for injected text).</summary>
         public readonly VoskWord[] Words;
 
-        /// <summary>
-        /// One entry per command extracted (or attempted) from this utterance.
-        /// Covers both accepted and rejected matches, plus a "no match" entry
-        /// when the parser found nothing.
-        /// </summary>
         public readonly VoskMatchAttempt[] Attempts;
 
-        /// <summary>
-        /// <see cref="UnityEngine.Time.frameCount"/> when this diagnostic was created.
-        /// The debug window compares against its last-seen frame to detect new data.
-        /// </summary>
         public readonly int Frame;
 
         public VoskMatchDiagnostics(string inputText, VoskWord[] words,
@@ -45,39 +29,24 @@ namespace VoskXR.Commands
         }
     }
 
-    /// <summary>
-    /// Diagnostic detail for a single command match attempt within an utterance.
-    /// </summary>
     internal readonly struct VoskMatchAttempt
     {
-        /// <summary>Matched intent name, or null if no pattern matched.</summary>
         public readonly string Intent;
 
-        /// <summary>The pattern string that matched (e.g. "fire {weapon}"), or null.</summary>
         public readonly string Pattern;
 
-        /// <summary>Normalised match score from the parser (0.0–1.0).</summary>
         public readonly float Score;
 
-        /// <summary>The minScore threshold that was applied.</summary>
         public readonly float MinScore;
 
-        /// <summary>Minimum word confidence across the matched token span.</summary>
         public readonly float AggregateConfidence;
 
-        /// <summary>The minConfidence threshold that was applied.</summary>
         public readonly float MinConfidence;
 
-        /// <summary>Per-slot diagnostic detail with word positions and confidence.</summary>
         public readonly VoskDiagnosticSlotMatch[] Slots;
 
-        /// <summary>
-        /// Human-readable rejection reason, or null if the command was accepted.
-        /// Examples: "score 0.42 &lt; minScore 0.60", "no match".
-        /// </summary>
         public readonly string RejectReason;
 
-        /// <summary>True if the command passed all thresholds and was fired.</summary>
         public readonly bool IsAccepted;
 
         public VoskMatchAttempt(string intent, string pattern, float score, float minScore,
@@ -96,26 +65,16 @@ namespace VoskXR.Commands
         }
     }
 
-    /// <summary>
-    /// Diagnostic-only slot match with word-level position and confidence data.
-    /// Separate from the runtime <see cref="VoskSlotMatch"/> to avoid enriching
-    /// the hot path with fields only the debug window uses.
-    /// </summary>
     internal readonly struct VoskDiagnosticSlotMatch
     {
-        /// <summary>Slot name (e.g. "weapon").</summary>
         public readonly string Name;
 
-        /// <summary>Matched canonical value (e.g. "missiles").</summary>
         public readonly string Value;
 
-        /// <summary>Index of the first token consumed by this slot (inclusive).</summary>
         public readonly int StartWord;
 
-        /// <summary>Index past the last token consumed by this slot (exclusive).</summary>
         public readonly int EndWord;
 
-        /// <summary>Minimum word confidence across the slot's token span (-1 if unavailable).</summary>
         public readonly float Confidence;
 
         public VoskDiagnosticSlotMatch(string name, string value,

--- a/Runtime/Commands/VoskNumberParser.cs
+++ b/Runtime/Commands/VoskNumberParser.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Converts spoken number-word sequences to integers (digit-by-digit and cardinal)
+// Layer:    Runtime.Commands
+// Owns:     VoskNumberParser (public static class)
+// Depends:  VoskCommandParser (SplitSeparator)
+// ============================================================================
 using System;
 using System.Collections.Generic;
 
@@ -29,7 +35,6 @@ namespace VoskXR.Commands
         public static readonly HashSet<string> DigitVocabulary =
             new HashSet<string>(WordValues.Keys, StringComparer.Ordinal);
 
-        static readonly char[] SplitSeparator = { ' ' };
 
         /// <summary>
         /// Parses a digit-per-word sequence by concatenating single digits.
@@ -42,7 +47,7 @@ namespace VoskXR.Commands
             if (string.IsNullOrWhiteSpace(words))
                 return 0;
 
-            string[] tokens = words.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+            string[] tokens = words.Split(VoskCommandParser.SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
             int result = 0;
 
             foreach (string token in tokens)
@@ -67,7 +72,7 @@ namespace VoskXR.Commands
             if (string.IsNullOrWhiteSpace(words))
                 return 0;
 
-            string[] tokens = words.Split(SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
+            string[] tokens = words.Split(VoskCommandParser.SplitSeparator, StringSplitOptions.RemoveEmptyEntries);
 
             int result = 0;
             int current = 0;

--- a/Runtime/Commands/VoskNumberParser.cs
+++ b/Runtime/Commands/VoskNumberParser.cs
@@ -9,11 +9,6 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Converts spoken number-word sequences to integers.
-    /// Provides the digit vocabulary used by <see cref="VoskCommandParser"/> for
-    /// NumberSequence slot matching and grammar generation.
-    /// </summary>
     public static class VoskNumberParser
     {
         static readonly Dictionary<string, int> WordValues = new Dictionary<string, int>(30, StringComparer.Ordinal)
@@ -28,20 +23,9 @@ namespace VoskXR.Commands
             { "hundred", 100 }, { "thousand", 1000 }
         };
 
-        /// <summary>
-        /// All number words recognized by the parser.
-        /// Derived from WordValues to maintain a single source of truth.
-        /// </summary>
         public static readonly HashSet<string> DigitVocabulary =
             new HashSet<string>(WordValues.Keys, StringComparer.Ordinal);
 
-
-        /// <summary>
-        /// Parses a digit-per-word sequence by concatenating single digits.
-        /// Each word must map to 0–9. "two seven zero" → 270, "one five" → 15.
-        /// </summary>
-        /// <returns>The concatenated integer, or 0 for null/empty input.</returns>
-        /// <exception cref="FormatException">A word is not a single digit (0–9).</exception>
         public static int ParseDigitSequence(string words)
         {
             if (string.IsNullOrWhiteSpace(words))
@@ -61,12 +45,6 @@ namespace VoskXR.Commands
             return result;
         }
 
-        /// <summary>
-        /// Parses a cardinal number phrase. Handles teens, tens, hundreds, and thousands.
-        /// "fifteen" → 15, "twenty" → 20, "two hundred" → 200.
-        /// </summary>
-        /// <returns>The parsed integer, or 0 for null/empty input.</returns>
-        /// <exception cref="FormatException">A word is not a recognized number word.</exception>
         public static int ParseCardinal(string words)
         {
             if (string.IsNullOrWhiteSpace(words))

--- a/Runtime/Commands/VoskPendingCommand.cs
+++ b/Runtime/Commands/VoskPendingCommand.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace VoskXR.Commands
+{
+    /// <summary>
+    /// Determines what happens when a pending command's timeout expires.
+    /// </summary>
+    public enum VoskPendingTimeoutBehavior
+    {
+        /// <summary>The pending command is cancelled and discarded.</summary>
+        Cancel,
+
+        /// <summary>The pending command fires as-is with whatever slots were filled.</summary>
+        FireAsIs
+    }
+
+    /// <summary>
+    /// Why a command entered pending state.
+    /// </summary>
+    internal enum VoskPendingReason
+    {
+        /// <summary>Matched with unfilled required slots; awaiting follow-up speech.</summary>
+        PartialMatch,
+
+        /// <summary>Fully matched but requires explicit confirmation before firing.</summary>
+        AwaitingConfirmation
+    }
+
+    /// <summary>
+    /// Tracks a single pending command awaiting follow-up or confirmation.
+    /// </summary>
+    internal struct VoskPendingCommand
+    {
+        public VoskCommand Command;
+        public VoskCommandDefinition Definition;
+        public string[] UnfilledSlots;
+        public VoskPendingReason Reason;
+        public float CreatedTime;
+    }
+
+    /// <summary>
+    /// Default confirm and cancel vocabulary for pending commands.
+    /// Used when the developer does not supply custom vocabulary.
+    /// </summary>
+    internal static class VoskFollowUpVocabulary
+    {
+        internal static readonly string[] DefaultConfirm =
+            { "confirm", "affirmative", "yes", "go ahead", "do it" };
+
+        internal static readonly string[] DefaultCancel =
+            { "cancel", "abort", "negative", "belay that", "never mind" };
+
+        internal static void AddPhraseWords(System.Collections.Generic.HashSet<string> set, string[] phrases)
+        {
+            foreach (string phrase in phrases)
+            {
+                foreach (string word in phrase.Split(' '))
+                {
+                    if (word.Length > 0)
+                        set.Add(word);
+                }
+            }
+        }
+    }
+}

--- a/Runtime/Commands/VoskPendingCommand.cs
+++ b/Runtime/Commands/VoskPendingCommand.cs
@@ -8,33 +8,18 @@ using System;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Determines what happens when a pending command's timeout expires.
-    /// </summary>
     public enum VoskPendingTimeoutBehavior
     {
-        /// <summary>The pending command is cancelled and discarded.</summary>
         Cancel,
-
-        /// <summary>The pending command fires as-is with whatever slots were filled.</summary>
         FireAsIs
     }
 
-    /// <summary>
-    /// Why a command entered pending state.
-    /// </summary>
     internal enum VoskPendingReason
     {
-        /// <summary>Matched with unfilled required slots; awaiting follow-up speech.</summary>
         PartialMatch,
-
-        /// <summary>Fully matched but requires explicit confirmation before firing.</summary>
         AwaitingConfirmation
     }
 
-    /// <summary>
-    /// Tracks a single pending command awaiting follow-up or confirmation.
-    /// </summary>
     internal struct VoskPendingCommand
     {
         public VoskCommand Command;
@@ -44,10 +29,6 @@ namespace VoskXR.Commands
         public float CreatedTime;
     }
 
-    /// <summary>
-    /// Default confirm and cancel vocabulary for pending commands.
-    /// Used when the developer does not supply custom vocabulary.
-    /// </summary>
     internal static class VoskFollowUpVocabulary
     {
         internal static readonly string[] DefaultConfirm =

--- a/Runtime/Commands/VoskPendingCommand.cs
+++ b/Runtime/Commands/VoskPendingCommand.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Data types and vocabulary for the pending command state machine
+// Layer:    Runtime.Commands
+// Owns:     VoskPendingTimeoutBehavior (public enum), VoskPendingReason (internal enum), VoskPendingCommand (internal struct), VoskFollowUpVocabulary (internal static)
+// Depends:  VoskCommand, VoskCommandDefinition
+// ============================================================================
 using System;
 
 namespace VoskXR.Commands

--- a/Runtime/Commands/VoskPendingCommand.cs.meta
+++ b/Runtime/Commands/VoskPendingCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fef4d4506df26ef4bbf0b4314b4109e1

--- a/Runtime/Commands/VoskSlotAsset.cs
+++ b/Runtime/Commands/VoskSlotAsset.cs
@@ -10,11 +10,6 @@ using UnityEngine;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// ScriptableObject for defining a slot in the Inspector.
-    /// Create via Assets > Create > VOSK XR > Slot Definition.
-    /// Use <see cref="ToDefinition"/> to convert to the runtime struct.
-    /// </summary>
     [CreateAssetMenu(menuName = "VOSK XR/Slot Definition")]
     public class VoskSlotAsset : ScriptableObject
     {
@@ -40,9 +35,6 @@ namespace VoskXR.Commands
             public string canonical;
         }
 
-        /// <summary>
-        /// Converts this asset to the runtime <see cref="VoskSlotDefinition"/> struct.
-        /// </summary>
         public VoskSlotDefinition ToDefinition()
         {
             if (slotType == VoskSlotType.NumberSequence)

--- a/Runtime/Commands/VoskSlotAsset.cs
+++ b/Runtime/Commands/VoskSlotAsset.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  ScriptableObject for Inspector-authored slot definitions
+// Layer:    Runtime.Commands
+// Owns:     VoskSlotAsset (public ScriptableObject), AliasEntry (public struct)
+// Depends:  VoskSlotDefinition, VoskSlotType
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Runtime/Commands/VoskSlotDefinition.cs
+++ b/Runtime/Commands/VoskSlotDefinition.cs
@@ -9,32 +9,18 @@ using System.Collections.Generic;
 
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Defines a named slot with a fixed set of allowed values and optional aliases,
-    /// or a NumberSequence slot that greedily matches digit words.
-    /// Slots are registered once and referenced by name across multiple command definitions.
-    /// </summary>
     public readonly struct VoskSlotDefinition
     {
-        /// <summary>The slot name used in pattern references, e.g. "weapon".</summary>
         public readonly string Name;
 
-        /// <summary>How this slot matches tokens during parsing.</summary>
         public readonly VoskSlotType Type;
 
-        /// <summary>Allowed values for this slot (Enumerated only).</summary>
         public readonly string[] Values;
 
-        /// <summary>
-        /// Maps variant words to canonical values, e.g. "jackals" → "jackal".
-        /// <see cref="VoskSlotMatch.Value"/> contains the canonical value after resolution.
-        /// </summary>
         public readonly Dictionary<string, string> Aliases;
 
-        /// <summary>Minimum number of digit words to consume (NumberSequence only).</summary>
         public readonly int MinWords;
 
-        /// <summary>Maximum number of digit words to consume (NumberSequence only).</summary>
         public readonly int MaxWords;
 
         public VoskSlotDefinition(string name, string[] values)
@@ -80,12 +66,6 @@ namespace VoskXR.Commands
             MaxWords = maxWords;
         }
 
-        /// <summary>
-        /// Creates a NumberSequence slot that greedily matches consecutive digit words.
-        /// </summary>
-        /// <param name="name">Slot name used in pattern references.</param>
-        /// <param name="minWords">Minimum digit words required for a match (must be >= 1).</param>
-        /// <param name="maxWords">Maximum digit words consumed (must be >= minWords).</param>
         public static VoskSlotDefinition NumberSequence(string name, int minWords = 1, int maxWords = 3)
         {
             if (minWords < 1)

--- a/Runtime/Commands/VoskSlotDefinition.cs
+++ b/Runtime/Commands/VoskSlotDefinition.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Immutable slot definition (enumerated values + aliases, or number sequence)
+// Layer:    Runtime.Commands
+// Owns:     VoskSlotDefinition (public readonly struct)
+// Depends:  VoskSlotType
+// ============================================================================
 using System;
 using System.Collections.Generic;
 

--- a/Runtime/Commands/VoskSlotType.cs
+++ b/Runtime/Commands/VoskSlotType.cs
@@ -6,15 +6,10 @@
 // ============================================================================
 namespace VoskXR.Commands
 {
-    /// <summary>
-    /// Determines how a slot matches tokens during command parsing.
-    /// </summary>
     public enum VoskSlotType
     {
-        /// <summary>Matches against a fixed set of allowed values and aliases.</summary>
         Enumerated,
 
-        /// <summary>Greedily consumes consecutive number-word tokens (e.g. "two seven zero").</summary>
         NumberSequence
     }
 }

--- a/Runtime/Commands/VoskSlotType.cs
+++ b/Runtime/Commands/VoskSlotType.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Enum distinguishing enumerated slots from number-sequence slots
+// Layer:    Runtime.Commands
+// Owns:     VoskSlotType (public enum)
+// Depends:  (none)
+// ============================================================================
 namespace VoskXR.Commands
 {
     /// <summary>

--- a/Runtime/Dsp/Agc.cs
+++ b/Runtime/Dsp/Agc.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Automatic gain control with soft-limiter for 16kHz speech normalization
+// Layer:    Runtime.Dsp
+// Owns:     Agc (internal sealed class)
+// Depends:  (none)
+// ============================================================================
 using System;
 
 namespace VoskXR.Dsp

--- a/Runtime/Dsp/Agc.cs
+++ b/Runtime/Dsp/Agc.cs
@@ -8,27 +8,6 @@ using System;
 
 namespace VoskXR.Dsp
 {
-    /// <summary>
-    /// Automatic Gain Control with soft saturation.
-    ///
-    /// Tracks signal level per-sample with asymmetric attack/release smoothing,
-    /// computes a gain to reach a configurable target level, and applies it with
-    /// per-sample interpolation to avoid clicks. A tanh soft limiter replaces
-    /// hard clipping to prevent harmonic distortion.
-    ///
-    /// Designed for the 16 kHz downsampled speech path before VOSK ingestion.
-    ///
-    /// C# port of <c>NativeBridge~/src/agc.h</c> — keep the time constants, gain
-    /// bounds, and tanh approximation in sync if the C++ version ever changes.
-    ///
-    /// Intentional divergence from the C++ source: the noise-floor gate checks the
-    /// current input sample (<c>absX</c>) instead of the smoothed level. Gating on
-    /// the smoothed level means a burst of pure silence takes ~2 seconds to drain
-    /// the envelope follower below 1e-5, during which <c>desiredGain</c> ramps to
-    /// <c>MaxGain</c> and pumps the gain. Gating on <c>absX</c> freezes gain
-    /// immediately when the input is truly silent, which matches standard "hold on
-    /// silence" AGC behaviour and the intent captured in the Editor tests.
-    /// </summary>
     internal sealed class Agc
     {
         public const float DefaultTargetDb = -18f;
@@ -69,9 +48,6 @@ namespace VoskXR.Dsp
             _gainReleaseCoeff  = EmaCoeff(sampleRate, GainReleaseMs);
         }
 
-        /// <summary>
-        /// Process samples in-place. Output is bounded to (-1, 1) by the soft limiter.
-        /// </summary>
         public void Process(float[] samples, int count)
         {
             for (int i = 0; i < count; i++)

--- a/Runtime/Dsp/Downsampler.cs
+++ b/Runtime/Dsp/Downsampler.cs
@@ -8,16 +8,6 @@ using System;
 
 namespace VoskXR.Dsp
 {
-    /// <summary>
-    /// FIR low-pass filter with integer-ratio decimation.
-    /// Designed for 48 kHz -> 16 kHz (factor 3) downsampling.
-    ///
-    /// Uses a 15-tap windowed-sinc filter with a cutoff at ~7.5 kHz
-    /// (Nyquist/2 for the 16 kHz target rate) to anti-alias before decimation.
-    ///
-    /// C# port of <c>NativeBridge~/src/downsampler.h</c> — keep the coefficients
-    /// and state layout in sync if the C++ version ever changes.
-    /// </summary>
     internal sealed class Downsampler
     {
         public const int DecimationFactor = 3;
@@ -40,13 +30,6 @@ namespace VoskXR.Dsp
         int _writePos;
         int _phase;
 
-        /// <summary>
-        /// Processes input samples at the source rate, producing output samples
-        /// at source/<see cref="DecimationFactor"/>. The output buffer must hold
-        /// at least <c>inputCount / DecimationFactor + 1</c> samples because
-        /// residual phase from prior calls can produce one extra output.
-        /// </summary>
-        /// <returns>The number of output samples written.</returns>
         public int Process(float[] input, int inputCount, float[] output)
         {
             int outCount = 0;

--- a/Runtime/Dsp/Downsampler.cs
+++ b/Runtime/Dsp/Downsampler.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  FIR low-pass filter with 3:1 decimation (48kHz to 16kHz)
+// Layer:    Runtime.Dsp
+// Owns:     Downsampler (internal sealed class)
+// Depends:  (none)
+// ============================================================================
 using System;
 
 namespace VoskXR.Dsp

--- a/Runtime/EditorMicBackend.cs
+++ b/Runtime/EditorMicBackend.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Editor-only Windows microphone capture via Unity.Microphone and libvosk P/Invoke
+// Layer:    Runtime (UNITY_EDITOR_WIN only)
+// Owns:     EditorMicBackend (internal sealed class)
+// Depends:  Downsampler, Agc, VoskNative, BridgeNative, VoskBridgeErrorCode
+// ============================================================================
 #if UNITY_EDITOR_WIN
 using System;
 using System.Collections.Generic;

--- a/Runtime/EditorMicBackend.cs
+++ b/Runtime/EditorMicBackend.cs
@@ -14,21 +14,6 @@ using VoskXR.Native;
 
 namespace VoskXR
 {
-    /// <summary>
-    /// Editor-only live microphone backend for the Windows Unity Editor.
-    ///
-    /// Captures audio via <see cref="UnityEngine.Microphone"/>, runs it through
-    /// the C# ports of the existing downsampler and AGC, and feeds the resulting
-    /// 16 kHz int16 PCM directly to <c>libvosk.dll</c> via P/Invoke. Produces the
-    /// same JSON result strings as the Android native bridge, so the result-drain
-    /// code in <see cref="VoskSpeechRecogniser"/> can share its parser helpers
-    /// between the two paths.
-    ///
-    /// Single-threaded by design — every method on this class must be called
-    /// from the Unity main thread. The only exception is the background
-    /// <c>Task.Run</c> wrapped around the blocking <c>vosk_model_new</c> call
-    /// inside <see cref="InitialiseAsync"/>.
-    /// </summary>
     internal sealed class EditorMicBackend
     {
         const int CaptureLengthSeconds = 5;
@@ -311,11 +296,6 @@ namespace VoskXR
             IsInitialised = false;
         }
 
-        /// <summary>
-        /// Pulls new microphone samples, runs them through downsample → AGC →
-        /// int16 → VOSK, and enqueues any resulting JSON for the main Update()
-        /// loop to drain via <see cref="TryDequeueResult"/>.
-        /// </summary>
         internal void Tick(Action<VoskBridgeErrorCode, string> fireError)
         {
             if (!IsRunning || _clip == null) return;

--- a/Runtime/ModelExtractor.cs
+++ b/Runtime/ModelExtractor.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Extracts ZIP-compressed VOSK models from StreamingAssets to persistent storage
+// Layer:    Runtime
+// Owns:     ModelExtractor (internal static class)
+// Depends:  VoskBridgeErrorCode
+// ============================================================================
 using System;
 using System.IO;
 using System.IO.Compression;

--- a/Runtime/Native/BridgeNative.cs
+++ b/Runtime/Native/BridgeNative.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  P/Invoke bindings for the Android vosk-bridge native library
+// Layer:    Runtime.Native
+// Owns:     BridgeNative (internal static class)
+// Depends:  (none)
+// ============================================================================
 using System;
 using System.Runtime.InteropServices;
 using UnityEngine.Scripting;

--- a/Runtime/Native/VoskNative.cs
+++ b/Runtime/Native/VoskNative.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  P/Invoke bindings for libvosk.dll (Windows Editor desktop build)
+// Layer:    Runtime.Native (UNITY_EDITOR_WIN only)
+// Owns:     VoskNative (internal static class)
+// Depends:  (none)
+// ============================================================================
 #if UNITY_EDITOR_WIN
 using System;
 using System.Runtime.InteropServices;

--- a/Runtime/Native/VoskNative.cs
+++ b/Runtime/Native/VoskNative.cs
@@ -11,13 +11,6 @@ using UnityEngine.Scripting;
 
 namespace VoskXR.Native
 {
-    /// <summary>
-    /// P/Invoke bindings for the upstream <c>libvosk.dll</c> desktop build.
-    ///
-    /// Used only by the Editor live-microphone backend on Windows. The Android
-    /// runtime path talks to <see cref="BridgeNative"/> (the custom JNI shim)
-    /// instead — the two are intentionally separate.
-    /// </summary>
     [Preserve]
     internal static class VoskNative
     {

--- a/Runtime/Testing/VoskBatchTestRunner.cs
+++ b/Runtime/Testing/VoskBatchTestRunner.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Feeds test cases through VoskCommandParser with threshold filtering, produces results matrix
+// Layer:    Runtime.Testing
+// Owns:     VoskBatchTestRunner (public class)
+// Depends:  VoskCommandParser, VoskSlotDefinition, VoskCommandDefinition, VoskCommandSet, VoskTestCase, VoskTestResult, VoskSpeechRecogniser
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Runtime/Testing/VoskBatchTestRunner.cs
+++ b/Runtime/Testing/VoskBatchTestRunner.cs
@@ -11,26 +11,12 @@ using VoskXR.Commands;
 
 namespace VoskXR.Testing
 {
-    /// <summary>
-    /// Feeds a list of test cases through the command parser and produces a results matrix.
-    /// Pure C# — no MonoBehaviour dependency, works in Edit Mode and CI.
-    /// Reuses <see cref="VoskCommandParser"/> directly (the same path that
-    /// <see cref="VoskCommandRecogniser.InjectText"/> uses internally).
-    /// </summary>
     public class VoskBatchTestRunner
     {
         readonly VoskCommandParser _parser;
         readonly float _minScore;
         readonly float _minConfidence;
 
-        /// <summary>
-        /// Creates a batch test runner with the given slot and command definitions.
-        /// All commands are active (no command sets).
-        /// </summary>
-        /// <param name="slots">Slot definitions used by the commands.</param>
-        /// <param name="commands">Command definitions to test against.</param>
-        /// <param name="minScore">Minimum match score threshold (default 0.6).</param>
-        /// <param name="minConfidence">Minimum word confidence threshold (default 0.4).</param>
         public VoskBatchTestRunner(VoskSlotDefinition[] slots, VoskCommandDefinition[] commands,
             float minScore = 0.6f, float minConfidence = 0.4f)
         {
@@ -42,15 +28,6 @@ namespace VoskXR.Testing
             _minConfidence = minConfidence;
         }
 
-        /// <summary>
-        /// Creates a batch test runner with named command sets. Only commands from
-        /// the specified active sets are tested.
-        /// </summary>
-        /// <param name="slots">Slot definitions used by the commands.</param>
-        /// <param name="sets">Named command sets.</param>
-        /// <param name="activeSetNames">Which sets to activate.</param>
-        /// <param name="minScore">Minimum match score threshold (default 0.6).</param>
-        /// <param name="minConfidence">Minimum word confidence threshold (default 0.4).</param>
         public VoskBatchTestRunner(VoskSlotDefinition[] slots, VoskCommandSet[] sets,
             string[] activeSetNames, float minScore = 0.6f, float minConfidence = 0.4f)
         {
@@ -84,9 +61,6 @@ namespace VoskXR.Testing
             _minConfidence = minConfidence;
         }
 
-        /// <summary>
-        /// Runs all test cases and returns aggregated results.
-        /// </summary>
         public VoskBatchResults RunAll(VoskTestCase[] testCases)
         {
             if (testCases == null) throw new ArgumentNullException(nameof(testCases));
@@ -98,9 +72,6 @@ namespace VoskXR.Testing
             return new VoskBatchResults(results);
         }
 
-        /// <summary>
-        /// Runs a single test case through the parser and threshold filter.
-        /// </summary>
         public VoskTestResult Run(VoskTestCase testCase)
         {
             if (testCase == null) throw new ArgumentNullException(nameof(testCase));
@@ -282,9 +253,6 @@ namespace VoskXR.Testing
 #endif
         }
 
-        /// <summary>
-        /// Exports batch results as a CSV string for diffing across runs.
-        /// </summary>
         public static string ToCsv(VoskBatchResults results)
         {
             var sb = new StringBuilder();

--- a/Runtime/Testing/VoskTestCase.cs
+++ b/Runtime/Testing/VoskTestCase.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Test case data: input text, expected intent/slots, simulated word confidence
+// Layer:    Runtime.Testing
+// Owns:     VoskTestCase (public class), ExpectedSlot (public struct)
+// Depends:  (none)
+// ============================================================================
 using System;
 using UnityEngine;
 

--- a/Runtime/Testing/VoskTestCase.cs
+++ b/Runtime/Testing/VoskTestCase.cs
@@ -9,49 +9,28 @@ using UnityEngine;
 
 namespace VoskXR.Testing
 {
-    /// <summary>
-    /// A single test case for the batch test runner.
-    /// Specifies input text, expected command result, and optional simulated word confidence.
-    /// </summary>
     [Serializable]
     public class VoskTestCase
     {
-        /// <summary>The text to feed through the command parser.</summary>
         [Tooltip("Text to feed through the command parser (as if from VOSK).")]
         public string input;
 
-        /// <summary>
-        /// Expected intent name after threshold filtering. Null or empty means
-        /// the input should be rejected (no match or below threshold).
-        /// </summary>
         [Tooltip("Expected intent name. Leave empty to expect rejection (no match or below threshold).")]
         public string expectedIntent;
 
-        /// <summary>Expected slot values. Each entry is a name/value pair.</summary>
         [Tooltip("Expected slot name/value pairs.")]
         public ExpectedSlot[] expectedSlots;
 
-        /// <summary>
-        /// Simulated uniform word confidence for threshold testing.
-        /// Set to -1 (default) to omit word data. When >= 0, the runner calls
-        /// <see cref="VoskSpeechRecogniser.CreateSimulatedWords"/> to generate
-        /// per-word confidence data.
-        /// </summary>
         [Tooltip("Simulated word confidence (0-1). Set to -1 to omit word data.")]
         public float wordConfidence = -1f;
 
-        /// <summary>Human-readable description of what this test case verifies.</summary>
         [TextArea]
         public string description;
 
-        /// <summary>True when the test expects no command to be accepted.</summary>
         internal bool ExpectsRejection =>
             string.IsNullOrEmpty(expectedIntent);
     }
 
-    /// <summary>
-    /// A single expected slot name/value pair within a <see cref="VoskTestCase"/>.
-    /// </summary>
     [Serializable]
     public struct ExpectedSlot
     {

--- a/Runtime/Testing/VoskTestResult.cs
+++ b/Runtime/Testing/VoskTestResult.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Single test result and aggregated batch results with pass/fail summary
+// Layer:    Runtime.Testing
+// Owns:     VoskTestResult (public class), VoskBatchResults (public class)
+// Depends:  VoskTestCase, VoskSlotMatch, VoskMatchDiagnostics
+// ============================================================================
 using System;
 using System.Text;
 using VoskXR.Commands;

--- a/Runtime/Testing/VoskTestResult.cs
+++ b/Runtime/Testing/VoskTestResult.cs
@@ -10,34 +10,23 @@ using VoskXR.Commands;
 
 namespace VoskXR.Testing
 {
-    /// <summary>
-    /// Result of running a single <see cref="VoskTestCase"/> through the batch test runner.
-    /// </summary>
     public class VoskTestResult
     {
-        /// <summary>The test case that produced this result.</summary>
         public readonly VoskTestCase TestCase;
 
-        /// <summary>The intent that was accepted, or null if no command passed thresholds.</summary>
         public readonly string ActualIntent;
 
-        /// <summary>Slot matches from the accepted command.</summary>
         public readonly VoskSlotMatch[] ActualSlots;
 
-        /// <summary>Best match score from the parser (0 if no match).</summary>
         public readonly float Score;
 
-        /// <summary>Minimum word confidence across matched tokens (-1 if unavailable).</summary>
         public readonly float Confidence;
 
-        /// <summary>True if the actual result matches expectations.</summary>
         public readonly bool Passed;
 
-        /// <summary>Human-readable failure reason, or null if passed.</summary>
         public readonly string FailureReason;
 
 #if UNITY_EDITOR
-        /// <summary>Full diagnostic data from the parse cycle (Editor only).</summary>
         internal readonly VoskMatchDiagnostics Diagnostics;
 #endif
 
@@ -65,29 +54,16 @@ namespace VoskXR.Testing
 #endif
     }
 
-    /// <summary>
-    /// Aggregated results from <see cref="VoskBatchTestRunner.RunAll"/>.
-    /// Provides <see cref="AllPassed"/> and <see cref="FailureSummary"/> for
-    /// convenient use in NUnit assertions.
-    /// </summary>
     public class VoskBatchResults
     {
-        /// <summary>Individual results for each test case, in input order.</summary>
         public readonly VoskTestResult[] Results;
 
-        /// <summary>True when every test case passed.</summary>
         public bool AllPassed { get; private set; }
 
-        /// <summary>Number of test cases that passed.</summary>
         public int PassCount { get; private set; }
 
-        /// <summary>Number of test cases that failed.</summary>
         public int FailCount { get; private set; }
 
-        /// <summary>
-        /// Multi-line summary of all failures. Empty string when all passed.
-        /// Suitable for passing as the message argument to <c>Assert.IsTrue</c>.
-        /// </summary>
         public string FailureSummary
         {
             get
@@ -114,9 +90,6 @@ namespace VoskXR.Testing
             Recount();
         }
 
-        /// <summary>
-        /// Recalculates PassCount, FailCount, and AllPassed after in-place result updates.
-        /// </summary>
         internal void Recount()
         {
             int pass = 0;

--- a/Runtime/Testing/VoskTestSuiteAsset.cs
+++ b/Runtime/Testing/VoskTestSuiteAsset.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  ScriptableObject wrapping a list of test cases with JSON import/export
+// Layer:    Runtime.Testing
+// Owns:     VoskTestSuiteAsset (public ScriptableObject)
+// Depends:  VoskTestCase
+// ============================================================================
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Runtime/Testing/VoskTestSuiteAsset.cs
+++ b/Runtime/Testing/VoskTestSuiteAsset.cs
@@ -10,11 +10,6 @@ using UnityEngine;
 
 namespace VoskXR.Testing
 {
-    /// <summary>
-    /// ScriptableObject wrapping a list of <see cref="VoskTestCase"/> entries.
-    /// Create via Assets > Create > VOSK XR > Test Suite.
-    /// Supports JSON import/export for portability and version control.
-    /// </summary>
     [CreateAssetMenu(menuName = "VOSK XR/Test Suite")]
     public class VoskTestSuiteAsset : ScriptableObject
     {
@@ -23,23 +18,14 @@ namespace VoskXR.Testing
 
         public List<VoskTestCase> cases = new List<VoskTestCase>();
 
-        /// <summary>
-        /// Returns the test cases as an array for <see cref="VoskBatchTestRunner.RunAll"/>.
-        /// </summary>
         public VoskTestCase[] ToArray() => cases.ToArray();
 
-        /// <summary>
-        /// Serialises the test cases to a JSON string.
-        /// </summary>
         public string ToJson()
         {
             var wrapper = new JsonWrapper { cases = cases.ToArray() };
             return JsonUtility.ToJson(wrapper, true);
         }
 
-        /// <summary>
-        /// Replaces the current test cases with those parsed from a JSON string.
-        /// </summary>
         public void FromJson(string json)
         {
             if (string.IsNullOrWhiteSpace(json))

--- a/Runtime/VoskBridgeErrorCode.cs
+++ b/Runtime/VoskBridgeErrorCode.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Error codes returned by the native bridge, with human-readable descriptions
+// Layer:    Runtime
+// Owns:     VoskBridgeErrorCode (public enum), VoskBridgeErrorCodeExtensions (public static)
+// Depends:  (none)
+// ============================================================================
 namespace VoskXR
 {
     public enum VoskBridgeErrorCode

--- a/Runtime/VoskJsonParser.cs
+++ b/Runtime/VoskJsonParser.cs
@@ -1,0 +1,200 @@
+// ============================================================================
+// Purpose:  Zero-allocation hand-rolled JSON parser for VOSK result/alternative/error JSON
+// Layer:    Runtime
+// Owns:     VoskJsonParser (internal static class)
+// Depends:  VoskWord, VoskAlternative, VoskBridgeErrorCode
+// ============================================================================
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace VoskXR
+{
+    internal static class VoskJsonParser
+    {
+        internal static VoskBridgeErrorCode ParseErrorCode(string json)
+        {
+            const string key = "\"code\":";
+            int idx = json.IndexOf(key, StringComparison.Ordinal);
+            if (idx < 0)
+                return VoskBridgeErrorCode.RingBufferOverflow;
+
+            idx += key.Length;
+            while (idx < json.Length && json[idx] == ' ') idx++;
+
+            int code = 0;
+            while (idx < json.Length && json[idx] >= '0' && json[idx] <= '9')
+            {
+                code = code * 10 + (json[idx] - '0');
+                idx++;
+            }
+
+            return (VoskBridgeErrorCode)code;
+        }
+
+        // VOSK returns JSON with word confidence when vosk_recognizer_set_words(1) is set:
+        // {"result": [{"conf":0.95,"end":0.6,"start":0.1,"word":"hello"}, ...], "text":"hello"}
+        // When there is no speech the "result" key is absent and "text" is empty.
+        internal static VoskWord[] ParseWordsFromJson(string json)
+            => ParseWordsInRange(json, 0, json.Length);
+
+        internal static VoskWord[] ParseWordsInRange(string json, int rangeStart, int rangeEnd)
+        {
+            const string key = "\"result\"";
+            int keyIdx = json.IndexOf(key, rangeStart, rangeEnd - rangeStart, StringComparison.Ordinal);
+            if (keyIdx < 0)
+                return Array.Empty<VoskWord>();
+
+            int arrayStart = json.IndexOf('[', keyIdx + key.Length);
+            if (arrayStart < 0 || arrayStart >= rangeEnd)
+                return Array.Empty<VoskWord>();
+
+            int arrayEnd = json.IndexOf(']', arrayStart);
+            if (arrayEnd < 0 || arrayEnd > rangeEnd)
+                return Array.Empty<VoskWord>();
+
+            // Count word objects
+            int count = 0;
+            for (int i = arrayStart; i < arrayEnd; i++)
+                if (json[i] == '{') count++;
+
+            if (count == 0)
+                return Array.Empty<VoskWord>();
+
+            var words = new VoskWord[count];
+            int wordIdx = 0;
+            int pos = arrayStart + 1;
+
+            while (wordIdx < count && pos < arrayEnd)
+            {
+                int objStart = json.IndexOf('{', pos);
+                if (objStart < 0 || objStart >= arrayEnd) break;
+
+                int objEnd = json.IndexOf('}', objStart);
+                if (objEnd < 0 || objEnd > arrayEnd) break;
+
+                // "conf" is absent when maxAlternatives > 0; use -1 sentinel.
+                bool hasConf = json.IndexOf("\"conf\"", objStart, objEnd - objStart,
+                    StringComparison.Ordinal) >= 0;
+                float conf = hasConf ? ParseFloatValue(json, objStart, objEnd, "\"conf\"") : -1f;
+                float start = ParseFloatValue(json, objStart, objEnd, "\"start\"");
+                float end = ParseFloatValue(json, objStart, objEnd, "\"end\"");
+                string word = ParseStringValue(json, objStart, objEnd, "\"word\"");
+
+                words[wordIdx++] = new VoskWord(word, conf, start, end);
+                pos = objEnd + 1;
+            }
+
+            return words;
+        }
+
+        // When max_alternatives > 0, VOSK wraps results in:
+        // {"alternatives": [{"confidence":123.4,"result":[...],"text":"hello"}, ...]}
+        internal static VoskAlternative[] ParseAlternativesFromJson(string json)
+        {
+            const string key = "\"alternatives\"";
+            int keyIdx = json.IndexOf(key, StringComparison.Ordinal);
+            if (keyIdx < 0)
+                return Array.Empty<VoskAlternative>();
+
+            int arrayStart = json.IndexOf('[', keyIdx + key.Length);
+            if (arrayStart < 0)
+                return Array.Empty<VoskAlternative>();
+
+            // Find matching ']' — must handle nested arrays ("result":[...])
+            int arrayEnd = FindMatchingDelimiter(json, arrayStart, '[', ']');
+            if (arrayEnd < 0)
+                return Array.Empty<VoskAlternative>();
+
+            // Alternatives contain nested "result":[{...}] arrays, so a simple '{'
+            // count would overcount. Use a List and walk depth-1 objects instead.
+            var alternatives = new List<VoskAlternative>();
+            int pos = arrayStart + 1;
+
+            while (pos < arrayEnd)
+            {
+                int objStart = json.IndexOf('{', pos);
+                if (objStart < 0 || objStart >= arrayEnd) break;
+
+                int objEnd = FindMatchingDelimiter(json, objStart, '{', '}');
+                if (objEnd < 0 || objEnd > arrayEnd) break;
+
+                string text = ParseStringValue(json, objStart, objEnd, "\"text\"");
+                float confidence = ParseFloatValue(json, objStart, objEnd, "\"confidence\"");
+                var words = ParseWordsInRange(json, objStart, objEnd);
+
+                alternatives.Add(new VoskAlternative(text, confidence, words));
+                pos = objEnd + 1;
+            }
+
+            return alternatives.Count > 0
+                ? alternatives.ToArray()
+                : Array.Empty<VoskAlternative>();
+        }
+
+        internal static int FindMatchingDelimiter(string json, int openPos, char open, char close)
+        {
+            int depth = 1;
+            for (int i = openPos + 1; i < json.Length; i++)
+            {
+                if (json[i] == open) depth++;
+                else if (json[i] == close) { depth--; if (depth == 0) return i; }
+            }
+            return -1;
+        }
+
+        internal static float ParseFloatValue(string json, int start, int end, string key)
+        {
+            int keyIdx = json.IndexOf(key, start, end - start, StringComparison.Ordinal);
+            if (keyIdx < 0) return 0f;
+
+            int colonIdx = json.IndexOf(':', keyIdx + key.Length);
+            if (colonIdx < 0 || colonIdx >= end) return 0f;
+
+            int valStart = colonIdx + 1;
+            while (valStart < end && json[valStart] == ' ') valStart++;
+
+            int valEnd = valStart;
+            while (valEnd < end && json[valEnd] != ',' && json[valEnd] != '}' && json[valEnd] != ' ')
+                valEnd++;
+
+            if (valEnd <= valStart) return 0f;
+
+            if (float.TryParse(json.AsSpan(valStart, valEnd - valStart),
+                NumberStyles.Float, CultureInfo.InvariantCulture, out float result))
+                return result;
+
+            return 0f;
+        }
+
+        internal static string ParseStringValue(string json, int start, int end, string key)
+        {
+            int keyIdx = json.IndexOf(key, start, end - start, StringComparison.Ordinal);
+            if (keyIdx < 0) return string.Empty;
+
+            int colonIdx = json.IndexOf(':', keyIdx + key.Length);
+            if (colonIdx < 0 || colonIdx >= end) return string.Empty;
+
+            int openQuote = json.IndexOf('"', colonIdx + 1);
+            if (openQuote < 0 || openQuote >= end) return string.Empty;
+
+            int closeQuote = -1;
+            for (int i = openQuote + 1; i < end; i++)
+            {
+                if (json[i] == '\\') { i++; continue; }
+                if (json[i] == '"') { closeQuote = i; break; }
+            }
+            if (closeQuote < 0) return string.Empty;
+
+            return json.Substring(openQuote + 1, closeQuote - openQuote - 1);
+        }
+
+        internal static string ParseTextFromJson(string json, bool isFinal)
+        {
+            string key = isFinal ? "\"text\"" : "\"partial\"";
+            string raw = ParseStringValue(json, 0, json.Length, key);
+            if (raw.Length == 0 || raw.IndexOf('\\') < 0) return raw;
+            return raw.Replace("\\\"", "\"").Replace("\\\\", "\\");
+        }
+    }
+}

--- a/Runtime/VoskJsonParser.cs
+++ b/Runtime/VoskJsonParser.cs
@@ -5,7 +5,6 @@
 // Depends:  VoskWord, VoskAlternative, VoskBridgeErrorCode
 // ============================================================================
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 
 namespace VoskXR
@@ -106,12 +105,29 @@ namespace VoskXR
             if (arrayEnd < 0)
                 return Array.Empty<VoskAlternative>();
 
-            // Alternatives contain nested "result":[{...}] arrays, so a simple '{'
-            // count would overcount. Use a List and walk depth-1 objects instead.
-            var alternatives = new List<VoskAlternative>();
+            // Count depth-1 objects to allocate exact-size array upfront.
+            int count = 0;
+            {
+                int depth = 0;
+                for (int i = arrayStart; i <= arrayEnd; i++)
+                {
+                    if (json[i] == '{')
+                    {
+                        depth++;
+                        if (depth == 1) count++;
+                    }
+                    else if (json[i] == '}') depth--;
+                }
+            }
+
+            if (count == 0)
+                return Array.Empty<VoskAlternative>();
+
+            var alternatives = new VoskAlternative[count];
+            int altIdx = 0;
             int pos = arrayStart + 1;
 
-            while (pos < arrayEnd)
+            while (altIdx < count && pos < arrayEnd)
             {
                 int objStart = json.IndexOf('{', pos);
                 if (objStart < 0 || objStart >= arrayEnd) break;
@@ -123,13 +139,11 @@ namespace VoskXR
                 float confidence = ParseFloatValue(json, objStart, objEnd, "\"confidence\"");
                 var words = ParseWordsInRange(json, objStart, objEnd);
 
-                alternatives.Add(new VoskAlternative(text, confidence, words));
+                alternatives[altIdx++] = new VoskAlternative(text, confidence, words);
                 pos = objEnd + 1;
             }
 
-            return alternatives.Count > 0
-                ? alternatives.ToArray()
-                : Array.Empty<VoskAlternative>();
+            return altIdx > 0 ? alternatives : Array.Empty<VoskAlternative>();
         }
 
         internal static int FindMatchingDelimiter(string json, int openPos, char open, char close)

--- a/Runtime/VoskJsonParser.cs.meta
+++ b/Runtime/VoskJsonParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c7940fb1e269214891551bd8f593512

--- a/Runtime/VoskResult.cs
+++ b/Runtime/VoskResult.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  Data structs for speech recognition results (word, alternative, result)
+// Layer:    Runtime
+// Owns:     VoskWord, VoskAlternative, VoskResult (public readonly structs)
+// Depends:  (none)
+// ============================================================================
 using System;
 
 namespace VoskXR

--- a/Runtime/VoskResult.cs
+++ b/Runtime/VoskResult.cs
@@ -8,22 +8,14 @@ using System;
 
 namespace VoskXR
 {
-    /// <summary>
-    /// A single recognised word with its confidence score and timing.
-    /// Returned by VOSK when word-level confidence is enabled.
-    /// </summary>
     public readonly struct VoskWord
     {
-        /// <summary>The recognised word.</summary>
         public readonly string Text;
 
-        /// <summary>Confidence score in the range [0, 1]. Higher is more confident.</summary>
         public readonly float Confidence;
 
-        /// <summary>Start time of the word in seconds from the beginning of the utterance.</summary>
         public readonly float StartTime;
 
-        /// <summary>End time of the word in seconds from the beginning of the utterance.</summary>
         public readonly float EndTime;
 
         public VoskWord(string text, float confidence, float startTime, float endTime)
@@ -37,24 +29,12 @@ namespace VoskXR
         public override string ToString() => $"{Text} ({Confidence:F2})";
     }
 
-    /// <summary>
-    /// One recognition hypothesis from VOSK's n-best list.
-    /// When <see cref="VoskSpeechRecogniser.maxAlternatives"/> is &gt; 0,
-    /// each final result contains multiple alternatives ranked by confidence.
-    /// </summary>
     public readonly struct VoskAlternative
     {
-        /// <summary>The recognised text for this hypothesis.</summary>
         public readonly string Text;
 
-        /// <summary>
-        /// Acoustic model score. Higher values indicate a better match.
-        /// Only meaningful for comparing alternatives within the same result;
-        /// the scale varies between models.
-        /// </summary>
         public readonly float Confidence;
 
-        /// <summary>Per-word confidence and timing for this hypothesis. May be empty.</summary>
         public readonly VoskWord[] Words;
 
         public VoskAlternative(string text, float confidence, VoskWord[] words)
@@ -67,25 +47,12 @@ namespace VoskXR
         public override string ToString() => $"{Text} (score {Confidence:F1})";
     }
 
-    /// <summary>
-    /// A complete recognition result containing the full text, per-word confidence data,
-    /// and alternative hypotheses when n-best is enabled.
-    /// </summary>
     public readonly struct VoskResult
     {
-        /// <summary>The full recognised text (same string as <see cref="VoskSpeechRecogniser.OnFinalResult"/>).</summary>
         public readonly string Text;
 
-        /// <summary>
-        /// Per-word confidence, timing, and text for the best hypothesis.
-        /// Empty when no words were recognised.
-        /// </summary>
         public readonly VoskWord[] Words;
 
-        /// <summary>
-        /// Alternative recognition hypotheses, ranked best-first.
-        /// Empty when <see cref="VoskSpeechRecogniser.maxAlternatives"/> is 0 (the default).
-        /// </summary>
         public readonly VoskAlternative[] Alternatives;
 
         public VoskResult(string text, VoskWord[] words, VoskAlternative[] alternatives)

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -36,11 +36,6 @@ namespace VoskXR
         public event Action<string> OnPartialResult;
         public event Action<string> OnFinalResult;
 
-        /// <summary>
-        /// Raised for each final recognition result with per-word confidence scores
-        /// and timing data. Subscribe to this when you need to inspect which words
-        /// VOSK is confident about and which it is not.
-        /// </summary>
         public event Action<VoskResult> OnResult;
 
         public event Action<VoskBridgeErrorCode, string> OnError;
@@ -298,13 +293,6 @@ namespace VoskXR
 #endif
         }
 
-        /// <summary>
-        /// Injects a final result as if VOSK had recognised it.
-        /// Bypasses bridge/model/session state, so events fire even when no recognition
-        /// session is active — gate downstream code that assumes an active session.
-        /// Empty or null text is passed through to match the real audio path. Must be
-        /// called from the main thread.
-        /// </summary>
         public void InjectResult(string text, VoskWord[] words = null, VoskAlternative[] alternatives = null)
         {
             AssertMainThread(nameof(InjectResult));
@@ -314,10 +302,6 @@ namespace VoskXR
                 alternatives ?? Array.Empty<VoskAlternative>());
         }
 
-        /// <summary>
-        /// Injects a partial result as if VOSK had recognised it. Empty or null text is
-        /// passed through to match the real audio path. Must be called from the main thread.
-        /// </summary>
         public void InjectPartialResult(string text)
         {
             AssertMainThread(nameof(InjectPartialResult));
@@ -327,12 +311,6 @@ namespace VoskXR
         // ~average English word duration; used to give simulated words a plausible non-zero span.
         const float SimulatedWordDurationSeconds = 0.3f;
 
-        /// <summary>
-        /// Synthesises a <see cref="VoskWord"/> array from a text string with uniform
-        /// confidence and sequential timing.
-        /// Confidence is passed through unchanged — values outside [0, 1] are valid but
-        /// may interact unexpectedly with downstream <c>minConfidence</c> filters.
-        /// </summary>
         public static VoskWord[] CreateSimulatedWords(string text, float confidence = 1.0f)
         {
             if (string.IsNullOrWhiteSpace(text)) return Array.Empty<VoskWord>();

--- a/Runtime/VoskSpeechRecogniser.cs
+++ b/Runtime/VoskSpeechRecogniser.cs
@@ -1,6 +1,11 @@
+// ============================================================================
+// Purpose:  MonoBehaviour orchestrating VOSK speech recognition lifecycle and result dispatch
+// Layer:    Runtime
+// Owns:     VoskSpeechRecogniser (public MonoBehaviour)
+// Depends:  VoskResult, VoskWord, VoskAlternative, VoskBridgeErrorCode, EditorMicBackend, BridgeNative, ModelExtractor
+// ============================================================================
 using System;
 using System.Collections;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -412,12 +417,12 @@ namespace VoskXR
 
             if (json.Contains("\"error\""))
             {
-                var code = ParseErrorCode(json);
+                var code = VoskJsonParser.ParseErrorCode(json);
                 FireError(code, code.ToDescription());
                 return;
             }
 
-            string text = ParseTextFromJson(json, isFinal);
+            string text = VoskJsonParser.ParseTextFromJson(json, isFinal);
 
             if (isFinal)
             {
@@ -430,11 +435,11 @@ namespace VoskXR
 #endif
                 if (needFullParse)
                 {
-                    alternatives = ParseAlternativesFromJson(json);
+                    alternatives = VoskJsonParser.ParseAlternativesFromJson(json);
                     if (alternatives.Length > 0 && alternatives[0].Words.Length > 0)
                         words = alternatives[0].Words;
                     else
-                        words = ParseWordsFromJson(json);
+                        words = VoskJsonParser.ParseWordsFromJson(json);
                 }
 
                 DispatchFinalResult(text, words, alternatives);
@@ -477,189 +482,5 @@ namespace VoskXR
                 "Ensure the native plugins are built and placed in Runtime/Plugins/Android/arm64-v8a/.");
         }
 
-        static VoskBridgeErrorCode ParseErrorCode(string json)
-        {
-            const string key = "\"code\":";
-            int idx = json.IndexOf(key, StringComparison.Ordinal);
-            if (idx < 0)
-                return VoskBridgeErrorCode.RingBufferOverflow;
-
-            idx += key.Length;
-            while (idx < json.Length && json[idx] == ' ') idx++;
-
-            int code = 0;
-            while (idx < json.Length && json[idx] >= '0' && json[idx] <= '9')
-            {
-                code = code * 10 + (json[idx] - '0');
-                idx++;
-            }
-
-            return (VoskBridgeErrorCode)code;
-        }
-
-        // VOSK returns JSON with word confidence when vosk_recognizer_set_words(1) is set:
-        // {"result": [{"conf":0.95,"end":0.6,"start":0.1,"word":"hello"}, ...], "text":"hello"}
-        // When there is no speech the "result" key is absent and "text" is empty.
-        internal static VoskWord[] ParseWordsFromJson(string json)
-            => ParseWordsInRange(json, 0, json.Length);
-
-        static VoskWord[] ParseWordsInRange(string json, int rangeStart, int rangeEnd)
-        {
-            const string key = "\"result\"";
-            int keyIdx = json.IndexOf(key, rangeStart, rangeEnd - rangeStart, StringComparison.Ordinal);
-            if (keyIdx < 0)
-                return Array.Empty<VoskWord>();
-
-            int arrayStart = json.IndexOf('[', keyIdx + key.Length);
-            if (arrayStart < 0 || arrayStart >= rangeEnd)
-                return Array.Empty<VoskWord>();
-
-            int arrayEnd = json.IndexOf(']', arrayStart);
-            if (arrayEnd < 0 || arrayEnd > rangeEnd)
-                return Array.Empty<VoskWord>();
-
-            // Count word objects
-            int count = 0;
-            for (int i = arrayStart; i < arrayEnd; i++)
-                if (json[i] == '{') count++;
-
-            if (count == 0)
-                return Array.Empty<VoskWord>();
-
-            var words = new VoskWord[count];
-            int wordIdx = 0;
-            int pos = arrayStart + 1;
-
-            while (wordIdx < count && pos < arrayEnd)
-            {
-                int objStart = json.IndexOf('{', pos);
-                if (objStart < 0 || objStart >= arrayEnd) break;
-
-                int objEnd = json.IndexOf('}', objStart);
-                if (objEnd < 0 || objEnd > arrayEnd) break;
-
-                // "conf" is absent when maxAlternatives > 0; use -1 sentinel.
-                bool hasConf = json.IndexOf("\"conf\"", objStart, objEnd - objStart,
-                    StringComparison.Ordinal) >= 0;
-                float conf = hasConf ? ParseFloatValue(json, objStart, objEnd, "\"conf\"") : -1f;
-                float start = ParseFloatValue(json, objStart, objEnd, "\"start\"");
-                float end = ParseFloatValue(json, objStart, objEnd, "\"end\"");
-                string word = ParseStringValue(json, objStart, objEnd, "\"word\"");
-
-                words[wordIdx++] = new VoskWord(word, conf, start, end);
-                pos = objEnd + 1;
-            }
-
-            return words;
-        }
-
-        // When max_alternatives > 0, VOSK wraps results in:
-        // {"alternatives": [{"confidence":123.4,"result":[...],"text":"hello"}, ...]}
-        internal static VoskAlternative[] ParseAlternativesFromJson(string json)
-        {
-            const string key = "\"alternatives\"";
-            int keyIdx = json.IndexOf(key, StringComparison.Ordinal);
-            if (keyIdx < 0)
-                return Array.Empty<VoskAlternative>();
-
-            int arrayStart = json.IndexOf('[', keyIdx + key.Length);
-            if (arrayStart < 0)
-                return Array.Empty<VoskAlternative>();
-
-            // Find matching ']' — must handle nested arrays ("result":[...])
-            int arrayEnd = FindMatchingDelimiter(json, arrayStart, '[', ']');
-            if (arrayEnd < 0)
-                return Array.Empty<VoskAlternative>();
-
-            // Alternatives contain nested "result":[{...}] arrays, so a simple '{'
-            // count would overcount. Use a List and walk depth-1 objects instead.
-            var alternatives = new System.Collections.Generic.List<VoskAlternative>();
-            int pos = arrayStart + 1;
-
-            while (pos < arrayEnd)
-            {
-                int objStart = json.IndexOf('{', pos);
-                if (objStart < 0 || objStart >= arrayEnd) break;
-
-                int objEnd = FindMatchingDelimiter(json, objStart, '{', '}');
-                if (objEnd < 0 || objEnd > arrayEnd) break;
-
-                string text = ParseStringValue(json, objStart, objEnd, "\"text\"");
-                float confidence = ParseFloatValue(json, objStart, objEnd, "\"confidence\"");
-                var words = ParseWordsInRange(json, objStart, objEnd);
-
-                alternatives.Add(new VoskAlternative(text, confidence, words));
-                pos = objEnd + 1;
-            }
-
-            return alternatives.Count > 0
-                ? alternatives.ToArray()
-                : Array.Empty<VoskAlternative>();
-        }
-
-        static int FindMatchingDelimiter(string json, int openPos, char open, char close)
-        {
-            int depth = 1;
-            for (int i = openPos + 1; i < json.Length; i++)
-            {
-                if (json[i] == open) depth++;
-                else if (json[i] == close) { depth--; if (depth == 0) return i; }
-            }
-            return -1;
-        }
-
-        static float ParseFloatValue(string json, int start, int end, string key)
-        {
-            int keyIdx = json.IndexOf(key, start, end - start, StringComparison.Ordinal);
-            if (keyIdx < 0) return 0f;
-
-            int colonIdx = json.IndexOf(':', keyIdx + key.Length);
-            if (colonIdx < 0 || colonIdx >= end) return 0f;
-
-            int valStart = colonIdx + 1;
-            while (valStart < end && json[valStart] == ' ') valStart++;
-
-            int valEnd = valStart;
-            while (valEnd < end && json[valEnd] != ',' && json[valEnd] != '}' && json[valEnd] != ' ')
-                valEnd++;
-
-            if (valEnd <= valStart) return 0f;
-
-            if (float.TryParse(json.AsSpan(valStart, valEnd - valStart),
-                NumberStyles.Float, CultureInfo.InvariantCulture, out float result))
-                return result;
-
-            return 0f;
-        }
-
-        static string ParseStringValue(string json, int start, int end, string key)
-        {
-            int keyIdx = json.IndexOf(key, start, end - start, StringComparison.Ordinal);
-            if (keyIdx < 0) return string.Empty;
-
-            int colonIdx = json.IndexOf(':', keyIdx + key.Length);
-            if (colonIdx < 0 || colonIdx >= end) return string.Empty;
-
-            int openQuote = json.IndexOf('"', colonIdx + 1);
-            if (openQuote < 0 || openQuote >= end) return string.Empty;
-
-            int closeQuote = -1;
-            for (int i = openQuote + 1; i < end; i++)
-            {
-                if (json[i] == '\\') { i++; continue; }
-                if (json[i] == '"') { closeQuote = i; break; }
-            }
-            if (closeQuote < 0) return string.Empty;
-
-            return json.Substring(openQuote + 1, closeQuote - openQuote - 1);
-        }
-
-        static string ParseTextFromJson(string json, bool isFinal)
-        {
-            string key = isFinal ? "\"text\"" : "\"partial\"";
-            string raw = ParseStringValue(json, 0, json.Length, key);
-            if (raw.Length == 0 || raw.IndexOf('\\') < 0) return raw;
-            return raw.Replace("\\\"", "\"").Replace("\\\\", "\\");
-        }
     }
 }

--- a/Samples~/CommandRecognition/DynamicSlotTestDriver.cs
+++ b/Samples~/CommandRecognition/DynamicSlotTestDriver.cs
@@ -1,12 +1,6 @@
 using UnityEngine;
 using VoskXR.Commands;
 
-/// <summary>
-/// Manual test driver for Phase 1–3 of the v4.0 test matrix.
-/// Drop onto the CommandDemo scene alongside VoskCommandRecogniser.
-/// Click a step button to set provider state, then inject text via the
-/// Command Debug window (Window > VOSK XR > Command Debug).
-/// </summary>
 public class DynamicSlotTestDriver : MonoBehaviour
 {
     [SerializeField] VoskCommandRecogniser commandRecogniser;

--- a/Tests/Editor/AudioMetricTests.cs
+++ b/Tests/Editor/AudioMetricTests.cs
@@ -5,10 +5,6 @@ using VoskXR;
 
 namespace VoskXR.Tests.Editor
 {
-    /// <summary>
-    /// Category 5: Audio metric tests (ComputeRms, forwarded properties).
-    /// Windows Editor only — the underlying code is #if UNITY_EDITOR_WIN guarded.
-    /// </summary>
     public class AudioMetricTests
     {
         // 5.4

--- a/Tests/Editor/VoskBatchTestRunnerTests.cs
+++ b/Tests/Editor/VoskBatchTestRunnerTests.cs
@@ -6,10 +6,6 @@ using VoskXR.Testing;
 
 namespace VoskXR.Tests.Editor
 {
-    /// <summary>
-    /// Meta-tests for the batch test runner itself.
-    /// Verifies that the runner correctly reports pass/fail for various scenarios.
-    /// </summary>
     public class VoskBatchTestRunnerTests
     {
         static VoskSlotDefinition[] MakeSlots() => new[]

--- a/Tests/Editor/VoskCommandParserDiagnosticTests.cs
+++ b/Tests/Editor/VoskCommandParserDiagnosticTests.cs
@@ -6,10 +6,6 @@ using VoskXR.Commands;
 
 namespace VoskXR.Tests.Editor
 {
-    /// <summary>
-    /// Category 3: Parser diagnostic fields (LastParseDiagnostics, slot positions,
-    /// ComputeConfidence, internal access).
-    /// </summary>
     public class VoskCommandParserDiagnosticTests
     {
         static VoskSlotDefinition[] MakeSlots() => new[]

--- a/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs
+++ b/Tests/Editor/VoskCommandRecogniserDiagnosticTests.cs
@@ -5,10 +5,6 @@ using VoskXR.Commands;
 
 namespace VoskXR.Tests.Editor
 {
-    /// <summary>
-    /// Category 4: Recogniser diagnostic population (LastMatchDiagnostics,
-    /// rejection reasons, per-slot confidence, partial result).
-    /// </summary>
     public class VoskCommandRecogniserDiagnosticTests
     {
         GameObject _go;

--- a/Tests/Editor/VoskMatchDiagnosticsTests.cs
+++ b/Tests/Editor/VoskMatchDiagnosticsTests.cs
@@ -4,9 +4,6 @@ using VoskXR.Commands;
 
 namespace VoskXR.Tests.Editor
 {
-    /// <summary>
-    /// Category 2: Diagnostic data structure construction and immutability.
-    /// </summary>
     public class VoskMatchDiagnosticsTests
     {
         // 2.1

--- a/Tests/Runtime/ParseAlternativesFromJsonTests.cs
+++ b/Tests/Runtime/ParseAlternativesFromJsonTests.cs
@@ -20,7 +20,7 @@ namespace VoskXR.Tests.Runtime
                 "\"text\":\"yellow world\"}" +
                 "]}";
 
-            var alts = VoskSpeechRecogniser.ParseAlternativesFromJson(json);
+            var alts = VoskJsonParser.ParseAlternativesFromJson(json);
 
             Assert.AreEqual(2, alts.Length);
 
@@ -47,7 +47,7 @@ namespace VoskXR.Tests.Runtime
                 "\"text\":\"yes\"}" +
                 "]}";
 
-            var alts = VoskSpeechRecogniser.ParseAlternativesFromJson(json);
+            var alts = VoskJsonParser.ParseAlternativesFromJson(json);
 
             Assert.AreEqual(1, alts.Length);
             Assert.AreEqual("yes", alts[0].Text);
@@ -61,7 +61,7 @@ namespace VoskXR.Tests.Runtime
                 "{\"result\":[{\"conf\":0.9,\"end\":0.5,\"start\":0.1,\"word\":\"hello\"}]," +
                 "\"text\":\"hello\"}";
 
-            var alts = VoskSpeechRecogniser.ParseAlternativesFromJson(json);
+            var alts = VoskJsonParser.ParseAlternativesFromJson(json);
 
             Assert.AreEqual(0, alts.Length);
         }
@@ -74,7 +74,7 @@ namespace VoskXR.Tests.Runtime
                 "{\"confidence\":100.0,\"text\":\"hello\"}" +
                 "]}";
 
-            var alts = VoskSpeechRecogniser.ParseAlternativesFromJson(json);
+            var alts = VoskJsonParser.ParseAlternativesFromJson(json);
 
             Assert.AreEqual(1, alts.Length);
             Assert.AreEqual("hello", alts[0].Text);
@@ -98,7 +98,7 @@ namespace VoskXR.Tests.Runtime
                 "    }]\n" +
                 "}";
 
-            var alts = VoskSpeechRecogniser.ParseAlternativesFromJson(json);
+            var alts = VoskJsonParser.ParseAlternativesFromJson(json);
 
             Assert.AreEqual(1, alts.Length);
             Assert.AreEqual("test", alts[0].Text);

--- a/Tests/Runtime/ParseWordsFromJsonTests.cs
+++ b/Tests/Runtime/ParseWordsFromJsonTests.cs
@@ -14,7 +14,7 @@ namespace VoskXR.Tests.Runtime
                 "{\"conf\":0.87,\"end\":1.20,\"start\":0.70,\"word\":\"world\"}" +
                 "],\"text\":\"hello world\"}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(2, words.Length);
 
@@ -36,7 +36,7 @@ namespace VoskXR.Tests.Runtime
                 "{\"result\":[{\"conf\":1.000000,\"end\":0.39,\"start\":0.09,\"word\":\"yes\"}]," +
                 "\"text\":\"yes\"}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(1, words.Length);
             Assert.AreEqual("yes", words[0].Text);
@@ -48,7 +48,7 @@ namespace VoskXR.Tests.Runtime
         {
             const string json = "{\"text\":\"\"}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(0, words.Length);
         }
@@ -58,7 +58,7 @@ namespace VoskXR.Tests.Runtime
         {
             const string json = "{\"result\":[],\"text\":\"\"}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(0, words.Length);
         }
@@ -77,7 +77,7 @@ namespace VoskXR.Tests.Runtime
                 "  \"text\" : \"test\"\n" +
                 "}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(1, words.Length);
             Assert.AreEqual("test", words[0].Text);
@@ -91,7 +91,7 @@ namespace VoskXR.Tests.Runtime
                 "{\"result\":[{\"conf\":0.000000,\"end\":0.5,\"start\":0.1,\"word\":\"um\"}]," +
                 "\"text\":\"um\"}";
 
-            var words = VoskSpeechRecogniser.ParseWordsFromJson(json);
+            var words = VoskJsonParser.ParseWordsFromJson(json);
 
             Assert.AreEqual(1, words.Length);
             Assert.AreEqual(0f, words[0].Confidence, 0.001f);

--- a/Tests/Runtime/VoskCommandParserTests.cs
+++ b/Tests/Runtime/VoskCommandParserTests.cs
@@ -60,9 +60,6 @@ namespace VoskXR.Tests.Runtime
             return new VoskCommandParser(MakeSlots(), MakeCommands());
         }
 
-        /// <summary>
-        /// Convenience: parse and assert exactly one match, returning that result.
-        /// </summary>
         static VoskCommandResult ParseOne(VoskCommandParser parser, string text,
             VoskWord[] words = null)
         {

--- a/Tests/Runtime/VoskDynamicSlotTests.cs
+++ b/Tests/Runtime/VoskDynamicSlotTests.cs
@@ -249,14 +249,11 @@ namespace VoskXR.Tests.Runtime
             // Capture grammar before
             _recogniser.RegisterSlotValueProvider("target", () => new[] { "hotel one" });
 
-            // Use reflection to read _grammarJson
-            var field = typeof(VoskCommandRecogniser)
-                .GetField("_grammarJson", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            string grammarBefore = (string)field.GetValue(_recogniser);
+            string grammarBefore = _recogniser.TestGrammarJson;
 
             _recogniser.NotifySlotChanged();
 
-            string grammarAfter = (string)field.GetValue(_recogniser);
+            string grammarAfter = _recogniser.TestGrammarJson;
             Assert.AreEqual(grammarBefore, grammarAfter,
                 "RebuildParser (via NotifySlotChanged) must not change grammar");
         }

--- a/Tests/Runtime/VoskPendingCommandTests.cs
+++ b/Tests/Runtime/VoskPendingCommandTests.cs
@@ -416,17 +416,12 @@ namespace VoskXR.Tests.Runtime
             _recogniser.InjectText("launch missiles target hotel one");
             Assert.IsTrue(_recogniser.HasPendingCommand);
 
-            // Use reflection to read _grammarJson before and after
-            var field = typeof(VoskCommandRecogniser)
-                .GetField("_grammarJson",
-                    System.Reflection.BindingFlags.NonPublic |
-                    System.Reflection.BindingFlags.Instance);
-            string grammarBefore = (string)field.GetValue(_recogniser);
+            string grammarBefore = _recogniser.TestGrammarJson;
 
             // This should be deferred
             _recogniser.RebuildGrammar();
 
-            string grammarDuring = (string)field.GetValue(_recogniser);
+            string grammarDuring = _recogniser.TestGrammarJson;
             Assert.AreEqual(grammarBefore, grammarDuring,
                 "Grammar should not change during pending state");
         }
@@ -451,17 +446,12 @@ namespace VoskXR.Tests.Runtime
             _recogniser.InjectText("launch missiles target hotel one");
             Assert.IsTrue(_recogniser.HasPendingCommand);
 
-            var field = typeof(VoskCommandRecogniser)
-                .GetField("_grammarRebuildDeferred",
-                    System.Reflection.BindingFlags.NonPublic |
-                    System.Reflection.BindingFlags.Instance);
-
             _recogniser.RebuildGrammar(); // Deferred
-            Assert.IsTrue((bool)field.GetValue(_recogniser), "Should be deferred");
+            Assert.IsTrue(_recogniser.TestGrammarRebuildDeferred, "Should be deferred");
 
             _recogniser.InjectText("confirm"); // Resolves pending
 
-            Assert.IsFalse((bool)field.GetValue(_recogniser),
+            Assert.IsFalse(_recogniser.TestGrammarRebuildDeferred,
                 "Deferred flag should be cleared after pending resolves");
         }
 
@@ -688,23 +678,7 @@ namespace VoskXR.Tests.Runtime
 
         void ForceTimeoutNow()
         {
-            // Use reflection to set CreatedTime far in the past
-            var pendingField = typeof(VoskCommandRecogniser)
-                .GetField("_pendingCommand",
-                    System.Reflection.BindingFlags.NonPublic |
-                    System.Reflection.BindingFlags.Instance);
-
-            var nullablePending = (VoskPendingCommand?)pendingField.GetValue(_recogniser);
-            if (!nullablePending.HasValue)
-                return;
-
-            var pending = nullablePending.Value;
-            pending.CreatedTime = -1000f; // Far in the past
-            pendingField.SetValue(_recogniser, (VoskPendingCommand?)pending);
-
-            // Manually trigger Update check
-            // Since Update() runs in MonoBehaviour lifecycle, we use SendMessage
-            _recogniser.SendMessage("Update", SendMessageOptions.DontRequireReceiver);
+            _recogniser.TestForceTimeoutNow();
         }
     }
 }

--- a/Tests/Runtime/VoskPendingCommandTests.cs
+++ b/Tests/Runtime/VoskPendingCommandTests.cs
@@ -1,0 +1,710 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskPendingCommandTests
+    {
+        GameObject _go;
+        VoskCommandRecogniser _recogniser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("TestPendingCommands");
+            _recogniser = _go.AddComponent<VoskCommandRecogniser>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                UnityEngine.Object.DestroyImmediate(_go);
+        }
+
+        // -------- Fixtures --------
+
+        static VoskSlotDefinition[] MakeSlots()
+        {
+            return new[]
+            {
+                new VoskSlotDefinition("target",
+                    new[] { "hotel one", "hotel two", "alpha one" },
+                    new Dictionary<string, string>
+                    {
+                        { "h one", "hotel one" },
+                        { "h two", "hotel two" },
+                    }),
+                new VoskSlotDefinition("weapon",
+                    new[] { "missiles", "torpedoes" }),
+            };
+        }
+
+        static VoskCommandDefinition[] MakeCommands(
+            bool allowPartial = false, bool requiresConfirm = false)
+        {
+            return new[]
+            {
+                new VoskCommandDefinition("launch_weapon", new[]
+                {
+                    new[] { "launch", "{weapon}", "target", "{target}" },
+                }, allowPartial, requiresConfirm),
+                new VoskCommandDefinition("cease_fire", new[]
+                {
+                    new[] { "cease", "fire" },
+                }),
+            };
+        }
+
+        void ConfigureSync(bool allowPartial = false, bool requiresConfirm = false)
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands(allowPartial, requiresConfirm));
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.PendingTimeout = 30f; // Long timeout so tests control resolution
+        }
+
+        // ======== AllowPartialMatch Basics ========
+
+        [Test]
+        public void PartialMatch_WithoutFlag_Rejected()
+        {
+            ConfigureSync(allowPartial: false);
+
+            string unrecognised = null;
+            _recogniser.OnUnrecognisedSpeech += text => unrecognised = text;
+            VoskCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => received = cmd;
+
+            // "launch missiles" is missing {target} — score below minScore
+            _recogniser.InjectText("launch missiles");
+
+            Assert.IsFalse(received.HasValue, "Partial match should be rejected without AllowPartialMatch");
+            Assert.IsNotNull(unrecognised);
+        }
+
+        [Test]
+        public void PartialMatch_WithFlag_EntersPending()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? pending = null;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+
+            Assert.IsTrue(pending.HasValue, "Partial match should enter pending");
+            Assert.AreEqual("launch_weapon", pending.Value.Intent);
+            Assert.IsTrue(pending.Value.HasSlot("weapon"));
+            Assert.AreEqual("missiles", pending.Value.GetSlot("weapon"));
+            Assert.IsFalse(recognised.HasValue, "Should not fire OnCommandRecognised yet");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void PartialMatch_AllSlotsFilled_FiresNormally()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? pending = null;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+
+            Assert.IsFalse(pending.HasValue, "Fully matched should not enter pending");
+            Assert.IsTrue(recognised.HasValue, "Should fire normally");
+            Assert.AreEqual("launch_weapon", recognised.Value.Intent);
+        }
+
+        [Test]
+        public void PartialMatch_FollowUp_FillsSlot()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Follow-up fills the missing {target} slot
+            _recogniser.InjectText("hotel one");
+
+            Assert.IsTrue(confirmed.HasValue, "Follow-up should confirm pending");
+            Assert.AreEqual("launch_weapon", confirmed.Value.Intent);
+            Assert.AreEqual("hotel one", confirmed.Value.GetSlot("target"));
+            Assert.AreEqual("missiles", confirmed.Value.GetSlot("weapon"));
+            Assert.IsTrue(recognised.HasValue, "Should also fire OnCommandRecognised");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void PartialMatch_FollowUp_WrongSlotValue_StaysPending()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Follow-up with unrecognised text
+            _recogniser.InjectText("something random");
+
+            Assert.IsFalse(confirmed.HasValue, "Random speech should not complete pending");
+            Assert.IsTrue(_recogniser.HasPendingCommand, "Should still be pending");
+        }
+
+        [Test]
+        public void PartialMatch_TimeoutCancel_FiresCancelled()
+        {
+            ConfigureSync(allowPartial: true);
+            _recogniser.PendingTimeout = 0.01f; // Very short timeout
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Simulate time passing via manual Update call
+            // We need to wait for timeout — use reflection to set CreatedTime in the past
+            ForceTimeoutNow();
+
+            Assert.IsTrue(cancelled.HasValue, "Should fire OnCommandCancelled on timeout");
+            Assert.AreEqual("launch_weapon", cancelled.Value.Intent);
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void PartialMatch_TimeoutFireAsIs_FiresWithPartialSlots()
+        {
+            ConfigureSync(allowPartial: true);
+            _recogniser.PendingTimeout = 0.01f;
+            _recogniser.PendingTimeoutBehavior = VoskPendingTimeoutBehavior.FireAsIs;
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            ForceTimeoutNow();
+
+            Assert.IsTrue(confirmed.HasValue, "Should fire OnCommandConfirmed");
+            Assert.IsTrue(recognised.HasValue, "Should fire OnCommandRecognised");
+            Assert.AreEqual("missiles", confirmed.Value.GetSlot("weapon"));
+            Assert.IsFalse(confirmed.Value.HasSlot("target"), "Target should be unfilled");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        // ======== RequiresConfirmation Basics ========
+
+        [Test]
+        public void RequiresConfirmation_FullMatch_EntersPending()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? pending = null;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+
+            Assert.IsTrue(pending.HasValue, "Should enter pending for confirmation");
+            Assert.AreEqual("launch_weapon", pending.Value.Intent);
+            Assert.IsFalse(recognised.HasValue, "Should not fire yet");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void RequiresConfirmation_Confirm_Fires()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            _recogniser.InjectText("confirm");
+
+            Assert.IsTrue(confirmed.HasValue, "Should fire OnCommandConfirmed");
+            Assert.IsTrue(recognised.HasValue, "Should fire OnCommandRecognised");
+            Assert.AreEqual("launch_weapon", confirmed.Value.Intent);
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void RequiresConfirmation_Cancel_Cancels()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.InjectText("cancel");
+
+            Assert.IsTrue(cancelled.HasValue, "Should fire OnCommandCancelled");
+            Assert.AreEqual("launch_weapon", cancelled.Value.Intent);
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void RequiresConfirmation_AffirmativeConfirms()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.InjectText("affirmative");
+
+            Assert.IsTrue(confirmed.HasValue, "Synonym 'affirmative' should confirm");
+        }
+
+        [Test]
+        public void RequiresConfirmation_BelayThat_Cancels()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.InjectText("belay that");
+
+            Assert.IsTrue(cancelled.HasValue, "Multi-word 'belay that' should cancel");
+        }
+
+        [Test]
+        public void RequiresConfirmation_CustomVocabulary()
+        {
+            ConfigureSync(requiresConfirm: true);
+            _recogniser.ConfirmVocabulary = new[] { "execute" };
+            _recogniser.CancelVocabulary = new[] { "stand down" };
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            // Default "confirm" should NOT work with custom vocabulary
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.InjectText("confirm");
+            Assert.IsFalse(confirmed.HasValue, "Default 'confirm' should not work with custom vocab");
+
+            // Custom "execute" should work
+            _recogniser.CancelPendingCommand(); // Reset
+            cancelled = null;
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.InjectText("execute");
+            Assert.IsTrue(confirmed.HasValue, "Custom 'execute' should confirm");
+        }
+
+        // ======== Combined AllowPartialMatch + RequiresConfirmation ========
+
+        [Test]
+        public void Combined_PartialThenFollowUpThenConfirm()
+        {
+            ConfigureSync(allowPartial: true, requiresConfirm: true);
+
+            var events = new List<string>();
+            _recogniser.OnCommandPending += cmd => events.Add($"pending:{cmd.Intent}");
+            _recogniser.OnCommandConfirmed += cmd => events.Add($"confirmed:{cmd.Intent}");
+            _recogniser.OnCommandRecognised += cmd => events.Add($"recognised:{cmd.Intent}");
+
+            // Step 1: Partial match enters pending
+            _recogniser.InjectText("launch missiles target");
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual("pending:launch_weapon", events[0]);
+
+            // Step 2: Follow-up fills slot — but RequiresConfirmation means it re-enters pending
+            _recogniser.InjectText("hotel one");
+            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual("pending:launch_weapon", events[1]);
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Step 3: Confirm fires
+            _recogniser.InjectText("confirm");
+            Assert.AreEqual(4, events.Count);
+            Assert.AreEqual("confirmed:launch_weapon", events[2]);
+            Assert.AreEqual("recognised:launch_weapon", events[3]);
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        // ======== Arbitration ========
+
+        [Test]
+        public void Pending_NewCompleteCommand_PreemptsPending()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            // launch_weapon enters pending (requires confirmation)
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // "cease fire" is a complete command — should preempt pending
+            _recogniser.InjectText("cease fire");
+
+            Assert.IsTrue(cancelled.HasValue, "Pending should be cancelled");
+            Assert.AreEqual("launch_weapon", cancelled.Value.Intent);
+            Assert.IsTrue(recognised.HasValue, "New command should fire");
+            Assert.AreEqual("cease_fire", recognised.Value.Intent);
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void Pending_FollowUpOnly_FollowUpWins()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            _recogniser.InjectText("hotel one");
+
+            Assert.IsTrue(confirmed.HasValue, "Follow-up should complete pending");
+            Assert.AreEqual("hotel one", confirmed.Value.GetSlot("target"));
+        }
+
+        [Test]
+        public void ConfirmCancel_NoPending_PassesThrough()
+        {
+            ConfigureSync();
+
+            string unrecognised = null;
+            _recogniser.OnUnrecognisedSpeech += text => unrecognised = text;
+
+            _recogniser.InjectText("confirm");
+
+            Assert.IsNotNull(unrecognised,
+                "'confirm' with no pending should pass through as unrecognised");
+        }
+
+        // ======== Deferred Grammar Rebuild ========
+
+        [Test]
+        public void RebuildGrammar_DuringPending_Deferred()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Use reflection to read _grammarJson before and after
+            var field = typeof(VoskCommandRecogniser)
+                .GetField("_grammarJson",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance);
+            string grammarBefore = (string)field.GetValue(_recogniser);
+
+            // This should be deferred
+            _recogniser.RebuildGrammar();
+
+            string grammarDuring = (string)field.GetValue(_recogniser);
+            Assert.AreEqual(grammarBefore, grammarDuring,
+                "Grammar should not change during pending state");
+        }
+
+        [Test]
+        public void RebuildParser_DuringPending_ExecutesImmediately()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // RebuildParser should not throw and should execute
+            Assert.DoesNotThrow(() => _recogniser.RebuildParser());
+        }
+
+        [Test]
+        public void DeferredRebuild_DrainsAfterPendingResolves()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            var field = typeof(VoskCommandRecogniser)
+                .GetField("_grammarRebuildDeferred",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance);
+
+            _recogniser.RebuildGrammar(); // Deferred
+            Assert.IsTrue((bool)field.GetValue(_recogniser), "Should be deferred");
+
+            _recogniser.InjectText("confirm"); // Resolves pending
+
+            Assert.IsFalse((bool)field.GetValue(_recogniser),
+                "Deferred flag should be cleared after pending resolves");
+        }
+
+        // ======== Public API ========
+
+        [Test]
+        public void CancelPendingCommand_Cancels()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            _recogniser.CancelPendingCommand();
+
+            Assert.IsTrue(cancelled.HasValue, "Should fire OnCommandCancelled");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void CancelPendingCommand_NoPending_NoOp()
+        {
+            ConfigureSync();
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.CancelPendingCommand();
+
+            Assert.IsFalse(cancelled.HasValue, "Should not fire when no pending");
+        }
+
+        [Test]
+        public void HasPendingCommand_Property()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            _recogniser.InjectText("confirm");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void PendingCommand_Property()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            Assert.IsNull(_recogniser.PendingCommand);
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsNotNull(_recogniser.PendingCommand);
+            Assert.AreEqual("launch_weapon", _recogniser.PendingCommand.Value.Intent);
+
+            _recogniser.InjectText("cancel");
+            Assert.IsNull(_recogniser.PendingCommand);
+        }
+
+        // ======== Lifecycle ========
+
+        [Test]
+        public void SetActiveSets_CancelsPending()
+        {
+            var slots = MakeSlots();
+            var sets = new[]
+            {
+                new VoskCommandSet("combat", MakeCommands(requiresConfirm: true)),
+            };
+
+            _recogniser.Configure(slots, sets);
+            _recogniser.SetActiveSets("combat");
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.PendingTimeout = 30f;
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            _recogniser.SetActiveSets("combat");
+
+            Assert.IsTrue(cancelled.HasValue, "SetActiveSets should cancel pending");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void Configure_CancelsPending()
+        {
+            ConfigureSync(requiresConfirm: true);
+
+            VoskCommand? cancelled = null;
+            _recogniser.OnCommandCancelled += cmd => cancelled = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+
+            // Reconfigure
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+
+            Assert.IsTrue(cancelled.HasValue, "Configure should cancel pending");
+            Assert.IsFalse(_recogniser.HasPendingCommand);
+        }
+
+        // ======== Backward Compatibility ========
+
+        [Test]
+        public void DefaultDefinition_BothFlagsFalse()
+        {
+            var def = new VoskCommandDefinition("test", new[] { new[] { "test" } });
+            Assert.IsFalse(def.AllowPartialMatch);
+            Assert.IsFalse(def.RequiresConfirmation);
+        }
+
+        [Test]
+        public void NormalCommand_UnchangedBehavior()
+        {
+            ConfigureSync(); // No flags
+
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+            VoskCommand? pending = null;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+
+            _recogniser.InjectText("launch missiles target hotel one");
+
+            Assert.IsTrue(recognised.HasValue, "Normal command should fire as before");
+            Assert.IsFalse(pending.HasValue, "Normal command should not enter pending");
+        }
+
+        [Test]
+        public void CeaseFireCommand_StillFiresNormally()
+        {
+            ConfigureSync(allowPartial: true); // Only launch_weapon has partial
+
+            VoskCommand? recognised = null;
+            _recogniser.OnCommandRecognised += cmd => recognised = cmd;
+
+            _recogniser.InjectText("cease fire");
+
+            Assert.IsTrue(recognised.HasValue);
+            Assert.AreEqual("cease_fire", recognised.Value.Intent);
+        }
+
+        // ======== Edge Cases ========
+
+        [Test]
+        public void NewPending_CancelsExistingPending()
+        {
+            // Use two commands that both allow partial
+            var slots = MakeSlots();
+            var commands = new[]
+            {
+                new VoskCommandDefinition("launch_weapon", new[]
+                {
+                    new[] { "launch", "{weapon}", "target", "{target}" },
+                }, allowPartialMatch: true),
+                new VoskCommandDefinition("engage_target", new[]
+                {
+                    new[] { "engage", "{target}" },
+                }, allowPartialMatch: true),
+            };
+
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.PendingTimeout = 30f;
+
+            var cancelledIntents = new List<string>();
+            _recogniser.OnCommandCancelled += cmd => cancelledIntents.Add(cmd.Intent);
+
+            var pendingIntents = new List<string>();
+            _recogniser.OnCommandPending += cmd => pendingIntents.Add(cmd.Intent);
+
+            // First partial enters pending
+            _recogniser.InjectText("launch missiles target");
+            Assert.AreEqual(1, pendingIntents.Count);
+            Assert.AreEqual("launch_weapon", pendingIntents[0]);
+
+            // Second partial (different weapon) replaces the first pending
+            _recogniser.InjectText("launch torpedoes target");
+            Assert.AreEqual(2, pendingIntents.Count);
+            Assert.AreEqual("launch_weapon", pendingIntents[1]);
+            Assert.AreEqual(1, cancelledIntents.Count, "First pending should be cancelled");
+            Assert.AreEqual("launch_weapon", cancelledIntents[0]);
+        }
+
+        [Test]
+        public void FollowUp_WithAlias_Works()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? confirmed = null;
+            _recogniser.OnCommandConfirmed += cmd => confirmed = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+            _recogniser.InjectText("h one");
+
+            Assert.IsTrue(confirmed.HasValue, "Alias 'h one' should fill target slot");
+            Assert.AreEqual("hotel one", confirmed.Value.GetSlot("target"));
+        }
+
+        [Test]
+        public void MatchedPatternIndex_PopulatedCorrectly()
+        {
+            ConfigureSync(allowPartial: true);
+
+            VoskCommand? pending = null;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+
+            _recogniser.InjectText("launch missiles target");
+
+            Assert.IsTrue(pending.HasValue);
+            Assert.AreEqual(0, pending.Value.MatchedPatternIndex,
+                "Should match pattern index 0");
+        }
+
+        // -------- Helpers --------
+
+        void ForceTimeoutNow()
+        {
+            // Use reflection to set CreatedTime far in the past
+            var pendingField = typeof(VoskCommandRecogniser)
+                .GetField("_pendingCommand",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance);
+
+            var nullablePending = (VoskPendingCommand?)pendingField.GetValue(_recogniser);
+            if (!nullablePending.HasValue)
+                return;
+
+            var pending = nullablePending.Value;
+            pending.CreatedTime = -1000f; // Far in the past
+            pendingField.SetValue(_recogniser, (VoskPendingCommand?)pending);
+
+            // Manually trigger Update check
+            // Since Update() runs in MonoBehaviour lifecycle, we use SendMessage
+            _recogniser.SendMessage("Update", SendMessageOptions.DontRequireReceiver);
+        }
+    }
+}

--- a/Tests/Runtime/VoskPendingCommandTests.cs.meta
+++ b/Tests/Runtime/VoskPendingCommandTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 968fa400ebf9cde4eb2fdd1287ced16c

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.vosk-xr",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "displayName": "VOSK XR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
  ## Summary
  - Splits `VoskCommandRecogniser` into focused helpers (`PendingCommandHandler`, `CommandSetManager`,
   `GrammarManager`, `DynamicSlotManager`, `UtteranceBuffer`, `CommandDebouncer`) and replaces JSON
  parsing with a dedicated `VoskJsonParser`.
  - Adds a pending command system with partial-match queuing, confirm/cancel vocabulary, timeout
  policies, and follow-up slot-fill — covered by 684 lines of new tests in
  `VoskPendingCommandTests.cs`.
  - Reduces per-utterance allocations: replaces transient `List` instances with pre-allocated buffers
  and removes the unsound slot array pool in favour of a simpler allocation strategy.
  - Improves editor diagnostics: `LastMatchDiagnostics` now records the resolved
  intent/score/confidence on timeout and confirm/cancel paths, and adds a shared `VoskEditorGUI`
  helper.
  - Bumps package to 0.16.0 with corresponding changelog and README entries; removes XML summary
  comments across all C# scripts.