### PR TITLE
Add opt-in eager flush for complete, non-extensible commands (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in eager flush for the command recogniser. When `eagerFlushOnCompleteMatch` is enabled, the utterance buffer fires a recognised command the moment the buffered speech forms a complete match that cannot be extended or completed by further speech, instead of always waiting out `bufferWindow`. This removes the buffer latency (default 0.5s; 1.5–2.0s on Quest 3) for clean single-breath commands while preserving split-command recovery: a command that is a prefix of a longer one — or whose trailing slot could still grow (multi-word enumerated values, or a variable-length number sequence) — keeps waiting the full window. Split commands also fire as soon as their second half completes. Off by default, so existing timing is unchanged. One behavioural note when enabled: a terminal command marked `RequiresConfirmation` now enters its pending/confirmation state with zero added latency (it still does not fire until confirmed). ([#25](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/25))
+
 ## [1.2.1] - 2026-05-28
 
 ### Fixed

--- a/Documentation~/api/command-recogniser.md
+++ b/Documentation~/api/command-recogniser.md
@@ -12,6 +12,7 @@ Subscribes to speech events and runs text through the command parser pipeline: p
 | `minConfidence` | `float` | `0.4` | Minimum per-word confidence to accept a command. Commands with confidence below this are rejected. `-1` (no data) bypasses this check. |
 | `minScore` | `float` | `0.6` | Minimum pattern match score (0.0--1.0) to accept a command |
 | `bufferWindow` | `float` | `1.5` | Seconds to buffer consecutive VOSK results before parsing. Merges speech split by mid-command pauses. Recommended: `2.0` on Quest 3. |
+| `eagerFlushOnCompleteMatch` | `bool` | `false` | Fire a complete command immediately when the buffered speech can't be extended or completed by more words, instead of waiting out `bufferWindow`. Commands that are a prefix of a longer one, or whose trailing slot could still grow, keep waiting. See [Eager flush](../command-recognition.md#eager-flush-low-latency-complete-commands). |
 | `commandCooldown` | `float` | `0.3` | Per-intent debounce window in seconds. Suppresses duplicate firings of the same intent within this period. |
 | `freeSpeechMode` | `bool` | `false` | When true, disables grammar constraint for unconstrained vocabulary with best-effort command matching |
 | `slotAssets` | `VoxrSlotAsset[]` | -- | Slot definitions for Inspector authoring |

--- a/Documentation~/command-recognition.md
+++ b/Documentation~/command-recognition.md
@@ -210,6 +210,18 @@ If the speaker says "launch missiles" *pause* "target hotel one" and both result
 
 **Tuning:** The default is 1.5s. Quest 3 VOSK latency adds ~0.5--1.0s to inter-result gaps, so 2.0s is more reliable on device. Don't exceed ~2.5--3.0s or unrelated utterances may merge ("cross-command bleed").
 
+### Eager flush (low-latency complete commands)
+
+By default the buffer is purely time-driven: every command -- complete or not -- waits the full `bufferWindow` before firing. Enable **Eager Flush On Complete Match** in the Inspector to fire a command the instant the buffered speech forms a complete match that *cannot* be extended or completed by more words:
+
+- **Complete and unambiguous** -> fires immediately, with zero buffer latency.
+- **A prefix of a longer command**, or a **trailing slot that could still grow** (a multi-word enumerated value such as `"red"` -> `"red dragon"`, or a variable-length number sequence) -> keeps waiting the full window, so split commands are still recovered.
+- **Split command** -> fires as soon as its second half completes, instead of waiting another full window on top.
+
+The feature is off by default; leaving it off preserves the exact time-only behaviour above. Each command's eligibility is computed once when commands are configured, so the only per-utterance cost is a single speculative parse of the buffer.
+
+> A command that is *also* a prefix of a longer one (split by a long pause) is the one case eager flush can't accelerate -- see [Known Limitations](../KNOWN_LIMITATIONS.md). Push-to-talk (`VoxrPushToTalkController.ReleaseTalk` -> `FlushPendingBuffer()`) gives those a deterministic, zero-latency endpoint.
+
 ---
 
 ## Sequential Extraction

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -290,6 +290,26 @@ deliberate trade-offs rather than oversights.
   - For conversational UX, prefer shorter patterns that complete within one
     VOSK final result.
 
+### A command that is also a prefix of a longer one can't be both instant and split-safe
+
+- **Repro**: Register `["fire"]` and `["fire", "at", "{target}"]`, enable
+  `eagerFlushOnCompleteMatch`, then say "fire" and pause longer than
+  `bufferWindow` before "at hotel one". Eager flush deliberately does *not* fire
+  "fire" early (it is a prefix of the longer command), so it waits the full
+  window — and if the pause exceeds it, only "fire" is recognised.
+- **Root cause**: Inherent, not a bug. A complete command that is also a prefix
+  of a longer command is genuinely ambiguous until either more speech arrives or
+  the window expires. No time/parse strategy makes it both zero-latency and
+  correct: firing instantly would drop the longer command; waiting adds latency.
+  Eager flush resolves this conservatively by waiting (correctness over latency);
+  non-prefix commands are unaffected and fire instantly.
+- **Workaround**:
+  - Use push-to-talk (`VoxrPushToTalkController`); `ReleaseTalk` calls
+    `FlushPendingBuffer()`, giving the prefix command a deterministic,
+    zero-latency endpoint.
+  - Avoid registering commands that are exact prefixes of others when low latency
+    matters — e.g. give the shorter command a distinct extra keyword.
+
 ### Confidence of `-1.00` means "no data", not "zero confidence"
 
 - **Repro**: Say a command with leading filler or out-of-grammar words

--- a/Runtime/Commands/UtteranceBuffer.cs
+++ b/Runtime/Commands/UtteranceBuffer.cs
@@ -40,29 +40,30 @@ namespace VoXR.Commands
             return currentTime - _lastResultTime >= bufferWindow;
         }
 
-        internal string Flush()
+        // Joins the buffered results without consuming them. Returns string.Empty (never
+        // null) for an empty buffer. Used by the eager-flush speculative parse.
+        internal string PeekText()
         {
-            IsActive = false;
-
             if (_texts.Count == 0)
                 return string.Empty;
 
             // Fast path: single entry avoids StringBuilder overhead.
-            string text;
             if (_texts.Count == 1)
+                return _texts[0];
+
+            _sb.Clear();
+            for (int i = 0; i < _texts.Count; i++)
             {
-                text = _texts[0];
+                if (i > 0) _sb.Append(' ');
+                _sb.Append(_texts[i]);
             }
-            else
-            {
-                _sb.Clear();
-                for (int i = 0; i < _texts.Count; i++)
-                {
-                    if (i > 0) _sb.Append(' ');
-                    _sb.Append(_texts[i]);
-                }
-                text = _sb.ToString();
-            }
+            return _sb.ToString();
+        }
+
+        internal string Flush()
+        {
+            IsActive = false;
+            string text = PeekText();
             _texts.Clear();
             return text;
         }

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -18,6 +18,12 @@ namespace VoXR.Commands
         const float RequiredSlotMissPenalty = -1.0f;
         const float RequiredLiteralMissPenalty = -0.5f;
 
+        // Upper bound on optional elements in a single pattern for eager-commit analysis
+        // (issue #25). ExpandOptionals enumerates 2^optionals concrete forms; past this the
+        // expansion is unbounded/overflowing, so the whole parser disables eager commit
+        // rather than partially (and unsoundly) analyse. Pathological grammars only.
+        const int MaxOptionalExpansion = 12;
+
         internal static readonly char[] SplitSeparator = { ' ' };
 
         readonly VoxrSlotDefinition[] _slots;
@@ -63,7 +69,11 @@ namespace VoXR.Commands
         // Per-(command, pattern) eager-commit eligibility (issue #25): true when a full
         // match of the pattern cannot be extended or completed by further speech — i.e. it
         // is not a prefix of any other pattern and its trailing element can't grow.
-        readonly bool[][] _canCommitEarly;
+        // Computed lazily on first eager check (see EnsureCanCommitEarly): opted-out callers
+        // never reach an eager entry point, so they never pay the precompute. May be left
+        // null when the grammar is too complex to analyse soundly (see MaxOptionalExpansion).
+        bool[][] _canCommitEarly;
+        bool _canCommitEarlyComputed;
 
         // Pooled StringBuilder for TryMatchNumberSequence.
         readonly System.Text.StringBuilder _numberSb = new System.Text.StringBuilder();
@@ -182,7 +192,9 @@ namespace VoXR.Commands
 
             _resultBuf = new VoxrCommandResult[Math.Max(commands.Length, 1)];
 
-            _canCommitEarly = ComputeCanCommitEarly();
+            // _canCommitEarly is computed lazily on the first eager check (issue #25), so
+            // callers who leave eager flush off never pay the O(2^optionals)+O(forms^2)
+            // precompute on Configure/RebuildParser/NotifySlotChanged.
 
             RunValidationWarnings(slots);
         }
@@ -872,11 +884,24 @@ namespace VoXR.Commands
 
         // -------- Eager-flush support (issue #25) --------
 
+        // Computes _canCommitEarly on first use and caches it. Both eager entry points
+        // (CanCommitEarly and TryEagerCommit) call this, so the precompute only runs for
+        // callers that actually probe eager commit; eager-flush-off callers never reach
+        // here. A rebuilt parser is a fresh instance, so the table is recomputed naturally.
+        void EnsureCanCommitEarly()
+        {
+            if (_canCommitEarlyComputed)
+                return;
+            _canCommitEarly = ComputeCanCommitEarly();
+            _canCommitEarlyComputed = true;
+        }
+
         // Whether a full match of commands[commandIndex].Patterns[patternIndex] may be
         // committed before bufferWindow elapses. Exposed for tests; the runtime path uses
         // the command/pattern index from TryEagerCommit's own scan.
         internal bool CanCommitEarly(int commandIndex, int patternIndex)
         {
+            EnsureCanCommitEarly();
             return _canCommitEarly != null
                 && (uint)commandIndex < (uint)_canCommitEarly.Length
                 && (uint)patternIndex < (uint)_canCommitEarly[commandIndex].Length
@@ -892,6 +917,8 @@ namespace VoXR.Commands
         {
             if (tokens == null || tokens.Length == 0)
                 return false;
+
+            EnsureCanCommitEarly();
 
             float bestScore = float.MinValue;
             int bestLiteralCount = -1;
@@ -942,11 +969,35 @@ namespace VoXR.Commands
             if (confidence >= 0f && confidence < minConfidence)
                 return false;
 
-            return _canCommitEarly[bestCommandIdx][bestPatternIdx];
+            // Guarded accessor: _canCommitEarly may legitimately be null when the grammar
+            // was too complex to analyse (MaxOptionalExpansion), and the indices come from a
+            // separate scan, so route through the bounds-checked path rather than indexing raw.
+            return CanCommitEarly(bestCommandIdx, bestPatternIdx);
         }
 
         bool[][] ComputeCanCommitEarly()
         {
+            // Guard pathological grammars: ExpandOptionals enumerates 2^optionals forms, which
+            // overflows/allocates unboundedly past MaxOptionalExpansion. If ANY pattern is over
+            // the limit, disable eager commit for the whole parser (return null -> CanCommitEarly
+            // reports false) rather than partially analyse — an un-expanded pattern used as the
+            // "longer" side would unsoundly let a real prefix through and fire the wrong command.
+            for (int ci = 0; ci < _commands.Length; ci++)
+            {
+                var patterns = _commands[ci].Patterns;
+                for (int pi = 0; pi < patterns.Length; pi++)
+                {
+                    if (CountOptionalElements(patterns[pi]) > MaxOptionalExpansion)
+                    {
+                        UnityEngine.Debug.LogWarning(
+                            $"[VoXR] Pattern for intent '{_commands[ci].Intent}' has more than " +
+                            $"{MaxOptionalExpansion} optional elements; eager flush is disabled for " +
+                            "this command set. Reduce optional tokens to re-enable it.");
+                        return null;
+                    }
+                }
+            }
+
             // Pre-expand every pattern over its optional elements once: a pattern with an
             // optional element matches with that element present OR absent, so prefix
             // analysis must consider every concrete form on both sides.
@@ -970,6 +1021,17 @@ namespace VoXR.Commands
                 result[ci] = flags;
             }
             return result;
+        }
+
+        // Number of optional elements ({?slot} or ?literal) in a pattern; ExpandOptionals
+        // produces 2^this concrete forms.
+        static int CountOptionalElements(string[] pattern)
+        {
+            int count = 0;
+            for (int i = 0; i < pattern.Length; i++)
+                if (IsOptionalLiteral(pattern[i]) || IsOptionalSlot(pattern[i]))
+                    count++;
+            return count;
         }
 
         // All concrete token sequences for a pattern, including/excluding each optional
@@ -1045,8 +1107,11 @@ namespace VoXR.Commands
             return false;
         }
 
-        // True if any concrete form of this pattern is a compatible prefix of any concrete
-        // form of a different pattern (so more speech could complete the longer command).
+        // True if any concrete form of this pattern is a prefix of any concrete form of a
+        // different pattern (so more speech could complete the longer command). Two notions
+        // of "prefix" are checked: an element-count prefix (P has fewer elements than Q and
+        // they line up), and a word-level prefix where P and Q have the same element count
+        // but a slot in P can match a word-sequence that Q extends (BoundaryWordPrefixHazard).
         bool IsPrefixOfAnyOtherPattern(int ci, int pi, List<string[]>[][] expanded)
         {
             var pForms = expanded[ci][pi];
@@ -1059,11 +1124,140 @@ namespace VoXR.Commands
                     var qForms = qPatterns[pj];
                     for (int a = 0; a < pForms.Count; a++)
                         for (int b = 0; b < qForms.Count; b++)
-                            if (pForms[a].Length < qForms[b].Length
-                                && IsCompatiblePrefix(pForms[a], qForms[b]))
+                            if ((pForms[a].Length < qForms[b].Length
+                                    && IsCompatiblePrefix(pForms[a], qForms[b]))
+                                || BoundaryWordPrefixHazard(pForms[a], qForms[b]))
                                 return true;
                 }
             }
+            return false;
+        }
+
+        // Word-level prefix hazard the element-count check above misses (issue #25). When
+        // pForm's final element is reached after a run of literals identical to qForm's, and
+        // at that element qForm can produce a word-sequence that strictly extends one of
+        // pForm's, a full match of P is a word-prefix of a full match of Q — so firing P
+        // early could ship the wrong command. The classic miss is two equal-element-count
+        // patterns: "go {dir=north}" vs "go {place=north pole}" (enumerated), or
+        // "dial {n3}" vs "dial {n5}" (number sequence). Cardinal rule: err toward a hazard.
+        bool BoundaryWordPrefixHazard(string[] pForm, string[] qForm)
+        {
+            int k = pForm.Length - 1;          // P's final element — the divergence point.
+            if (k < 0 || qForm.Length < k + 1) // Q must have an element aligned with it.
+                return false;
+
+            // Everything before the divergence must be identical literals so both sides have
+            // consumed the same words up to k and the slot analysis at k is word-aligned.
+            // (A slot in the shared run could realign words; that case is left to the
+            // conservative element-count check and is not analysed word-precisely here.)
+            if (SharedLiteralPrefixLen(pForm, qForm) != k)
+                return false;
+
+            string pSlot = ExtractSlotName(pForm[k]);
+            string qSlot = ExtractSlotName(qForm[k]);
+
+            if (pSlot == null)
+            {
+                // P ends in a literal: only a slot on Q's side can grow past it. (A literal
+                // qForm[k] is either equal — making the shared run longer than k — or differs,
+                // so it cannot extend P's word.)
+                return qSlot != null && SlotCanExtendWord(qSlot, StripOptionalLiteral(pForm[k]));
+            }
+
+            if (qSlot == null)
+                return false; // P slot vs Q literal: Q can extend only via trailing elements,
+                              // which the element-count check already covers.
+
+            // Both sides are slots at the divergence: a value (or fixed-width number run) of
+            // P's slot must be a strict word-prefix of a value (or wider run) of Q's slot.
+            return SlotValueIsWordPrefixOfSlot(pSlot, qSlot);
+        }
+
+        // Length of the leading run where p and q are identical literals (no slots), so the
+        // two forms produce exactly the same words over that run.
+        static int SharedLiteralPrefixLen(string[] p, string[] q)
+        {
+            int n = Math.Min(p.Length, q.Length);
+            int i = 0;
+            for (; i < n; i++)
+            {
+                if (ExtractSlotName(p[i]) != null || ExtractSlotName(q[i]) != null)
+                    break;
+                if (!string.Equals(StripOptionalLiteral(p[i]), StripOptionalLiteral(q[i]),
+                        StringComparison.Ordinal))
+                    break;
+            }
+            return i;
+        }
+
+        // True if slotName can produce a surface form that begins with firstWord and is
+        // longer than one word, so it strictly extends a command ending in that literal.
+        // A number sequence is treated as able to start with any word (NUMBER is a wildcard),
+        // so any multi-word run extends.
+        bool SlotCanExtendWord(string slotName, string firstWord)
+        {
+            if (!_slotIndex.TryGetValue(slotName, out int slotIdx))
+                return true; // unknown slot — stay safe.
+
+            if (_slots[slotIdx].Type == VoxrSlotType.NumberSequence)
+                return _slots[slotIdx].MaxWords > 1;
+
+            foreach (var list in _slotLookups[slotIdx].Values)
+                foreach (var entry in list)
+                    if (entry.Words.Length > 1 &&
+                        string.Equals(entry.Words[0], firstWord, StringComparison.Ordinal))
+                        return true;
+            return false;
+        }
+
+        // True if some realization of slot pSlotName is a strict word-prefix of some
+        // realization of slot qSlotName. Number-sequence runs match any word (NUMBER is a
+        // wildcard), so they compare by width; enumerated slots compare surface forms.
+        bool SlotValueIsWordPrefixOfSlot(string pSlotName, string qSlotName)
+        {
+            if (!_slotIndex.TryGetValue(pSlotName, out int pIdx) ||
+                !_slotIndex.TryGetValue(qSlotName, out int qIdx))
+                return true; // unknown slot — stay safe.
+
+            bool pNum = _slots[pIdx].Type == VoxrSlotType.NumberSequence;
+            bool qNum = _slots[qIdx].Type == VoxrSlotType.NumberSequence;
+
+            if (pNum && qNum)
+                // P's shortest run can be a strict prefix of a wider Q run.
+                return _slots[qIdx].MaxWords > _slots[pIdx].MinWords;
+
+            if (pNum)
+                // A min-width number run is a strict prefix of any longer Q value.
+                return AnySlotSurfaceFormLongerThan(qIdx, _slots[pIdx].MinWords);
+
+            if (qNum)
+                // Any P value is a strict prefix of a wider number run.
+                return AnySlotSurfaceFormShorterThan(pIdx, _slots[qIdx].MaxWords);
+
+            foreach (var pList in _slotLookups[pIdx].Values)
+                foreach (var pEntry in pList)
+                    foreach (var qList in _slotLookups[qIdx].Values)
+                        foreach (var qEntry in qList)
+                            if (IsWordPrefix(pEntry.Words, qEntry.Words))
+                                return true;
+            return false;
+        }
+
+        bool AnySlotSurfaceFormLongerThan(int slotIdx, int wordCount)
+        {
+            foreach (var list in _slotLookups[slotIdx].Values)
+                foreach (var entry in list)
+                    if (entry.Words.Length > wordCount)
+                        return true;
+            return false;
+        }
+
+        bool AnySlotSurfaceFormShorterThan(int slotIdx, int wordCount)
+        {
+            foreach (var list in _slotLookups[slotIdx].Values)
+                foreach (var entry in list)
+                    if (entry.Words.Length < wordCount)
+                        return true;
             return false;
         }
 

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -60,6 +60,11 @@ namespace VoXR.Commands
         readonly VoxrCommandResult[] _resultBuf;
         int _resultCount;
 
+        // Per-(command, pattern) eager-commit eligibility (issue #25): true when a full
+        // match of the pattern cannot be extended or completed by further speech — i.e. it
+        // is not a prefix of any other pattern and its trailing element can't grow.
+        readonly bool[][] _canCommitEarly;
+
         // Pooled StringBuilder for TryMatchNumberSequence.
         readonly System.Text.StringBuilder _numberSb = new System.Text.StringBuilder();
 
@@ -176,6 +181,8 @@ namespace VoXR.Commands
 #endif
 
             _resultBuf = new VoxrCommandResult[Math.Max(commands.Length, 1)];
+
+            _canCommitEarly = ComputeCanCommitEarly();
 
             RunValidationWarnings(slots);
         }
@@ -861,6 +868,236 @@ namespace VoXR.Commands
             }
 
             return denominator > 0f ? rawScore / denominator : 0f;
+        }
+
+        // -------- Eager-flush support (issue #25) --------
+
+        // Whether a full match of commands[commandIndex].Patterns[patternIndex] may be
+        // committed before bufferWindow elapses. Exposed for tests; the runtime path uses
+        // the command/pattern index from TryEagerCommit's own scan.
+        internal bool CanCommitEarly(int commandIndex, int patternIndex)
+        {
+            return _canCommitEarly != null
+                && (uint)commandIndex < (uint)_canCommitEarly.Length
+                && (uint)patternIndex < (uint)_canCommitEarly[commandIndex].Length
+                && _canCommitEarly[commandIndex][patternIndex];
+        }
+
+        // Single-pass speculative check: does the buffered text already form one complete,
+        // confident command that cannot be extended or completed by more speech? The
+        // selection mirrors ParseInternal's inner loop (searchStart = 0) exactly so the
+        // verdict matches the command the subsequent FlushBuffer will actually fire.
+        internal bool TryEagerCommit(string[] tokens, Dictionary<string, float> wordConfidence,
+            float minScore, float minConfidence)
+        {
+            if (tokens == null || tokens.Length == 0)
+                return false;
+
+            float bestScore = float.MinValue;
+            int bestLiteralCount = -1;
+            int bestCommandIdx = -1;
+            int bestPatternIdx = -1;
+            int bestStartIdx = int.MaxValue;
+            int bestEndIdx = 0;
+
+            for (int ci = 0; ci < _commands.Length; ci++)
+            {
+                var patterns = _commands[ci].Patterns;
+                for (int pi = 0; pi < patterns.Length; pi++)
+                {
+                    for (int startIdx = 0; startIdx < tokens.Length; startIdx++)
+                    {
+                        if (tokens[startIdx] == UnkToken)
+                            continue;
+
+                        var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
+
+                        if (matchResult.Score > 0f &&
+                            (bestScore <= 0f ||
+                             startIdx < bestStartIdx ||
+                             (startIdx == bestStartIdx &&
+                              (matchResult.Score > bestScore ||
+                               (matchResult.Score == bestScore && matchResult.LiteralCount > bestLiteralCount)))))
+                        {
+                            bestScore = matchResult.Score;
+                            bestLiteralCount = matchResult.LiteralCount;
+                            bestCommandIdx = ci;
+                            bestPatternIdx = pi;
+                            bestStartIdx = startIdx;
+                            bestEndIdx = matchResult.EndIdx;
+                        }
+                    }
+                }
+            }
+
+            if (bestCommandIdx < 0 || bestScore < minScore)
+                return false;
+
+            // The match must span the whole buffer: anything left over (including trailing
+            // [unk]) means an in-progress tail that more speech could still complete.
+            if (bestStartIdx != 0 || bestEndIdx != tokens.Length)
+                return false;
+
+            float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
+            if (confidence >= 0f && confidence < minConfidence)
+                return false;
+
+            return _canCommitEarly[bestCommandIdx][bestPatternIdx];
+        }
+
+        bool[][] ComputeCanCommitEarly()
+        {
+            // Pre-expand every pattern over its optional elements once: a pattern with an
+            // optional element matches with that element present OR absent, so prefix
+            // analysis must consider every concrete form on both sides.
+            var expanded = new List<string[]>[_commands.Length][];
+            for (int ci = 0; ci < _commands.Length; ci++)
+            {
+                var patterns = _commands[ci].Patterns;
+                expanded[ci] = new List<string[]>[patterns.Length];
+                for (int pi = 0; pi < patterns.Length; pi++)
+                    expanded[ci][pi] = ExpandOptionals(patterns[pi]);
+            }
+
+            var result = new bool[_commands.Length][];
+            for (int ci = 0; ci < _commands.Length; ci++)
+            {
+                var patterns = _commands[ci].Patterns;
+                var flags = new bool[patterns.Length];
+                for (int pi = 0; pi < patterns.Length; pi++)
+                    flags[pi] = IsTerminalPattern(patterns[pi])
+                        && !IsPrefixOfAnyOtherPattern(ci, pi, expanded);
+                result[ci] = flags;
+            }
+            return result;
+        }
+
+        // All concrete token sequences for a pattern, including/excluding each optional
+        // element ({?slot} or ?literal). A pattern with no optionals yields one form.
+        static List<string[]> ExpandOptionals(string[] pattern)
+        {
+            var optionalIdx = new List<int>();
+            for (int i = 0; i < pattern.Length; i++)
+                if (IsOptionalLiteral(pattern[i]) || IsOptionalSlot(pattern[i]))
+                    optionalIdx.Add(i);
+
+            int combos = 1 << optionalIdx.Count;
+            var forms = new List<string[]>(combos);
+            var form = new List<string>(pattern.Length);
+            for (int mask = 0; mask < combos; mask++)
+            {
+                form.Clear();
+                for (int i = 0; i < pattern.Length; i++)
+                {
+                    int optPos = optionalIdx.IndexOf(i);
+                    if (optPos >= 0 && (mask & (1 << optPos)) == 0)
+                        continue; // this optional element is omitted in this combo.
+                    form.Add(pattern[i]);
+                }
+                forms.Add(form.ToArray());
+            }
+            return forms;
+        }
+
+        // A pattern is "terminal" when its final element cannot absorb or be followed by
+        // more speech within the same command.
+        bool IsTerminalPattern(string[] pattern)
+        {
+            if (pattern.Length == 0)
+                return false;
+
+            string last = pattern[pattern.Length - 1];
+
+            // A trailing optional element could still be filled by later speech.
+            if (IsOptionalLiteral(last) || IsOptionalSlot(last))
+                return false;
+
+            string slotName = ExtractSlotName(last);
+            if (slotName == null)
+                return true; // required literal — fixed.
+
+            if (!_slotIndex.TryGetValue(slotName, out int slotIdx))
+                return false; // unknown slot (ctor validates) — stay safe.
+
+            if (_slots[slotIdx].Type == VoxrSlotType.NumberSequence)
+                return _slots[slotIdx].MinWords == _slots[slotIdx].MaxWords; // fixed width.
+
+            // Enumerated: terminal only if no surface form (value or alias key) is a word-
+            // prefix of another, so a matched value can't grow into a longer one.
+            return !HasWordPrefixAmbiguity(slotIdx);
+        }
+
+        bool HasWordPrefixAmbiguity(int slotIdx)
+        {
+            // Surface forms (values + alias keys), already split into words by AddSlotEntry.
+            var forms = new List<string[]>();
+            foreach (var list in _slotLookups[slotIdx].Values)
+                foreach (var entry in list)
+                    forms.Add(entry.Words);
+
+            for (int i = 0; i < forms.Count; i++)
+                for (int j = 0; j < forms.Count; j++)
+                {
+                    if (i == j) continue;
+                    if (IsWordPrefix(forms[i], forms[j]))
+                        return true;
+                }
+            return false;
+        }
+
+        // True if any concrete form of this pattern is a compatible prefix of any concrete
+        // form of a different pattern (so more speech could complete the longer command).
+        bool IsPrefixOfAnyOtherPattern(int ci, int pi, List<string[]>[][] expanded)
+        {
+            var pForms = expanded[ci][pi];
+            for (int cj = 0; cj < _commands.Length; cj++)
+            {
+                var qPatterns = expanded[cj];
+                for (int pj = 0; pj < qPatterns.Length; pj++)
+                {
+                    if (cj == ci && pj == pi) continue;
+                    var qForms = qPatterns[pj];
+                    for (int a = 0; a < pForms.Count; a++)
+                        for (int b = 0; b < qForms.Count; b++)
+                            if (pForms[a].Length < qForms[b].Length
+                                && IsCompatiblePrefix(pForms[a], qForms[b]))
+                                return true;
+                }
+            }
+            return false;
+        }
+
+        static bool IsCompatiblePrefix(string[] p, string[] q)
+        {
+            for (int i = 0; i < p.Length; i++)
+                if (!TokensCompatible(p[i], q[i]))
+                    return false;
+            return true;
+        }
+
+        // Conservative: any slot-involving position is treated as compatible (slots may
+        // overlap), so uncertainty blocks early commit. Two literals match only when equal
+        // after stripping a leading optional '?'.
+        static bool TokensCompatible(string a, string b)
+        {
+            if (ExtractSlotName(a) != null || ExtractSlotName(b) != null)
+                return true;
+            return string.Equals(StripOptionalLiteral(a), StripOptionalLiteral(b), StringComparison.Ordinal);
+        }
+
+        static string StripOptionalLiteral(string element)
+        {
+            return IsOptionalLiteral(element) ? element.Substring(1) : element;
+        }
+
+        static bool IsWordPrefix(string[] shorter, string[] longer)
+        {
+            if (shorter.Length >= longer.Length)
+                return false;
+            for (int i = 0; i < shorter.Length; i++)
+                if (!string.Equals(shorter[i], longer[i], StringComparison.Ordinal))
+                    return false;
+            return true;
         }
     }
 }

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -36,6 +36,13 @@ namespace VoXR.Commands
                  "Set to 0 to disable buffering (v2.2 behaviour).")]
         [SerializeField] float bufferWindow = 0.5f;
 
+        [Tooltip("When the buffered speech already forms a complete command that cannot be " +
+                 "extended or completed by more words, flush and fire immediately instead " +
+                 "of waiting out bufferWindow. Zero latency for unambiguous commands; " +
+                 "commands that are a prefix of a longer one still wait the full window. " +
+                 "Opt-in — off preserves the time-only buffering behaviour.")]
+        [SerializeField] bool eagerFlushOnCompleteMatch = false;
+
         [Tooltip("Minimum seconds between firing the same intent. " +
                  "Prevents duplicate commands from rapid VOSK results. " +
                  "Set to 0 to disable debounce.")]
@@ -257,6 +264,7 @@ namespace VoXR.Commands
 
         // Test-only setters. Production callers configure via the Inspector.
         internal float BufferWindow { set => bufferWindow = value; }
+        internal bool EagerFlushOnCompleteMatch { set => eagerFlushOnCompleteMatch = value; }
         internal float CommandCooldown { set => commandCooldown = value; }
         internal VoxrSpeechRecogniser SpeechRecogniser
         {
@@ -427,6 +435,13 @@ namespace VoXR.Commands
 
             // Append to buffer and reset timer
             _buffer.Append(result.Text, result.Words, Time.time);
+
+            // Eager flush: if the buffered speech already forms a complete command that
+            // cannot be extended or completed by more words, flush now instead of waiting
+            // out bufferWindow. Skipped while a command is pending so confirm/follow-up
+            // stays on the timer path.
+            if (eagerFlushOnCompleteMatch && !_pending.HasPending && ShouldEagerFlush())
+                FlushBuffer();
         }
 
         void FlushBuffer()
@@ -441,6 +456,24 @@ namespace VoXR.Commands
             var words = _buffer.GetWordsSpan();
             ProcessParsedResults(text, words);
             _buffer.ClearWords();
+        }
+
+        // Speculative check used by HandleResult: peek (don't consume) the buffer and ask
+        // the parser whether it already forms one complete, terminal, confident command.
+        bool ShouldEagerFlush()
+        {
+            string text = _buffer.PeekText();
+            if (text.Length == 0)
+                return false;
+
+            string[] tokens = text.Split(VoxrCommandParser.SplitSeparator,
+                StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0)
+                return false;
+
+            var words = _buffer.GetWordsSpan();
+            var wordConfidence = _parser.InstanceBuildWordConfidence(words);
+            return _parser.TryEagerCommit(tokens, wordConfidence, minScore, minConfidence);
         }
 
         void ProcessParsedResults(string text, VoxrWord[] words)

--- a/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
+++ b/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
@@ -408,5 +408,118 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(1, fireCount, "Completing the command should eager-fire immediately");
             Assert.AreEqual("hotel one", received.Value.GetSlot("target"));
         }
+
+        // -------- Eager flush: confirmation, pending, and number sequences (review fix #7) --------
+
+        [Test]
+        public void EagerFlush_RequiresConfirmation_EntersPendingNotFire()
+        {
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("arm", new[] { new[] { "arm", "system" } },
+                    allowPartialMatch: false, requiresConfirmation: true),
+            };
+            _recogniser.Configure(new VoxrSlotDefinition[0], commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int recognised = 0;
+            VoxrCommand? pending = null;
+            _recogniser.OnCommandRecognised += _ => recognised++;
+            _recogniser.OnCommandPending += cmd => pending = cmd;
+
+            _recogniser.InjectText("arm system");
+
+            Assert.IsTrue(pending.HasValue,
+                "A complete command requiring confirmation should eager-flush into pending");
+            Assert.AreEqual("arm", pending.Value.Intent);
+            Assert.AreEqual(0, recognised,
+                "It must enter pending, not fire OnCommandRecognised directly");
+            Assert.IsTrue(_recogniser.HasPendingCommand);
+        }
+
+        [Test]
+        public void EagerFlush_WhilePending_DoesNotEagerFire()
+        {
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("arm", new[] { new[] { "arm", "system" } },
+                    allowPartialMatch: false, requiresConfirmation: true),
+                new VoxrCommandDefinition("cease_fire", new[] { new[] { "cease", "fire" } }),
+            };
+            _recogniser.Configure(new VoxrSlotDefinition[0], commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int recognised = 0;
+            _recogniser.OnCommandRecognised += _ => recognised++;
+
+            // Enter pending via the confirmation path.
+            _recogniser.InjectText("arm system");
+            Assert.IsTrue(_recogniser.HasPendingCommand, "Setup: arm system should be pending");
+            Assert.AreEqual(0, recognised);
+
+            // A new terminal command must NOT eager-fire while a command is pending (the
+            // !_pending.HasPending guard suppresses eager); it stays buffered.
+            _recogniser.InjectText("cease fire");
+            Assert.AreEqual(0, recognised,
+                "Eager flush must be suppressed while a command is pending");
+
+            // Flushing the buffer releases the buffered command (which preempts the pending one).
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, recognised, "The buffered command fires on an explicit flush");
+        }
+
+        [Test]
+        public void EagerFlush_FixedWidthNumberSequence_FiresImmediately()
+        {
+            var slots = new[] { VoxrSlotDefinition.NumberSequence("code", 4, 4) };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("enter", new[] { new[] { "enter", "{code}" } }),
+            };
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            VoxrCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => received = cmd;
+
+            _recogniser.InjectText("enter one two three four");
+
+            Assert.IsTrue(received.HasValue,
+                "A fixed-width number sequence completes the command, so it should eager-fire");
+            Assert.AreEqual("enter", received.Value.Intent);
+            Assert.AreEqual("one two three four", received.Value.GetSlot("code"));
+        }
+
+        [Test]
+        public void EagerFlush_VariableWidthNumberSequence_WaitsForWindow()
+        {
+            var slots = new[] { VoxrSlotDefinition.NumberSequence("code", 1, 4) };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("enter", new[] { new[] { "enter", "{code}" } }),
+            };
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            // A variable-width number sequence can always absorb another digit, so the command
+            // is not eager-committable — it must wait for the buffer window.
+            _recogniser.InjectText("enter one two three");
+            Assert.AreEqual(0, fireCount,
+                "A variable-width number sequence must not eager-fire (more digits may follow)");
+
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, fireCount, "It still fires on the normal flush");
+        }
     }
 }

--- a/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
+++ b/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
@@ -269,5 +269,144 @@ namespace VoXR.Tests.Runtime
                 "Speech-layer InjectResult did not propagate to command recogniser");
             Assert.AreEqual("cease_fire", received.Value.Intent);
         }
+
+        // -------- Eager flush (issue #25) --------
+
+        [Test]
+        public void EagerFlush_TerminalCommand_FiresImmediatelyWithoutFlush()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            _recogniser.InjectText("cease fire");
+
+            Assert.AreEqual(1, fireCount,
+                "A terminal command should fire immediately under eager flush, " +
+                "without waiting for the buffer window");
+        }
+
+        [Test]
+        public void EagerFlush_FullSlottedCommand_FiresImmediately()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            VoxrCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => received = cmd;
+
+            _recogniser.InjectText("launch all missiles target hotel one");
+
+            Assert.IsTrue(received.HasValue,
+                "A complete slotted command should fire immediately under eager flush");
+            Assert.AreEqual("launch_weapon", received.Value.Intent);
+            Assert.AreEqual("hotel one", received.Value.GetSlot("target"));
+        }
+
+        [Test]
+        public void EagerFlush_Off_PreservesTimeOnlyBuffering()
+        {
+            // The default (flag off) must keep today's behaviour: buffered until flushed.
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            // eagerFlushOnCompleteMatch intentionally left at its default (false).
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            _recogniser.InjectText("cease fire");
+            Assert.AreEqual(0, fireCount,
+                "With eager flush off, a buffered command must not fire immediately");
+
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, fireCount);
+        }
+
+        [Test]
+        public void EagerFlush_PrefixCommand_WaitsForTheWindow()
+        {
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two" }),
+            };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("status", new[] { new[] { "status" } }),
+                new VoxrCommandDefinition("status_report",
+                    new[] { new[] { "status", "report", "{target}" } }),
+            };
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            // "status" is a prefix of "status report {target}", so it must NOT eager-fire.
+            _recogniser.InjectText("status");
+            Assert.AreEqual(0, fireCount,
+                "A command that is a prefix of a longer one must wait the full window");
+
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, fireCount, "It still fires on the normal flush");
+        }
+
+        [Test]
+        public void EagerFlush_TrailingExtensibleSlot_WaitsForTheWindow()
+        {
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("colour", new[] { "red", "red dragon" }),
+            };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("pick", new[] { new[] { "pick", "{colour}" } }),
+            };
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int fireCount = 0;
+            _recogniser.OnCommandRecognised += _ => fireCount++;
+
+            // "pick red" could still grow into "pick red dragon", so it must NOT eager-fire.
+            _recogniser.InjectText("pick red");
+            Assert.AreEqual(0, fireCount,
+                "A trailing slot whose value can grow must wait the full window");
+
+            _recogniser.FlushPendingBuffer();
+            Assert.AreEqual(1, fireCount);
+        }
+
+        [Test]
+        public void EagerFlush_SplitCommand_FiresWhenSecondHalfCompletes()
+        {
+            _recogniser.Configure(MakeSlots(), MakeCommands());
+            _recogniser.BufferWindow = 1.5f;
+            _recogniser.CommandCooldown = 0f;
+            _recogniser.EagerFlushOnCompleteMatch = true;
+
+            int fireCount = 0;
+            VoxrCommand? received = null;
+            _recogniser.OnCommandRecognised += cmd => { fireCount++; received = cmd; };
+
+            // First half is incomplete (target slot unfilled) -> below threshold -> no fire.
+            _recogniser.InjectText("launch all missiles");
+            Assert.AreEqual(0, fireCount, "An incomplete command must not eager-fire");
+
+            // The second half completes the command on the merged buffer -> eager fire.
+            _recogniser.InjectText("target hotel one");
+            Assert.AreEqual(1, fireCount, "Completing the command should eager-fire immediately");
+            Assert.AreEqual("hotel one", received.Value.GetSlot("target"));
+        }
     }
 }

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using VoXR.Commands;
+
+namespace VoXR.Tests.Runtime
+{
+    // Unit tests for the eager-flush precompute (CanCommitEarly) and the speculative
+    // TryEagerCommit gate on VoxrCommandParser (issue #25).
+    public class VoxrEagerCommitTests
+    {
+        static VoxrSlotDefinition[] Slots(params VoxrSlotDefinition[] s) => s;
+        static VoxrCommandDefinition[] Commands(params VoxrCommandDefinition[] c) => c;
+        static VoxrCommandDefinition Cmd(string intent, params string[][] patterns)
+            => new VoxrCommandDefinition(intent, patterns);
+        static string[] P(params string[] tokens) => tokens;
+        static string[] Tok(string text) => text.Split(' ');
+
+        // ---------- CanCommitEarly classification ----------
+
+        [Test]
+        public void Terminal_LiteralEnding_IsCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(Cmd("cease_fire", P("cease", "fire"))));
+
+            Assert.IsTrue(parser.CanCommitEarly(0, 0));
+        }
+
+        [Test]
+        public void Terminal_EnumeratedSlotEnding_NoValuePrefix_IsCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" })),
+                Commands(Cmd("fire", P("fire", "{weapon}"))));
+
+            Assert.IsTrue(parser.CanCommitEarly(0, 0));
+        }
+
+        [Test]
+        public void PrefixOfAnotherCommand_IsNotCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("target", new[] { "hotel one" })),
+                Commands(
+                    Cmd("status", P("status")),
+                    Cmd("status_report", P("status", "report", "{target}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0),
+                "\"status\" is a prefix of \"status report {target}\"");
+            Assert.IsTrue(parser.CanCommitEarly(1, 0),
+                "the longer command is terminal and not a prefix of anything");
+        }
+
+        [Test]
+        public void PrefixOfSameCommandLongerPattern_IsNotCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(Cmd("go", P("go"), P("go", "now"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0), "[go] is a prefix of [go, now]");
+            Assert.IsTrue(parser.CanCommitEarly(0, 1), "[go, now] cannot be extended");
+        }
+
+        [Test]
+        public void TrailingOptional_IsNotCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(Cmd("go", P("go", "?now"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0));
+        }
+
+        [Test]
+        public void LeadingOptionalInOtherCommand_StillDetectsPrefix()
+        {
+            // "status" must wait because dropping the optional "?please" makes
+            // "status report" a valid utterance of the longer command.
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(
+                    Cmd("status", P("status")),
+                    Cmd("polite_status", P("?please", "status", "report"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0),
+                "expansion over optionals must catch the shifted prefix");
+        }
+
+        [Test]
+        public void TrailingExtensibleEnumeratedSlot_IsNotCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("colour", new[] { "red", "red dragon" })),
+                Commands(Cmd("pick", P("pick", "{colour}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0), "\"red\" can grow into \"red dragon\"");
+        }
+
+        [Test]
+        public void AliasKeyThatIsWordPrefixOfAnotherSurfaceForm_IsNotCommittable()
+        {
+            var slot = new VoxrSlotDefinition("colour",
+                new[] { "crimson" },
+                new Dictionary<string, string> { { "red", "crimson" }, { "red dragon", "crimson" } });
+            var parser = new VoxrCommandParser(
+                Slots(slot),
+                Commands(Cmd("pick", P("pick", "{colour}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0),
+                "alias \"red\" is a word-prefix of alias \"red dragon\"");
+        }
+
+        [Test]
+        public void NumberSequence_FixedWidth_IsCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(VoxrSlotDefinition.NumberSequence("code", 3, 3)),
+                Commands(Cmd("enter", P("enter", "{code}"))));
+
+            Assert.IsTrue(parser.CanCommitEarly(0, 0), "min == max can't grow");
+        }
+
+        [Test]
+        public void NumberSequence_VariableWidth_IsNotCommittable()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(VoxrSlotDefinition.NumberSequence("code", 1, 3)),
+                Commands(Cmd("enter", P("enter", "{code}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0), "min < max can absorb more digits");
+        }
+
+        [Test]
+        public void CanCommitEarly_OutOfRange_ReturnsFalse()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(Cmd("cease_fire", P("cease", "fire"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(5, 0));
+            Assert.IsFalse(parser.CanCommitEarly(0, 5));
+            Assert.IsFalse(parser.CanCommitEarly(-1, -1));
+        }
+
+        // ---------- TryEagerCommit gate ----------
+
+        [Test]
+        public void TryEagerCommit_FullTerminalMatch_ReturnsTrue()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("weapon", new[] { "missiles" })),
+                Commands(Cmd("fire", P("fire", "{weapon}"))));
+
+            Assert.IsTrue(parser.TryEagerCommit(Tok("fire missiles"), null, 0.6f, 0.4f));
+        }
+
+        [Test]
+        public void TryEagerCommit_BelowScoreThreshold_ReturnsFalse()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(
+                    new VoxrSlotDefinition("weapon", new[] { "missiles" }),
+                    new VoxrSlotDefinition("target", new[] { "hotel one" })),
+                Commands(Cmd("launch", P("launch", "{weapon}", "target", "{target}"))));
+
+            // {target} unfilled -> score 0.5 < 0.6 -> not eligible.
+            Assert.IsFalse(parser.TryEagerCommit(Tok("launch missiles target"), null, 0.6f, 0.4f));
+        }
+
+        [Test]
+        public void TryEagerCommit_LeftoverTrailingTokens_ReturnsFalse()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(Cmd("cease_fire", P("cease", "fire"))));
+
+            // "cease fire" matches fully and is committable, but "now" is unconsumed,
+            // so the match does not span the whole buffer.
+            Assert.IsFalse(parser.TryEagerCommit(Tok("cease fire now"), null, 0.6f, 0.4f));
+        }
+
+        [Test]
+        public void TryEagerCommit_PrefixCommand_ReturnsFalse()
+        {
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("target", new[] { "hotel one" })),
+                Commands(
+                    Cmd("status", P("status")),
+                    Cmd("status_report", P("status", "report", "{target}"))));
+
+            Assert.IsFalse(parser.TryEagerCommit(Tok("status"), null, 0.6f, 0.4f),
+                "a prefix command must not eager-commit even though it matches fully");
+        }
+
+        // ---------- Tie-break parity with ParseInternal (Review MF-5) ----------
+
+        [Test]
+        public void TryEagerCommit_AgreesWithParseInternalSelection()
+        {
+            // ParseInternal fires "greet" for input "hello"; the eager gate must agree
+            // that this very command is NOT safe to commit early (it is a prefix of
+            // "hello there"). This guards the duplicated selection scan from drifting.
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(
+                    Cmd("greet", P("hello")),
+                    Cmd("greet_long", P("hello", "there"))));
+
+            var results = parser.Parse("hello");
+            Assert.AreEqual(1, results.Length);
+            Assert.AreEqual("greet", results[0].Command.Intent);
+            Assert.AreEqual(0, results[0].Command.MatchedPatternIndex);
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0), "greet is a prefix of greet_long");
+            Assert.IsFalse(parser.TryEagerCommit(Tok("hello"), null, 0.6f, 0.4f),
+                "eager verdict must match the non-committable selection ParseInternal made");
+        }
+    }
+}

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 using VoXR.Commands;
 
 namespace VoXR.Tests.Runtime
@@ -130,6 +133,91 @@ namespace VoXR.Tests.Runtime
                 Commands(Cmd("enter", P("enter", "{code}"))));
 
             Assert.IsFalse(parser.CanCommitEarly(0, 0), "min < max can absorb more digits");
+        }
+
+        // ---------- Cross-pattern word-level prefix (issue #25, review fix #1) ----------
+
+        [Test]
+        public void CrossSlotMultiWordValue_IsNotCommittable()
+        {
+            // "go {dir}" and "go {place}" have equal element counts, so the element-count
+            // prefix check misses them — but "go north" (a full match of the first) is a word-
+            // prefix of "go north pole" (a full match of the second), so the first must wait.
+            var parser = new VoxrCommandParser(
+                Slots(
+                    new VoxrSlotDefinition("dir", new[] { "north" }),
+                    new VoxrSlotDefinition("place", new[] { "north pole" })),
+                Commands(
+                    Cmd("go_dir", P("go", "{dir}")),
+                    Cmd("go_place", P("go", "{place}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0),
+                "\"go north\" is a word-prefix of \"go north pole\"");
+        }
+
+        [Test]
+        public void FixedWidthNumberSequence_WithWiderSibling_IsNotCommittable()
+        {
+            // Both commands end in a fixed-width number sequence. "dial 1 2 3" (a full match of
+            // n3) is a word-prefix of "dial 1 2 3 4 5" (a full match of n5), so the narrower
+            // command must wait. The wider one cannot be a prefix of the narrower, so it stays
+            // committable — the cardinal rule only forbids firing too early, not too late.
+            var parser = new VoxrCommandParser(
+                Slots(
+                    VoxrSlotDefinition.NumberSequence("n3", 3, 3),
+                    VoxrSlotDefinition.NumberSequence("n5", 5, 5)),
+                Commands(
+                    Cmd("dial3", P("dial", "{n3}")),
+                    Cmd("dial5", P("dial", "{n5}"))));
+
+            Assert.IsFalse(parser.CanCommitEarly(0, 0),
+                "the 3-digit command is a word-prefix of the 5-digit one");
+            Assert.IsTrue(parser.CanCommitEarly(1, 0),
+                "the 5-digit command is terminal and is not a prefix of the shorter sibling");
+        }
+
+        [Test]
+        public void SharedVerbDistinctValues_StillCommittable()
+        {
+            // The tight rule must not over-suppress: "select {item}" shares the verb "select"
+            // with "select all", but "all" is not a value of {item}, so "select red" can never
+            // grow into "select all". The slotted command stays eligible for eager commit.
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("item", new[] { "red" })),
+                Commands(
+                    Cmd("select_item", P("select", "{item}")),
+                    Cmd("select_all", P("select", "all"))));
+
+            Assert.IsTrue(parser.CanCommitEarly(0, 0),
+                "\"select red\" cannot be extended into \"select all\"");
+        }
+
+        // ---------- Optional-expansion guard (issue #25, review fix #2) ----------
+
+        [Test]
+        public void ManyOptionalElements_DisablesEagerCommitForWholeParser()
+        {
+            // ExpandOptionals enumerates 2^optionals concrete forms; past MaxOptionalExpansion
+            // (12) the parser refuses to analyse and disables eager commit for the whole command
+            // set rather than overflow or partially (and unsoundly) analyse a single pattern.
+            var noisy = Cmd("noisy", P("noisy",
+                "?a", "?b", "?c", "?d", "?e", "?f", "?g", "?h", "?i", "?j", "?k", "?l", "?m"));
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(noisy, Cmd("cease_fire", P("cease", "fire"))));
+
+            LogAssert.Expect(LogType.Warning, new Regex("more than 12 optional"));
+
+            bool overLimit = true, normal = true;
+            Assert.DoesNotThrow(() =>
+            {
+                overLimit = parser.CanCommitEarly(0, 0); // triggers the lazy precompute
+                normal = parser.CanCommitEarly(1, 0);
+            });
+
+            Assert.IsFalse(overLimit, "the over-limit pattern is disabled");
+            Assert.IsFalse(normal,
+                "a normal command in the same set is also disabled (whole-parser, never partial)");
         }
 
         [Test]


### PR DESCRIPTION
Closes #25

## What
Adds an opt-in `eagerFlushOnCompleteMatch` flag (default **off**) to `VoxrCommandRecogniser`. When enabled, the utterance buffer flushes and fires a command the instant the buffered speech forms a complete match that **cannot be extended or completed by more words**, instead of always waiting out `bufferWindow`. With the flag off, recognition timing is byte-for-byte unchanged.

- **Complete + unambiguous** → fires immediately (zero buffer latency).
- **Prefix of a longer command**, or a **trailing slot that could still grow** (multi-word enumerated values, variable-length number sequences) → keeps waiting the full window, so split-command recovery is preserved.
- **Split command** → fires as soon as its second half completes.

## Why
The buffer was purely time-driven (`Update` → `UtteranceBuffer.ShouldFlush`): a clean single-breath command incurred the entire `bufferWindow` delay (default 0.5s; 1.5–2.0s on Quest 3) even though nothing more was coming, because the buffer could not distinguish a complete command from the first half of a split one. Lowering `bufferWindow` trades latency for split-recovery — there is no fixed value good at both. This adds the missing completeness signal.

## How
- **`VoxrCommandParser`** precomputes a per-(command, pattern) `canCommitEarly` flag at construction: *terminal* (its trailing element can't grow — a required literal, a fixed-width number sequence, or an enumerated slot with no word-prefix-ambiguous values/aliases) **and** *not a prefix* of any other pattern (compared over optional-expanded forms, with slots treated conservatively as compatible). New `TryEagerCommit` runs a single best-match scan mirroring `ParseInternal`'s selection and only commits on a full-span, threshold-passing, committable match.
- **`VoxrCommandRecogniser.HandleResult`** does a non-destructive speculative parse (`UtteranceBuffer.PeekText`) and, when eligible, flushes early through the existing `FlushBuffer` → `ProcessParsedResultsCore` pipeline — so thresholds, debounce, pending/confirm and follow-up are unchanged. Skipped while a command is pending.
- Conservative throughout: any uncertainty falls back to the timer, so a command is never fired early when more speech could change the result. `ParseInternal` and the existing matcher/scoring are untouched.

## Validation
- [x] Static review (this is a bare UPM package — `Tests~` can't run standalone here): balanced braces, symbol/wiring checks, `ParseInternal` left untouched.
- [x] Parser unit tests (`VoxrEagerCommitTests`): terminality/prefix classification (literal, enumerated slot, prefix-of-another, same-command shorter pattern, trailing optional, leading-optional-in-other-command, extensible slot, alias word-prefix, number-sequence fixed vs variable, out-of-range), the `TryEagerCommit` gate, and tie-break parity with `ParseInternal`.
- [x] Recogniser PlayMode tests (`VoxrCommandRecogniserInjectionTests`): terminal command fires immediately; full slotted command fires; flag-off preserves buffering; prefix / extensible-slot commands wait; split command fires on completion.
- [x] **Run the test suites in a host Unity project** (EditMode + PlayMode) — cannot execute from this bare package.
- [ ] On-device (Quest) smoke test that perceived latency drops for clean commands (optional; not required for C# correctness).

Design note: a command that is *also* a prefix of a longer one, split by a pause longer than `bufferWindow`, cannot be both instant and correct under any time/parse strategy — documented in `KNOWN_LIMITATIONS.md`. Push-to-talk (`ReleaseTalk` → `FlushPendingBuffer`) removes the latency there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
