### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-28
+
 ### Added
 
 - `prefixHoldSeconds` on `VoxrCommandRecogniser` — a separate, shorter hold for the "complete match, but still extendable" state under `eagerFlushOnCompleteMatch`. Eager flush deliberately refuses to commit a command that is a prefix of a longer one (`orient to heading {heading}` prefixes `orient to heading {heading} mark {mark_sign} {mark}`) or whose trailing slot could still grow, so the common plain form paid the *entire* buffer window — 2.0s of dead air on Quest 3 — for an ambiguity a continuing speaker resolves almost immediately. The refusal to commit early is correct and unchanged; what changes is how long the buffer then waits for that continuation. When `prefixHoldSeconds` is above 0, a held complete match flushes after that much silence instead of the full `bufferWindow`, so the plain form fires in ~0.5–0.8s while the extended form stays speakable. The hold only ever shortens the wait — values above `bufferWindow` are ignored — and it applies solely to a buffer that already parses as one complete, confident, whole-buffer command: partial speech mid-split-command, unmatched speech, and grammars too complex for the eager precompute to analyse all keep the full window. The verdict is re-derived on every VOSK result, so a continuation that arrives restores the full window for the rest of the utterance. Default `0` keeps the previous behaviour exactly. ([#32](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/32))

--- a/Documentation~/getting-started.md
+++ b/Documentation~/getting-started.md
@@ -15,7 +15,7 @@ Everything you need to install the SDK, set up a VOSK model, and get your first 
 To pin a specific version (recommended):
 
 ```
-https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.0.0
+https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.4.0
 ```
 
 ### Via manifest.json
@@ -25,7 +25,7 @@ Add to `Packages/manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.voxr": "https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.0.0"
+    "com.jinwoo1601.voxr": "https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.4.0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Offline speech recognition and voice command parsing for Unity XR applications. 
 **Pinned version:**
 
 ```
-https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.2.0
+https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.4.0
 ```
 
 **Via manifest.json:**
@@ -65,7 +65,7 @@ https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.2.0
 ```json
 {
   "dependencies": {
-    "com.jinwoo1601.voxr": "https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.2.0"
+    "com.jinwoo1601.voxr": "https://github.com/jinwoo1601/VoXR-Speech-Recognition.git#v1.4.0"
   }
 }
 ```
@@ -225,6 +225,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 | Version | Milestone |
 |---|---|
+| 1.4.0 | Latency and accuracy tuning for command recognition -- `prefixHoldSeconds`, `skippedWordPenalty`, and vocabulary-aware eager-flush eligibility |
 | 1.3.0 | Automatic session debug log -- every Play Mode match exported to self-describing JSON for post-session analysis |
 | 1.2.0 | Zero-alloc byte-span parsing on the recognition hot path (breaking change to `vosk_bridge_get_result` native ABI) |
 | 1.1.0 | Removed n-best alternatives (breaking change to `VoxrResult` and native ABI) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jinwoo1601.voxr",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "displayName": "VoXR Speech Recognition",
   "description": "Offline speech recognition for XR applications. Wraps the VOSK toolkit behind a Unity-native C# API with native audio capture via AudioRecord JNI on Android arm64, plus live microphone capture in the Unity Editor on Windows for iteration without a Quest device.",
   "unity": "6000.0",


### PR DESCRIPTION
Version bump for **v1.4.0**. Prep-only PR — no code changes; the release itself is cut by `release.yml` after this merges.

## Contents

Everything merged to `main` since `v1.3.0`:

| Issue | Change |
|---|---|
| [#32](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/32) | **Added** `prefixHoldSeconds` — shorter hold for complete-but-extendable matches under eager flush |
| [#31](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/31) | **Changed** skipped leading words now count against the match score (`skippedWordPenalty`, default `1.0`) |
| [#33](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/33) | **Changed** eager-flush eligibility is now vocabulary-aware for slot-vs-literal prefix compatibility |
| [#34](https://github.com/jinwoo1601/VoXR-Speech-Recognition/issues/34) | **Fixed** Quest 3 `bufferWindow` tooltip recommendation (1.5s → 2.0s) |

## Why minor, not patch

Two new public fields on `VoxrCommandRecogniser` (`prefixHoldSeconds`, `skippedWordPenalty`) plus a default-on matching behaviour change from #31 — new surface, no API breakage.

## Changes in this PR

- `package.json` — `1.3.0` → `1.4.0`
- `CHANGELOG.md` — `[Unreleased]` entries rolled under `## [1.4.0] - 2026-07-28`, empty `[Unreleased]` left on top
- `README.md` — version-table row for 1.4.0
- Install pins rolled to `#v1.4.0` — these had drifted and are **not** strictly part of the bump: `README.md` was still pinned at `#v1.2.0` and `Documentation~/getting-started.md` at `#v1.0.0`, neither updated for 1.2.1/1.2.2/1.3.0

## Verification

Full suite run against `main` @ `b56a095` in the `VoXR TestGround` host project (Unity 6000.4.7f1):

- **EditMode — 97/97 passed**, 0 failed
- **PlayMode — 261/261 passed**, 0 failed

`NativeBridge~/` is unchanged since the last release, so the CMake build was not re-run. On-device Quest verification is the documented human-only step and has **not** been performed.

Simulated the `release.yml` preconditions locally — version match, `## [1.4.0]` section present, `v1.4.0` tag and `release/1.4.0` branch both free, prebuilt `.so` present — all pass.

## After merge

```
gh workflow run release.yml -f version=1.4.0
```