### PR TITLE
Release 1.2.1: dynamic score denominator fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-28
+
 ### Fixed
 
 - Command match scores no longer penalize valid utterances that take advantage of optional tokens. `VoxrCommandParser` previously normalized the raw score by the static pattern length, so an omitted `?word`/`{?slot}` optional still counted toward the denominator (dropping the score even though optionality permits omission), and a spoken optional literal could never reach a perfect 1.0. The denominator is now dynamic — required elements always count, optional elements only when actually matched — so a perfect match scores 1.0 whether or not its optionals were uttered. The same fix is applied to follow-up scoring (`ScoreFollowUp`) so initial and pending-command scores stay consistent. Short patterns with optionals (e.g. `["go", "?now"]` said as just "go") are no longer pushed below the default `minScore` of 0.6. ([#21](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/21))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.voxr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "VoXR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
Prep for the **v1.2.1** release. This is the prerequisite step the one-click Release workflow expects on `main`:

- Bumps `package.json` version `1.2.0` → `1.2.1`.
- Moves the dynamic-score-denominator fix ([#21](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/21), merged in #23) from `[Unreleased]` under a new `## [1.2.1] - 2026-05-28` CHANGELOG heading.

Patch bump: the change is a backward-compatible scoring bug fix with no API or ABI changes.

Once merged, the **Release** workflow (Actions → Release → Run workflow, version `1.2.1`) cuts `release/1.2.1`, strips `NativeBridge~/` + `Tests~/`, tags `v1.2.1`, and publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)