### PR TITLE
Use a dynamic score denominator so optional tokens don't penalize matches (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Command match scores no longer penalize valid utterances that take advantage of optional tokens. `VoxrCommandParser` previously normalized the raw score by the static pattern length, so an omitted `?word`/`{?slot}` optional still counted toward the denominator (dropping the score even though optionality permits omission), and a spoken optional literal could never reach a perfect 1.0. The denominator is now dynamic — required elements always count, optional elements only when actually matched — so a perfect match scores 1.0 whether or not its optionals were uttered. The same fix is applied to follow-up scoring (`ScoreFollowUp`) so initial and pending-command scores stay consistent. Short patterns with optionals (e.g. `["go", "?now"]` said as just "go") are no longer pushed below the default `minScore` of 0.6. ([#21](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/21))
+
 ## [1.2.0] - 2026-04-29
 
 ### Changed

--- a/Documentation~/command-recognition.md
+++ b/Documentation~/command-recognition.md
@@ -99,7 +99,7 @@ commandRecogniser.minScore = 0.6f;       // Reject low-quality pattern matches
 commandRecogniser.minConfidence = 0.4f;   // Reject low VOSK word confidence
 ```
 
-**Score** (`VoxrCommand.Score`) is computed by the parser based on how many pattern tokens were satisfied. A perfect match with all required and optional tokens scores 1.0. Missing optional tokens reduce the score proportionally.
+**Score** (`VoxrCommand.Score`) is computed by the parser based on how well the transcript satisfies the pattern, normalised against a *dynamic* denominator. Required tokens always count toward that denominator; optional tokens (`?word` literals and `{?slot}` slots) count only when they are actually spoken. An omitted optional therefore drops out of both sides of the ratio rather than diluting it, so a perfect match scores 1.0 whether or not its optional tokens were uttered — taking advantage of optionality is never penalized. A missed *required* token still pulls the score down.
 
 **Confidence** (`VoxrCommand.Confidence`) is the minimum per-word VOSK acoustic confidence across matched tokens. This reflects how certain VOSK was about the words it heard. A value of `-1` means no word-level data was available (e.g. the transcript contained only `[unk]` tokens), which bypasses the `minConfidence` check entirely -- the command is accepted or rejected on score alone.
 

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -533,7 +533,11 @@ namespace VoXR.Commands
         {
             int tokenIdx = startIdx;
             float rawScore = 0f;
-            int patternLength = pattern.Length;
+            // Dynamic denominator: required elements always count toward it, but optional
+            // elements only count when actually matched. Omitted optionals then drop out of
+            // both numerator and denominator, so taking advantage of optionality is never
+            // penalized and a perfect match always normalizes to 1.0.
+            float denominator = 0f;
             int literalCount = 0;
             int slotCount = 0;
 
@@ -569,11 +573,14 @@ namespace VoXR.Commands
                         _matchSlotBuf[slotCount++] = new VoxrSlotMatch(slotName, matchedValue);
                         tokenIdx += consumed;
                         rawScore += MatchScore;
+                        denominator += MatchScore;
                     }
                     else if (!isOptional)
                     {
                         rawScore += RequiredSlotMissPenalty;
+                        denominator += MatchScore;
                     }
+                    // Unmatched optional slot: contributes nothing to score or denominator.
                 }
                 else if (IsOptionalLiteral(element))
                 {
@@ -581,12 +588,15 @@ namespace VoXR.Commands
                         string.Equals(tokens[tokenIdx], _optionalLiteralCache[element], StringComparison.Ordinal))
                     {
                         rawScore += OptionalLiteralScore;
+                        denominator += OptionalLiteralScore;
                         literalCount++;
                         tokenIdx++;
                     }
+                    // Unmatched optional literal: contributes nothing to score or denominator.
                 }
                 else
                 {
+                    denominator += MatchScore;
                     if (tokenIdx < tokens.Length &&
                         string.Equals(tokens[tokenIdx], element, StringComparison.Ordinal))
                     {
@@ -602,7 +612,7 @@ namespace VoXR.Commands
             }
 
             _matchSlotCount = slotCount;
-            float normalizedScore = patternLength > 0 ? rawScore / patternLength : 0f;
+            float normalizedScore = denominator > 0f ? rawScore / denominator : 0f;
 
             return new MatchResult
             {
@@ -803,7 +813,10 @@ namespace VoXR.Commands
             if (pattern == null || pattern.Length == 0)
                 return 1f; // Fallback — don't block the command
 
+            // Dynamic denominator, mirroring TryMatchScored: required elements always count,
+            // optional elements only when satisfied, so unfilled optionals don't penalize.
             float rawScore = 0f;
+            float denominator = 0f;
             for (int i = 0; i < pattern.Length; i++)
             {
                 string element = pattern[i];
@@ -822,24 +835,32 @@ namespace VoXR.Commands
                     }
 
                     if (filled)
+                    {
                         rawScore += MatchScore;
+                        denominator += MatchScore;
+                    }
                     else if (!IsOptionalSlot(element))
+                    {
                         rawScore += RequiredSlotMissPenalty;
-                    // Optional slots that are unfilled contribute 0
+                        denominator += MatchScore;
+                    }
+                    // Unfilled optional slots contribute 0 to both numerator and denominator.
                 }
                 else if (IsOptionalLiteral(element))
                 {
-                    // Optional literals may or may not have been spoken — give no credit
+                    // Optional literals may or may not have been spoken — give no credit and
+                    // leave them out of the denominator (treated as omitted optionals).
                 }
                 else
                 {
                     // Required literal — the original parse matched initial literals,
                     // and follow-up implies the remaining ones. Credit them.
                     rawScore += MatchScore;
+                    denominator += MatchScore;
                 }
             }
 
-            return pattern.Length > 0 ? rawScore / pattern.Length : 0f;
+            return denominator > 0f ? rawScore / denominator : 0f;
         }
     }
 }

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -920,5 +920,84 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(1, launchResult.Length);
             Assert.AreEqual("launch_weapon", launchResult[0].Command.Intent);
         }
+
+        // --- Optional tokens no longer inflate the score denominator (issue #21) ---
+
+        static VoxrCommandParser MakeOptionalLiteralParser()
+        {
+            var slots = new[] { new VoxrSlotDefinition("device", new[] { "light", "fan" }) };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("activate", new[]
+                {
+                    new[] { "turn", "on", "?the", "{device}" },
+                }),
+            };
+            return new VoxrCommandParser(slots, commands);
+        }
+
+        [Test]
+        public void Score_OptionalLiteralPresent_ReachesOne()
+        {
+            var parser = MakeOptionalLiteralParser();
+
+            // Optional literal "?the" spoken: (1 + 1 + 0.5 + 1) / (1 + 1 + 0.5 + 1) = 1.0.
+            // Previously this capped at 3.5/4 = 0.875 (optional literal never reached full credit).
+            var result = ParseOne(parser, "turn on the light");
+
+            Assert.AreEqual("activate", result.Command.Intent);
+            Assert.AreEqual("light", result.Command.GetSlot("device"));
+            Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
+        }
+
+        [Test]
+        public void Score_OptionalLiteralOmitted_NotPenalized()
+        {
+            var parser = MakeOptionalLiteralParser();
+
+            // Omitting "?the" must not cost anything: (1 + 1 + 1) / (1 + 1 + 1) = 1.0.
+            // Previously this was 3.0/4 = 0.75 — penalized for using optionality.
+            var result = ParseOne(parser, "turn on fan");
+
+            Assert.AreEqual("activate", result.Command.Intent);
+            Assert.AreEqual("fan", result.Command.GetSlot("device"));
+            Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
+        }
+
+        [Test]
+        public void Score_ShortPatternOptionalOmitted_AboveDefaultThreshold()
+        {
+            // Pattern ["go", "?now"] spoken as just "go". Under the old static denominator
+            // this scored 1.0/2 = 0.5 and was rejected by the default minScore of 0.6.
+            // The dynamic denominator drops the omitted optional, giving 1.0/1.0 = 1.0.
+            var slots = Array.Empty<VoxrSlotDefinition>();
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("go", new[]
+                {
+                    new[] { "go", "?now" },
+                }),
+            };
+            var parser = new VoxrCommandParser(slots, commands);
+
+            var result = ParseOne(parser, "go");
+
+            Assert.AreEqual("go", result.Command.Intent);
+            Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
+        }
+
+        [Test]
+        public void ScoreFollowUp_OptionalLiteralOmitted_ReachesOne()
+        {
+            // Follow-up scoring must use the same dynamic denominator so initial and
+            // follow-up scores stay consistent: a filled required slot plus required
+            // literals, with the optional literal dropping out, scores 1.0 (not 3/4).
+            var parser = MakeOptionalLiteralParser();
+
+            var filled = new[] { new VoxrSlotMatch("device", "light") };
+            float score = parser.ScoreFollowUp("activate", 0, filled);
+
+            Assert.AreEqual(1.0f, score, 0.001f);
+        }
     }
 }


### PR DESCRIPTION
Closes #21

## What

`VoxrCommandParser` now normalizes the raw match score by a **dynamic** denominator instead of the static `pattern.Length`:

- Required elements always count toward the denominator.
- Optional elements (`?word` literals and `{?slot}` slots) count **only when actually matched**.
- Omitted optionals drop out of both numerator and denominator.

Applied in both `TryMatchScored()` (initial parse) and `ScoreFollowUp()` (pending-command merge) so the two stay consistent. `OptionalLiteralScore` keeps its existing `0.5` weight — it's now mirrored into the denominator, so a spoken optional literal reaches a perfect-ratio 1.0 rather than capping at 0.875. (Resolves the issue's open question by preserving existing weights, the smallest change that fixes both problems.)

## Why

The static denominator counted optional elements even when legitimately omitted, so:
1. **Omitted optionals inflated the denominator** — e.g. `["turn", "on", "?the", "{device}"]` said as "turn on light" scored 3.0/4 = 0.75 instead of 1.0, penalizing the speaker for using optionality.
2. **Optional literals could never reach 1.0** — a spoken `?the` paid +0.5 but occupied a full 1.0 slot, capping perfect matches at 0.875.

Short patterns were hit hardest: `["go", "?now"]` said as just "go" scored 1.0/2 = 0.5 and was rejected below the default `minScore` of 0.6. With the dynamic denominator it scores 1.0.

## Validation

Ran the full package test suite against a host Unity project (Unity **6000.4.7f1**) that embeds this package via a local `file:` reference — **298 tests, 0 failures**:

- [x] **PlayMode** (`Tests~/Runtime`): 210/210 passed, including all of `VoxrCommandParserTests` and `VoxrPendingCommandTests` (ScoreFollowUp), plus the **four new** regression tests — optional literal present → 1.0, optional literal omitted → 1.0, short pattern with omitted optional clears the default `minScore`, and `ScoreFollowUp` consistency.
- [x] **EditMode** (`Tests~/Editor`): 88/88 passed, including `VoxrCommandParserDiagnosticTests` and `VoxrMatchDiagnosticsTests` (parser diagnostics unaffected).
- [x] Verified no existing `.Score` assertion or score consumer (`VoxrCommandRecogniser`, `VoxrBatchTestRunner`, editor windows) hardcodes an old sub-1.0 value — all only threshold/display the score.
- [x] Updated `CHANGELOG.md` (`Fixed`) and the scoring description in `Documentation~/command-recognition.md`, which previously stated "missing optional tokens reduce the score proportionally."

No native bridge or device-specific runtime code changed, so no on-device (Quest) check is required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
