### PR TITLE
Release 1.2.2: opt-in eager flush on complete match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-05-29
+
 ### Added
 
 - Opt-in eager flush for the command recogniser. When `eagerFlushOnCompleteMatch` is enabled, the utterance buffer fires a recognised command the moment the buffered speech forms a complete match that cannot be extended or completed by further speech, instead of always waiting out `bufferWindow`. This removes the buffer latency (default 0.5s; 1.5–2.0s on Quest 3) for clean single-breath commands while preserving split-command recovery: a command that is a prefix of a longer one — or whose trailing slot could still grow (multi-word enumerated values, or a variable-length number sequence) — keeps waiting the full window. Split commands also fire as soon as their second half completes. Off by default, so existing timing is unchanged. One behavioural note when enabled: a terminal command marked `RequiresConfirmation` now enters its pending/confirmation state with zero added latency (it still does not fire until confirmed). ([#25](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/25))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.voxr",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "displayName": "VoXR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
Release prep for **v1.2.2**. Cuts the eager-flush feature (PR #26, closes #25) into a tagged release.

## Changes
- `package.json`: `1.2.1` → `1.2.2`
- `CHANGELOG.md`: moved the eager-flush entry from `[Unreleased]` under a dated `## [1.2.2] - 2026-05-29` heading

No source changes — the feature itself already landed via #26.

## Release steps
After merge, the **Release** workflow (`workflow_dispatch`) is triggered with `version=1.2.2`. It cuts `release/1.2.2` from `main`, strips `NativeBridge~/` + `Tests~/`, tags `v1.2.2`, and publishes the GitHub Release with notes pulled from this CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)