### PR TITLE
Correct the Quest 3 bufferWindow recommendation in the tooltip (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `bufferWindow` Inspector tooltip recommended 1.5s on Quest 3 where every other source — `KNOWN_LIMITATIONS.md`, the README, the command-recognition and troubleshooting guides, and the command-recognition sample — recommends 2.0s. 1.5s sits below the ~1.9–2.1s inter-result gap measured on Quest 3, so the tooltip was recommending a window the project's own test matrices found insufficient; it appears to be a fossil of the v2.3 default rather than a Quest figure. The tooltip now says 2.0s and carries the measured gap plus the ~2.5s ceiling past which unrelated utterances start merging. Tooltip text only — no behaviour change, and the default remains 0.5s. ([#34](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/34))
+
 ## [1.3.0] - 2026-07-25
 
 ### Added

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -31,8 +31,10 @@ namespace VoXR.Commands
 
         [Tooltip("Time in seconds to wait for additional speech before parsing. " +
                  "Longer values recover split commands but add latency. " +
-                 "Default 0.5s matches typical PC latency; bump to 1.5s on Quest 3, " +
-                 "where VOSK adds ~0.5–1.0s to inter-result gaps. " +
+                 "Default 0.5s matches typical PC latency; use 2.0s on Quest 3, " +
+                 "where VOSK adds ~0.5–1.0s to inter-result gaps and the measured " +
+                 "gap between results runs ~1.9–2.1s. Past ~2.5s unrelated " +
+                 "utterances start merging. " +
                  "Set to 0 to disable buffering (v2.2 behaviour).")]
         [SerializeField] float bufferWindow = 0.5f;
 


### PR DESCRIPTION
Closes #34

## What

One string. The `bufferWindow` Inspector tooltip recommended **1.5s** on Quest 3; every other source recommends **2.0s**.

```diff
- "Default 0.5s matches typical PC latency; bump to 1.5s on Quest 3, " +
- "where VOSK adds ~0.5–1.0s to inter-result gaps. " +
+ "Default 0.5s matches typical PC latency; use 2.0s on Quest 3, " +
+ "where VOSK adds ~0.5–1.0s to inter-result gaps and the measured " +
+ "gap between results runs ~1.9–2.1s. Past ~2.5s unrelated " +
+ "utterances start merging. " +
```

## Why 2.0s is the right value

Six sources already said 2.0s — `KNOWN_LIMITATIONS.md`, `README.md`, the command-recognition and troubleshooting guides, the command-recognition sample, and the v2.3 CHANGELOG notes. Only the tooltip disagreed, and the tooltip is the surface a user tuning the field is most likely to actually read.

`KNOWN_LIMITATIONS.md` carries the measurement that settles it:

> On Quest 3 the gap measured between VOSK results is often ~1.9–2.1s, so any window shorter than that flushes before the second half arrives and the command is lost. […] even the former 1.5s default (v2.3) was marginal — just under the typical gap.

So 1.5s sits *below* the observed gap range: the tooltip was recommending a window the project's own test matrices (v2.3 Phase 4.1, v2.4 Phase 8.2) had already found insufficient. It looks like a fossil of the v2.3 **default**, carried into the tooltip as though it were a Quest figure.

The replacement also surfaces the two bounds that were previously only in `KNOWN_LIMITATIONS.md` — the measured gap (which is *why* 2.0s beats 1.5s) and the ~2.5s ceiling past which cross-command bleed starts. The Inspector is where someone tuning this value is standing.

## Scope

Tooltip text only. **No behaviour change, and the default remains `0.5f`.**

Deliberately untouched:

- **`KNOWN_LIMITATIONS.md`** — its entry is about the *default* being too short on Quest 3, which is still true (the default is still 0.5s). That limitation is real and separate from this disagreement.
- **The twelve `BufferWindow = 1.5f` lines in `Tests~/`** — arbitrary test values for exercising buffering behaviour, unrelated to any Quest recommendation. Changing them would be churn.
- **`Documentation~/api/command-recogniser.md`** — says "raise it on Quest 3" and links to troubleshooting without naming a number, so it was never in disagreement.

## Validation

- [x] **EditMode 97/97**, **PlayMode 240/240** — matches baseline exactly
- [x] No `error CS` in either log
- [x] UTF-8 integrity confirmed — the en-dashes are `E2 80 93` (U+2013) at the byte level, `iconv` round-trips clean, no `â€"` mojibake. This was the realistic failure mode for a non-ASCII multi-line concatenated literal, so it was checked explicitly rather than assumed.

No device check needed — a `[Tooltip]` is editor metadata and never reaches a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCt62L1mPHGeU6GWrRKpYy