### PR TITLE
Push-to-talk: Add VoskPushToTalkController with runtime-switchable listening mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `VoskPushToTalkController` MonoBehaviour — hold-to-talk gating with runtime-switchable listening mode (`VoskListeningMode.Continuous` | `VoskListeningMode.PushToTalk`), optional command-recogniser integration (auto `FlushPendingBuffer` on release; opt-in `CancelPendingCommand`), `UnityEvent` hooks for Inspector wiring, and automatic correction for the Android mic-permission race.
+- `VoskListeningMode` enum.
+- Push-to-talk sample at `Samples~/PushToTalk/`.
+- `VoskPushToTalkControllerTests` — 16 Play Mode tests covering default state, null safety, press/release idempotence, buffer flushing, pending-command cancel, listening-mode transitions, lifecycle silence across disable/enable, and destroy cleanup.
+
 ## [0.16.0] - 2026-04-13
 
 ### Changed

--- a/Documentation~/push-to-talk.md
+++ b/Documentation~/push-to-talk.md
@@ -1,12 +1,88 @@
-# Push-to-Talk and Error Handling
+# Push-to-Talk
 
-This guide covers the push-to-talk pattern for gating recognition to intentional speech, and the error handling system for responding to runtime failures.
+`VoskPushToTalkController` is a drop-in MonoBehaviour that gates `VoskSpeechRecogniser` behind a talk button and optionally flushes buffered commands on release. It also exposes a runtime-switchable listening mode so you can offer both hold-to-talk and always-on listening in the same build.
+
+## Overview
+
+Use push-to-talk when false triggers from ambient noise, coughs, or background conversation are unacceptable — that is, for most serious XR applications. In grammar mode, VOSK has no "silence" output and must map every detected audio frame to an in-vocabulary word, so push-to-talk is the cleanest way to suppress spurious matches.
+
+`VoskPushToTalkController` wraps the recommended pattern (`Initialise` on scene load, `Start/Stop` on press/release, `FlushPendingBuffer` on release) and adds:
+
+- A best-effort guard for the Android mic-permission race (the dialog can resolve *after* the user released).
+- Runtime switching between `PushToTalk` and `Continuous` modes via the `ListeningMode` property.
+- `UnityEvent` hooks for wiring a recording indicator in the Inspector.
+- Correct lifecycle handling across disable/enable and `OnApplicationPause` so Continuous mode survives the Quest home overlay.
+
+## Quick Setup
+
+1. Add `VoskSpeechRecogniser` and `VoskPushToTalkController` to a GameObject in your scene. If you are using command parsing, add `VoskCommandRecogniser` to the same GameObject.
+2. On the controller, assign the `Speech Recogniser` reference, and optionally the `Command Recogniser`.
+3. Wire your input to the controller's public methods:
+   - On press: `VoskPushToTalkController.PressTalk()`
+   - On release: `VoskPushToTalkController.ReleaseTalk()`
+   - A UI `Button.onClick` fires on release only. For true press/release, use an `EventTrigger` component (`PointerDown` → `PressTalk`, `PointerUp` → `ReleaseTalk`), an XRI `InteractableUnityEventsWrapper`, or an `InputAction` with `started`/`canceled` callbacks.
+4. (Optional) Wire `On Talk Started` and `On Talk Ended` in the controller's Inspector to your recording indicator (e.g. toggle an `Image.color`).
+
+The controller pre-warms the model on `Start` via `VoskSpeechRecogniser.Initialise()`. Disable `Initialise On Start` if your code calls `Initialise()` elsewhere.
+
+## Listening Modes
+
+```csharp
+public enum VoskListeningMode { Continuous, PushToTalk }
+```
+
+- **`PushToTalk`** (default) — recognition only runs between `PressTalk()` and `ReleaseTalk()`.
+- **`Continuous`** — recognition runs whenever the controller is enabled; `PressTalk()` and `ReleaseTalk()` become no-ops.
+
+Switch at runtime by assigning the property:
+
+```csharp
+controller.ListeningMode = VoskListeningMode.Continuous;
+```
+
+Setter semantics:
+
+| From → To                      | Behaviour                                                                                           |
+|--------------------------------|-----------------------------------------------------------------------------------------------------|
+| `PushToTalk` → `Continuous`    | Starts recognition if not already running; fires `OnTalkStarted` (unless a press was already held). |
+| `Continuous` → `PushToTalk`    | Stops recognition; fires `OnTalkEnded`.                                                             |
+| Same → same                    | No-op.                                                                                              |
+
+## Inspector Reference
+
+| Field                         | Purpose                                                                                 |
+|-------------------------------|-----------------------------------------------------------------------------------------|
+| `Speech Recogniser`           | The `VoskSpeechRecogniser` the controller drives. Required.                              |
+| `Command Recogniser`          | Optional. When assigned, `ReleaseTalk` calls `FlushPendingBuffer` so trailing speech parses immediately rather than waiting for the buffer window. |
+| `Listening Mode`              | Initial mode (`PushToTalk` or `Continuous`). Can be changed at runtime via the property. |
+| `Initialise On Start`         | When enabled, calls `VoskSpeechRecogniser.Initialise()` in `Start` so the model is pre-warmed before the first press. |
+| `Cancel Pending On Release`   | When enabled, `ReleaseTalk` also cancels any pending command on the command recogniser (see below). |
+| `On Talk Started`             | `UnityEvent` fired when recognition begins (first press, or switch to Continuous).      |
+| `On Talk Ended`               | `UnityEvent` fired when recognition ends (release, or switch from Continuous).          |
+
+## Cancel Pending On Release
+
+`VoskCommandRecogniser` can hold a command in a *pending* state when it waits for confirmation (`RequiresConfirmation`) or for a follow-up slot-fill (`AllowPartialMatch`). Pending commands normally resolve on their own — via follow-up speech, a confirm/cancel phrase, or the configurable `pendingTimeout` (default 5 s).
+
+With `Cancel Pending On Release` enabled, lifting the talk button immediately cancels any pending command, firing `OnCommandCancelled`. Use this when you want the talk button to act as a hard reset for partial utterances. Leave it disabled if you want pending commands to survive release and resolve on their own timer.
+
+## Android Permission Race
+
+`VoskSpeechRecogniser.StartRecognition` requests `RECORD_AUDIO` on first use. The request is asynchronous — a user who presses and releases the talk button faster than the permission dialog resolves would, without this controller, end up with recognition running *after* they released.
+
+The controller reconciles this in `Update`: if it observes `IsRecognising == true` while the user is not asking to listen, it calls `StopRecognition`. The window between the native start and the reconciling stop is at most one frame. Fully closing the race would require cancelling the permission coroutine from inside `VoskSpeechRecogniser` itself; the `Update` check is additive and keeps the low-level API unchanged.
+
+(The guard cannot fire in the editor test runner — without the native DLL, `IsRecognising` is always false. Verification is manual, on a Quest device, using `logcat -s vosk-bridge:*`.)
+
+## Lifecycle
+
+- `OnDisable` / `OnApplicationPause(true)` stop recognition but preserve the want-to-recognise flag, so `OnEnable` / `OnApplicationPause(false)` resume silently without re-firing `OnTalkStarted`. This matters for Continuous mode: a disable/enable cycle (or the Quest home overlay) otherwise drops Continuous listening entirely.
 
 ---
 
-## Push-to-Talk Pattern
+## Manual Pattern (advanced)
 
-Push-to-talk gates recognition to a button press, ensuring the SDK only processes intentional speech. This is the recommended approach for noisy environments and any application where false triggers from ambient sound, coughs, or background conversation are unacceptable.
+If you want full control — or you are adding push-to-talk behind a feature flag in an existing scene — you can wire the recipe yourself instead of using the controller. This is the pattern the controller encapsulates:
 
 ```csharp
 public class PushToTalk : MonoBehaviour
@@ -47,6 +123,7 @@ Push-to-talk eliminates this problem entirely by only running recognition during
 - Call `FlushPendingBuffer()` on button release to ensure any speech still in the utterance buffer is parsed immediately, rather than waiting for the buffer window to expire.
 - Wire the button press to an XR controller input (e.g. grip or trigger) using Unity's Input System or XR Interaction Toolkit.
 - Provide visual feedback (e.g. a microphone icon or recording indicator) so the user knows when the system is listening.
+- The manual pattern does **not** close the Android permission race (see above). If you hit it in practice, either switch to `VoskPushToTalkController` or add the same `Update` guard yourself.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 - Two-tier native lifecycle: heavy model load once, then start / stop recognition instantly
 - Adaptive automatic gain control (AGC) with soft saturation
 - Structured error codes for all failure modes
+- Built-in push-to-talk controller with runtime-switchable listening mode
 
 **Command Recognition**
 - Grammar-constrained VOSK parsing for high-accuracy command match

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 - Batch test runner for regression-testing command definitions -- visual results table, CSV export, CI-safe Edit Mode API
 - Text injection API for Editor testing, CI, and replay without audio hardware
 - Live microphone in the Windows Editor -- speak into your PC mic, see commands fire in the Console
-- 20 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, batch testing, asset conversion, and pending commands
+- 21 automated test suites (Edit Mode + Play Mode) covering parser, injection, lifecycle, DSP, diagnostics, batch testing, asset conversion, pending commands, and push-to-talk
 - Extensively tested on Quest 3 with published test matrices for every release
 
 ## Requirements
@@ -57,7 +57,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 **Pinned version:**
 
 ```
-https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0
+https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.16.0
 ```
 
 **Via manifest.json:**
@@ -65,7 +65,7 @@ https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.15.0"
+    "com.jinwoo1601.vosk-xr": "https://github.com/jinwoo1601/VOSK-Unity-XR-SDK.git#v0.16.0"
   }
 }
 ```
@@ -190,10 +190,11 @@ Import samples via **Package Manager > VOSK XR Speech Recognition > Samples**.
 |---|---|
 | **Basic Transcription** | Live speech-to-text with on-screen display. Demonstrates `VoskSpeechRecogniser` events, partial/final results, and per-word confidence. |
 | **Command Recognition** | Full command parsing with slots, command sets, mode switching, utterance buffering, and sequential extraction. Includes an Inspector authoring toggle and 20 ScriptableObject assets covering every slot type and pattern form. |
+| **Push-to-Talk** | Hold-to-talk gating with `VoskPushToTalkController`, runtime switching between push-to-talk and continuous modes, `UnityEvent` wiring for a recording indicator, and optional command-recogniser flush on release. |
 
 ## Running Tests
 
-The package includes 20 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model. Add `"testables": ["com.jinwoo1601.vosk-xr"]` to your project's `Packages/manifest.json`, then open **Window > General > Test Runner**. See [Getting Started](Documentation~/getting-started.md) for details.
+The package includes 21 test suites (Edit Mode and Play Mode) that run without audio hardware or a VOSK model. Add `"testables": ["com.jinwoo1601.vosk-xr"]` to your project's `Packages/manifest.json`, then open **Window > General > Test Runner**. See [Getting Started](Documentation~/getting-started.md) for details.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ The SDK does not bundle a VOSK model. You must download one separately:
 
 Any VOSK-compatible model works. Larger models improve accuracy at the cost of memory and download size.
 
+## Windows Editor Setup (Optional)
+
+Required only if you want the live microphone backend in the Unity Editor on Windows. Skip this if you only deploy to Android -- the Android native libraries are bundled in the package.
+
+1. Download `vosk-win64-*.zip` from [alphacep/vosk-api releases](https://github.com/alphacep/vosk-api/releases).
+2. Extract and drop these four DLLs into the package's `Runtime/Plugins/x86_64/` folder:
+   - `libvosk.dll`
+   - `libgcc_s_seh-1.dll`
+   - `libstdc++-6.dll`
+   - `libwinpthread-1.dll`
+3. Plugin importer meta files are pre-configured for Editor-only loading on Windows x86_64 -- no build settings changes needed. These DLLs are excluded from Android and standalone builds.
+
+If the DLLs are missing, `VoskSpeechRecogniser.OnError` fires with `ModelLoadFailed` on the first `StartRecognition()` call in the Editor. See [Editor Testing](Documentation~/editor-testing.md) for the full live-mic workflow.
+
 ## Quick Start -- Basic Transcription
 
 ```csharp

--- a/Runtime/VoskListeningMode.cs
+++ b/Runtime/VoskListeningMode.cs
@@ -1,0 +1,14 @@
+// ============================================================================
+// Purpose:  Enum selecting between always-on and hold-to-talk listening behaviour
+// Layer:    Runtime
+// Owns:     VoskListeningMode (public enum)
+// Depends:  (none)
+// ============================================================================
+namespace VoskXR
+{
+    public enum VoskListeningMode
+    {
+        Continuous = 0,
+        PushToTalk = 1,
+    }
+}

--- a/Runtime/VoskListeningMode.cs.meta
+++ b/Runtime/VoskListeningMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7f2a1c984d64e57b0a3f61e0d9c4c72

--- a/Runtime/VoskPushToTalkController.cs
+++ b/Runtime/VoskPushToTalkController.cs
@@ -1,0 +1,162 @@
+// ============================================================================
+// Purpose:  MonoBehaviour gating speech recognition via hold-to-talk or continuous listening
+// Layer:    Runtime
+// Owns:     VoskPushToTalkController (public MonoBehaviour)
+// Depends:  VoskSpeechRecogniser, VoskCommandRecogniser, VoskListeningMode
+// ============================================================================
+using UnityEngine;
+using UnityEngine.Events;
+using VoskXR.Commands;
+
+namespace VoskXR
+{
+    [AddComponentMenu("VOSK XR/Push-To-Talk Controller")]
+    public sealed class VoskPushToTalkController : MonoBehaviour
+    {
+        [Header("References")]
+        [Tooltip("The speech recogniser to start and stop. Required.")]
+        [SerializeField] VoskSpeechRecogniser _speechRecogniser;
+
+        [Tooltip("Optional command recogniser. When assigned, ReleaseTalk flushes the " +
+                 "utterance buffer so speech spoken just before release parses immediately.")]
+        [SerializeField] VoskCommandRecogniser _commandRecogniser;
+
+        [Header("Behaviour")]
+        [Tooltip("PushToTalk gates recognition to a button press; Continuous runs recognition " +
+                 "whenever the component is enabled. Can be changed at runtime via ListeningMode.")]
+        [SerializeField] VoskListeningMode _listeningMode = VoskListeningMode.PushToTalk;
+
+        [Tooltip("Call VoskSpeechRecogniser.Initialise() in Start so the model is pre-warmed " +
+                 "before the first PressTalk. Disable if your code calls Initialise() elsewhere.")]
+        [SerializeField] bool _initialiseOnStart = true;
+
+        [Tooltip("When enabled, ReleaseTalk also cancels any pending command awaiting " +
+                 "confirmation or follow-up slot-fill on the command recogniser.")]
+        [SerializeField] bool _cancelPendingOnRelease = false;
+
+        [Header("Events")]
+        [SerializeField] UnityEvent _onTalkStarted = new UnityEvent();
+        [SerializeField] UnityEvent _onTalkEnded = new UnityEvent();
+
+        bool _wantRecognising;
+
+        public VoskListeningMode ListeningMode
+        {
+            get => _listeningMode;
+            set
+            {
+                if (_listeningMode == value)
+                    return;
+
+                var previous = _listeningMode;
+                _listeningMode = value;
+
+                if (value == VoskListeningMode.Continuous)
+                {
+                    if (!_wantRecognising)
+                    {
+                        _wantRecognising = true;
+                        _speechRecogniser?.StartRecognition();
+                        _onTalkStarted?.Invoke();
+                    }
+                }
+                else // PushToTalk
+                {
+                    if (previous == VoskListeningMode.Continuous && _wantRecognising)
+                    {
+                        _wantRecognising = false;
+                        _speechRecogniser?.StopRecognition();
+                        _onTalkEnded?.Invoke();
+                    }
+                }
+            }
+        }
+
+        public UnityEvent OnTalkStarted => _onTalkStarted;
+
+        public UnityEvent OnTalkEnded => _onTalkEnded;
+
+        public void PressTalk()
+        {
+            if (_listeningMode != VoskListeningMode.PushToTalk) return;
+            if (_speechRecogniser == null) return;
+            if (_wantRecognising) return;
+
+            _wantRecognising = true;
+            _speechRecogniser.StartRecognition();
+            _onTalkStarted?.Invoke();
+        }
+
+        public void ReleaseTalk()
+        {
+            if (_listeningMode != VoskListeningMode.PushToTalk) return;
+            if (_speechRecogniser == null) return;
+            if (!_wantRecognising) return;
+
+            _wantRecognising = false;
+            _speechRecogniser.StopRecognition();
+
+            if (_commandRecogniser != null)
+            {
+                _commandRecogniser.FlushPendingBuffer();
+                if (_cancelPendingOnRelease)
+                    _commandRecogniser.CancelPendingCommand();
+            }
+
+            _onTalkEnded?.Invoke();
+        }
+
+        void Awake()
+        {
+            if (_listeningMode == VoskListeningMode.Continuous)
+                _wantRecognising = true;
+        }
+
+        void Start()
+        {
+            if (_initialiseOnStart && _speechRecogniser != null)
+                _speechRecogniser.Initialise();
+        }
+
+        void OnEnable()
+        {
+            if (_wantRecognising && _speechRecogniser != null)
+                _speechRecogniser.StartRecognition();
+        }
+
+        void OnDisable()
+        {
+            if (_wantRecognising && _speechRecogniser != null)
+                _speechRecogniser.StopRecognition();
+        }
+
+        void OnApplicationPause(bool paused)
+        {
+            if (_speechRecogniser == null) return;
+
+            if (paused)
+            {
+                if (_wantRecognising)
+                    _speechRecogniser.StopRecognition();
+            }
+            else
+            {
+                if (_wantRecognising && !_speechRecogniser.IsRecognising)
+                    _speechRecogniser.StartRecognition();
+            }
+        }
+
+        void Update()
+        {
+            // Closes the Android mic-permission race: the permission coroutine can fire
+            // a native start after the user already released, so reconcile on the next frame.
+            if (!_wantRecognising && _speechRecogniser != null && _speechRecogniser.IsRecognising)
+                _speechRecogniser.StopRecognition();
+        }
+
+        internal VoskSpeechRecogniser SpeechRecogniser { set => _speechRecogniser = value; }
+        internal VoskCommandRecogniser CommandRecogniser { set => _commandRecogniser = value; }
+        internal bool InitialiseOnStart { set => _initialiseOnStart = value; }
+        internal bool CancelPendingOnRelease { set => _cancelPendingOnRelease = value; }
+    }
+}

--- a/Runtime/VoskPushToTalkController.cs.meta
+++ b/Runtime/VoskPushToTalkController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d8e5f1b7c2a4a8d9e1f2b3c4d5e6f70

--- a/Samples~/PushToTalk/PushToTalkDemo.cs
+++ b/Samples~/PushToTalk/PushToTalkDemo.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using VoskXR;
+
+public class PushToTalkDemo : MonoBehaviour
+{
+    [SerializeField] VoskSpeechRecogniser recogniser;
+    [SerializeField] VoskPushToTalkController controller;
+    [SerializeField] TextMeshProUGUI transcriptText;
+    [SerializeField] Image recordingIndicator;
+    [SerializeField] Color idleColor = new Color(0.2f, 0.2f, 0.2f, 1f);
+    [SerializeField] Color activeColor = new Color(0.9f, 0.2f, 0.2f, 1f);
+
+    void OnEnable()
+    {
+        if (recogniser != null)
+        {
+            recogniser.OnPartialResult += OnPartialResult;
+            recogniser.OnFinalResult += OnFinalResult;
+            recogniser.OnError += OnError;
+        }
+
+        if (controller != null)
+        {
+            controller.OnTalkStarted.AddListener(ShowRecording);
+            controller.OnTalkEnded.AddListener(ShowIdle);
+        }
+
+        ShowIdle();
+    }
+
+    void OnDisable()
+    {
+        if (recogniser != null)
+        {
+            recogniser.OnPartialResult -= OnPartialResult;
+            recogniser.OnFinalResult -= OnFinalResult;
+            recogniser.OnError -= OnError;
+        }
+
+        if (controller != null)
+        {
+            controller.OnTalkStarted.RemoveListener(ShowRecording);
+            controller.OnTalkEnded.RemoveListener(ShowIdle);
+        }
+    }
+
+    public void TogglePushToTalkMode()
+    {
+        if (controller == null) return;
+
+        controller.ListeningMode = controller.ListeningMode == VoskListeningMode.PushToTalk
+            ? VoskListeningMode.Continuous
+            : VoskListeningMode.PushToTalk;
+
+        Debug.Log($"[PushToTalkDemo] Listening mode: {controller.ListeningMode}");
+    }
+
+    void ShowRecording()
+    {
+        if (recordingIndicator != null)
+            recordingIndicator.color = activeColor;
+    }
+
+    void ShowIdle()
+    {
+        if (recordingIndicator != null)
+            recordingIndicator.color = idleColor;
+    }
+
+    void OnPartialResult(string text)
+    {
+        if (transcriptText != null)
+            transcriptText.text = text;
+    }
+
+    void OnFinalResult(string text)
+    {
+        if (transcriptText != null)
+            transcriptText.text = text;
+        Debug.Log($"[PushToTalkDemo] Final: {text}");
+    }
+
+    void OnError(VoskBridgeErrorCode code, string message)
+    {
+        Debug.LogError($"[PushToTalkDemo] VOSK [{code}] {code.ToDescription()}: {message}");
+    }
+}

--- a/Samples~/PushToTalk/README.md
+++ b/Samples~/PushToTalk/README.md
@@ -1,0 +1,80 @@
+# Push-to-Talk Sample
+
+Hold-to-talk gating with the `VoskPushToTalkController` component. Includes a runtime toggle between push-to-talk and continuous listening modes.
+
+## Setup
+
+1. **Import the sample** via Package Manager > VOSK XR Speech Recognition > Samples > Push-to-Talk > Import.
+
+2. **Download a VOSK model:**
+   - Get [vosk-model-small-en-us-0.15](https://alphacephei.com/vosk/models) (~50 MB).
+   - Place the `.zip` in `Assets/StreamingAssets/vosk-model-small-en-us-0.15.zip`.
+
+3. **Build the scene:**
+   - Create a new scene.
+   - Add a GameObject named `VoskRig`. Attach:
+     - `VoskSpeechRecogniser`
+     - `VoskPushToTalkController`
+     - `VoskCommandRecogniser` (optional — enables pending-buffer flush on release)
+   - In the `VoskPushToTalkController` Inspector:
+     - Drag the `VoskSpeechRecogniser` into the `Speech Recogniser` slot.
+     - Drag the `VoskCommandRecogniser` into the `Command Recogniser` slot (optional).
+     - Leave `Listening Mode` on `PushToTalk` (default).
+   - Add a Canvas with:
+     - A `Button` labelled "Hold to Talk".
+     - A `TextMeshPro - Text (UI)` element for live transcription.
+     - A small `Image` (recording indicator).
+   - Add the `PushToTalkDemo` script to any GameObject and wire the `recogniser`, `controller`, `transcriptText`, and `recordingIndicator` references in the Inspector.
+
+4. **Wire the talk button:**
+   - Select the Button > Inspector > add an `EventTrigger` component.
+   - Add `PointerDown` event → drag the `VoskPushToTalkController` → select `PressTalk()`.
+   - Add `PointerUp` event → drag the `VoskPushToTalkController` → select `ReleaseTalk()`.
+   - (Plain `onClick` fires on release only; use `EventTrigger` for true press/release semantics.)
+
+5. **Optional — Mode toggle:**
+   - Add a second Button labelled "Toggle Mode".
+   - On its `onClick`, call `PushToTalkDemo.TogglePushToTalkMode()`.
+
+6. **Optional — Recording indicator via UnityEvents:**
+   - In the controller's `On Talk Started` list, add a callback on the indicator's `Image.color` setter pointing to your active colour.
+   - In `On Talk Ended`, point it back to your idle colour.
+   - The demo script does the same thing in code — use whichever approach fits your project.
+
+7. **Build and deploy:**
+   - Switch platform to Android (arm64).
+   - Ensure `RECORD_AUDIO` is enabled in Player Settings > Android > Other Settings.
+   - Build and run on a Meta Quest headset.
+
+## Wiring XR controllers
+
+For XR Interaction Toolkit, bind a controller button (e.g. grip) to a press/release action:
+
+```csharp
+[SerializeField] UnityEngine.InputSystem.InputActionReference talkAction;
+[SerializeField] VoskPushToTalkController controller;
+
+void OnEnable()
+{
+    talkAction.action.started  += _ => controller.PressTalk();
+    talkAction.action.canceled += _ => controller.ReleaseTalk();
+    talkAction.action.Enable();
+}
+```
+
+## Runtime mode switching
+
+```csharp
+// Continuous (always-on) listening — PressTalk / ReleaseTalk become no-ops.
+controller.ListeningMode = VoskListeningMode.Continuous;
+
+// Back to hold-to-talk.
+controller.ListeningMode = VoskListeningMode.PushToTalk;
+```
+
+Switching to `Continuous` fires `OnTalkStarted`; switching away while recognising fires `OnTalkEnded`. Setting the same mode twice is a no-op.
+
+## See Also
+
+- [Push-to-Talk guide](../../Documentation~/push-to-talk.md) — full component reference and the manual (low-level) pattern
+- [Command Recognition sample](../CommandRecognition/README.md) — command parsing with intent and slot extraction

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,7 +9,7 @@ This package includes or depends on the following third-party software.
 - **Project:** https://github.com/alphacep/vosk-api
 - **Author:** Alpha Cephei Inc. (https://alphacephei.com/)
 - **License:** Apache License 2.0
-- **Usage:** This package uses prebuilt VOSK native libraries (`libvosk.so` for Android arm64, `libvosk.dll` for Windows x86_64) for offline speech recognition. The libraries are not bundled in the repository -- developers download them from the [VOSK releases](https://github.com/alphacep/vosk-api/releases) page.
+- **Usage:** This package uses prebuilt VOSK native libraries for offline speech recognition. `libvosk.so` for Android arm64 is bundled in this package under `Runtime/Plugins/Android/arm64-v8a/`. `libvosk.dll` for Windows x86_64 (and its three MinGW runtime dependencies) is not bundled -- developers using the Editor live-microphone backend download it from the [VOSK releases](https://github.com/alphacep/vosk-api/releases) page and drop it into `Runtime/Plugins/x86_64/`.
 - **Models:** VOSK language models (e.g. `vosk-model-small-en-us-0.15`) are downloaded separately by the developer and are not included in this package. Models are provided by Alpha Cephei under the Apache 2.0 license.
 
 ### Apache License 2.0

--- a/Tests/Runtime/VoskPushToTalkControllerTests.cs
+++ b/Tests/Runtime/VoskPushToTalkControllerTests.cs
@@ -1,0 +1,269 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using VoskXR;
+using VoskXR.Commands;
+
+namespace VoskXR.Tests.Runtime
+{
+    public class VoskPushToTalkControllerTests
+    {
+        GameObject _go;
+        VoskPushToTalkController _controller;
+        VoskSpeechRecogniser _speech;
+        VoskCommandRecogniser _command;
+
+        int _startedCount;
+        int _endedCount;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("TestPTTController");
+            _speech = _go.AddComponent<VoskSpeechRecogniser>();
+            _command = _go.AddComponent<VoskCommandRecogniser>();
+            _controller = _go.AddComponent<VoskPushToTalkController>();
+
+            _controller.SpeechRecogniser = _speech;
+            _controller.CommandRecogniser = _command;
+            _controller.InitialiseOnStart = false;
+            _command.SpeechRecogniser = _speech;
+
+            _startedCount = 0;
+            _endedCount = 0;
+            _controller.OnTalkStarted.AddListener(() => _startedCount++);
+            _controller.OnTalkEnded.AddListener(() => _endedCount++);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                Object.DestroyImmediate(_go);
+        }
+
+        // -------- Fixtures --------
+
+        static VoskSlotDefinition[] MakeSlots() => new[]
+        {
+            new VoskSlotDefinition("target", new[] { "hotel one", "alpha one" }),
+            new VoskSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+        };
+
+        static VoskCommandDefinition[] MakeCommands(bool allowPartial = false) => new[]
+        {
+            new VoskCommandDefinition("launch_weapon",
+                new[] { new[] { "launch", "{weapon}", "target", "{target}" } },
+                allowPartial, false),
+            new VoskCommandDefinition("cease_fire",
+                new[] { new[] { "cease", "fire" } }),
+        };
+
+        void ConfigureBuffered()
+        {
+            _command.Configure(MakeSlots(), MakeCommands());
+            _command.BufferWindow = 1.5f;
+            _command.CommandCooldown = 0f;
+        }
+
+        void ConfigureSync(bool allowPartial = false)
+        {
+            _command.Configure(MakeSlots(), MakeCommands(allowPartial));
+            _command.BufferWindow = 0f;
+            _command.CommandCooldown = 0f;
+            _command.PendingTimeout = 30f;
+        }
+
+        [Test]
+        public void AddComponent_DefaultState_ListeningModeIsPushToTalk()
+        {
+            Assert.AreEqual(VoskListeningMode.PushToTalk, _controller.ListeningMode);
+        }
+
+        [Test]
+        public void PressTalk_SpeechRecogniserNull_IsNoOp()
+        {
+            _controller.SpeechRecogniser = null;
+
+            Assert.DoesNotThrow(() => _controller.PressTalk());
+            Assert.AreEqual(0, _startedCount);
+        }
+
+        [Test]
+        public void PressTalk_FirstPress_FiresOnTalkStarted()
+        {
+            _controller.PressTalk();
+            Assert.AreEqual(1, _startedCount);
+        }
+
+        [Test]
+        public void PressTalk_CalledTwice_FiresOnTalkStartedOnce()
+        {
+            _controller.PressTalk();
+            _controller.PressTalk();
+            Assert.AreEqual(1, _startedCount);
+        }
+
+        [Test]
+        public void ReleaseTalk_WithoutPriorPress_IsNoOp()
+        {
+            _controller.ReleaseTalk();
+            Assert.AreEqual(0, _endedCount);
+        }
+
+        [Test]
+        public void ReleaseTalk_AfterPress_FiresOnTalkEnded()
+        {
+            _controller.PressTalk();
+            _controller.ReleaseTalk();
+            Assert.AreEqual(1, _endedCount);
+        }
+
+        [Test]
+        public void ReleaseTalk_WithCommandRecogniser_CallsFlushPendingBuffer()
+        {
+            ConfigureBuffered();
+
+            int recognised = 0;
+            _command.OnCommandRecognised += _ => recognised++;
+
+            _controller.PressTalk();
+            _command.InjectText("cease fire");
+            Assert.AreEqual(0, recognised,
+                "Buffered injection must not fire before release");
+
+            _controller.ReleaseTalk();
+            Assert.AreEqual(1, recognised,
+                "Release must flush the buffered command through the command recogniser");
+        }
+
+        [Test]
+        public void ReleaseTalk_CancelPendingFalse_DoesNotCallCancelPendingCommand()
+        {
+            ConfigureSync(allowPartial: true);
+            _controller.CancelPendingOnRelease = false;
+
+            int cancelled = 0;
+            _command.OnCommandCancelled += _ => cancelled++;
+
+            _controller.PressTalk();
+            _command.InjectText("launch missiles target");
+            Assume.That(_command.HasPendingCommand, Is.True,
+                "Precondition: command recogniser should be in pending state");
+
+            _controller.ReleaseTalk();
+
+            Assert.IsTrue(_command.HasPendingCommand,
+                "Pending command should survive release when CancelPendingOnRelease is false");
+            Assert.AreEqual(0, cancelled);
+        }
+
+        [Test]
+        public void ReleaseTalk_CancelPendingTrue_CallsCancelPendingCommand()
+        {
+            ConfigureSync(allowPartial: true);
+            _controller.CancelPendingOnRelease = true;
+
+            int cancelled = 0;
+            _command.OnCommandCancelled += _ => cancelled++;
+
+            _controller.PressTalk();
+            _command.InjectText("launch missiles target");
+            Assume.That(_command.HasPendingCommand, Is.True,
+                "Precondition: command recogniser should be in pending state");
+
+            _controller.ReleaseTalk();
+
+            Assert.IsFalse(_command.HasPendingCommand,
+                "Pending command should be cancelled on release when the flag is true");
+            Assert.AreEqual(1, cancelled);
+        }
+
+        [Test]
+        public void ListeningMode_SetToContinuous_FiresOnTalkStarted()
+        {
+            _controller.ListeningMode = VoskListeningMode.Continuous;
+
+            Assert.AreEqual(VoskListeningMode.Continuous, _controller.ListeningMode);
+            Assert.AreEqual(1, _startedCount);
+        }
+
+        [Test]
+        public void ListeningMode_SetToPushToTalk_WhenPressed_FiresOnTalkEnded()
+        {
+            _controller.ListeningMode = VoskListeningMode.Continuous;
+            Assume.That(_startedCount, Is.EqualTo(1));
+
+            _controller.ListeningMode = VoskListeningMode.PushToTalk;
+
+            Assert.AreEqual(VoskListeningMode.PushToTalk, _controller.ListeningMode);
+            Assert.AreEqual(1, _endedCount);
+        }
+
+        [Test]
+        public void PressTalk_InContinuousMode_IsNoOp()
+        {
+            _controller.ListeningMode = VoskListeningMode.Continuous;
+            int startedAfterMode = _startedCount;
+
+            _controller.PressTalk();
+
+            Assert.AreEqual(startedAfterMode, _startedCount,
+                "PressTalk must not re-fire OnTalkStarted in continuous mode");
+        }
+
+        [Test]
+        public void OnDisable_WhilePressed_DoesNotFireOnTalkEnded()
+        {
+            _controller.PressTalk();
+            Assume.That(_startedCount, Is.EqualTo(1));
+
+            _controller.enabled = false;
+
+            Assert.AreEqual(0, _endedCount,
+                "OnDisable is a lifecycle event — OnTalkEnded must not fire");
+        }
+
+        [Test]
+        public void OnDisable_InContinuousMode_PreservesWantRecognisingFlag()
+        {
+            _controller.ListeningMode = VoskListeningMode.Continuous;
+            Assume.That(_startedCount, Is.EqualTo(1));
+
+            _controller.enabled = false;
+            _controller.enabled = true;
+
+            Assert.AreEqual(1, _startedCount,
+                "Re-enable must not re-fire OnTalkStarted (lifecycle resume is silent)");
+            Assert.AreEqual(0, _endedCount);
+
+            _controller.ListeningMode = VoskListeningMode.PushToTalk;
+
+            Assert.AreEqual(1, _endedCount,
+                "Switching back to PushToTalk after a disable/enable cycle must fire " +
+                "OnTalkEnded exactly once — proves _wantRecognising was preserved");
+        }
+
+        [Test]
+        public void OnEnable_WhenWantRecognisingTrue_DoesNotFireOnTalkStarted()
+        {
+            _controller.ListeningMode = VoskListeningMode.Continuous;
+            int startedBefore = _startedCount;
+
+            _controller.enabled = false;
+            _controller.enabled = true;
+
+            Assert.AreEqual(startedBefore, _startedCount);
+        }
+
+        [UnityTest]
+        public IEnumerator OnDestroy_Cleanup_DoesNotThrow()
+        {
+            _controller.PressTalk();
+            Object.DestroyImmediate(_go);
+            _go = null;
+            yield return null;
+        }
+    }
+}

--- a/Tests/Runtime/VoskPushToTalkControllerTests.cs.meta
+++ b/Tests/Runtime/VoskPushToTalkControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c9a2d8e5b374b82a1c5e2f3d4b5a6c8

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
       "displayName": "Command Recognition",
       "description": "Demonstrates grammar-constrained command parsing with intent and slot extraction.",
       "path": "Samples~/CommandRecognition"
+    },
+    {
+      "displayName": "Push-to-Talk",
+      "description": "Demonstrates the VoskPushToTalkController with hold-to-talk gating, continuous mode switching, and UnityEvent wiring.",
+      "path": "Samples~/PushToTalk"
     }
   ]
 }


### PR DESCRIPTION
  ## Summary

  - New `VoskPushToTalkController` MonoBehaviour: drop-in hold-to-talk gating for
  `VoskSpeechRecogniser`, with optional `VoskCommandRecogniser` integration that auto-flushes the
  pending utterance buffer on release and (opt-in) cancels any pending command.
  - Runtime-switchable listening mode via `VoskListeningMode` enum (`PushToTalk` | `Continuous`) —
  switching is a property assignment and fires `OnTalkStarted`/`OnTalkEnded` UnityEvents accordingly.
  - Best-effort guard for the Android `RECORD_AUDIO` permission race: if the dialog resolves after
  the user already released the talk button, `Update` reconciles by calling `StopRecognition` within
  one frame.
  - Lifecycle handling across `OnDisable` / `OnEnable` and `OnApplicationPause` so Continuous mode
  survives the Quest home overlay without re-firing UnityEvents.
  - New "Push-to-Talk" sample (`Samples~/PushToTalk/`) demonstrating button wiring (`EventTrigger`
  press/release), mode toggle, and recording-indicator UnityEvent wiring. Registered in
  `package.json`.
  - Significantly expanded `Documentation~/push-to-talk.md` with controller reference, listening-mode
  "advanced" section.
  - README updates: new sample row, push-to-talk feature bullet, bumped pinned-version examples to
  `v0.16.0`, test-count 20 → 21.
  - Also picks up a small docs commit (`721c1db`) clarifying that Windows `libvosk.dll` is a user
  setup step.