### PR TITLE
Release 1.3.0: automatic command debug session log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-25
+
 ### Added
 
 - Command debug results are now auto-exported to disk when Play Mode ends. Every `VoxrMatchDiagnostics` entry produced during a session — the full session, not the debug window's rolling 20-entry history — is written to `<project>/Library/VoxrDebugLogs/session-<timestamp>.json`, with the path logged to the Console. Each entry records the transcript, per-word confidences, active command sets, and every match attempt (intent, pattern, score vs `minScore`, aggregate confidence vs `minConfidence`, extracted slots, reject reason, accepted flag). The file is self-describing — schema version, package/Unity versions, and a `readme` field — so scripts or LLM tooling can analyse recognition behaviour after a playtest without reading the SDK source. Always on, no setup, and the debug window does not need to be open; the ten most recent sessions are retained and a session with no matches writes nothing. Test runs are skipped so they cannot evict real playtest sessions from the retention pool — batch mode (`-runTests`, CI) via `Application.isBatchMode`, and in-editor Test Runner runs via a `TestRunnerApi` callback that lives in its own assembly, compiled only when `com.unity.test-framework` is installed so the package takes no dependency on it. Editor-only and compiled out of builds, like the diagnostics it records. ([#28](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/28))
+
+### Fixed
+
+- Documentation stated a `bufferWindow` default of 1.5s, which had been lowered to 0.5s in code without the docs following. The API reference, command-recognition guide, troubleshooting guide, and `KNOWN_LIMITATIONS.md` now state the actual 0.5s default, preserving the v2.3 history and the empirical Quest 3 tuning notes. Note the Quest 3 *recommendation* still differs between the code tooltip (1.5s) and the docs/test data (2.0s); that remains open.
 
 ## [1.2.2] - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 | Version | Milestone |
 |---|---|
+| 1.3.0 | Automatic session debug log -- every Play Mode match exported to self-describing JSON for post-session analysis |
 | 1.2.0 | Zero-alloc byte-span parsing on the recognition hot path (breaking change to `vosk_bridge_get_result` native ABI) |
 | 1.1.0 | Removed n-best alternatives (breaking change to `VoxrResult` and native ABI) |
 | 1.0.0 | First stable release -- public API committed for the v1.x series |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.voxr",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "displayName": "VoXR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
Version bump only — no code changes. Cuts 1.3.0 from `main`.

## Why 1.3.0 and not 1.2.3

New user-facing feature, no breaking change, no API removal — a minor bump by semver. The feature is entirely editor-side (`Editor/` assembly plus a runtime hook inside `#if UNITY_EDITOR`), so a **shipped player build behaves identically to 1.2.2**.

## What's in it

- **`#28` — automatic command debug session log.** Every match of a Play Mode session exported to self-describing JSON in `Library/VoxrDebugLogs/`, for post-session analysis by scripts or LLM tooling. (PR #29, merged as `315230f`.)
- **`259b10b` — bufferWindow docs correction.** A docs-only fix that had been sitting unpushed on `main` since 29 May: the stated default was 1.5s where the code had long since moved to 0.5s. It carried no CHANGELOG entry of its own, so this PR records it under `### Fixed`.

## Changes here

| File | Change |
|---|---|
| `package.json` | `1.2.2` → `1.3.0` |
| `CHANGELOG.md` | `[Unreleased]` stamped as `## [1.3.0] - 2026-07-25`; added the `### Fixed` entry for the docs correction |
| `README.md` | Version-history row (the table tracks minor-version milestones, so no 1.2.1/1.2.2 rows exist and none were added) |

## Release-workflow preconditions — all verified locally

- [x] `package.json` version is exactly `1.3.0`
- [x] `CHANGELOG.md` contains a `## [1.3.0]` section
- [x] `Runtime/Plugins/Android/arm64-v8a/libvosk-bridge.so` present (55048 bytes)
- [x] Tag `v1.3.0` does not exist on origin
- [x] Branch `release/1.3.0` does not exist on origin
- [x] The workflow's `awk` notes extraction returns the Added + Fixed sections cleanly

## After you merge

I'll trigger `release.yml` with `version=1.3.0`, which cuts `release/1.3.0`, strips `NativeBridge~/` and `Tests~/`, tags `v1.3.0`, and publishes the GitHub Release. **Tags are immutable** — if the version number is wrong, say so before merging rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCt62L1mPHGeU6GWrRKpYy