### PR TITLE
Fail the release if docs' install pins are stale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,10 @@ name: Release
 #   1. Bump "version" in package.json to X.Y.Z
 #   2. Move the CHANGELOG.md "## [Unreleased]" entries under a new
 #      "## [X.Y.Z] - <date>" heading
-#   3. Merge that to `main`
+#   3. Roll the docs' install pins (`…VoXR-Speech-Recognition.git#vX.Y.Z`)
+#      to the new version — validated below, since these silently drifted
+#      three releases running (1.2.1 through 1.3.0)
+#   4. Merge that to `main`
 #
 # This workflow then cuts the release from `main`:
 #   - creates branch `release/X.Y.Z`
@@ -61,6 +64,20 @@ jobs:
           if ! grep -qF "## [$VERSION]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [$VERSION]' section."; exit 1
           fi
+
+          # Every pinned install URL in the docs must point at the version being
+          # released — a stale pin sends new consumers to an older package.
+          # CHANGELOG.md is excluded: its entries are a historical record and may
+          # legitimately name older versions.
+          STALE_PINS="$(git grep -nE 'VoXR-Speech-Recognition\.git#v[0-9]+\.[0-9]+\.[0-9]+' \
+                          -- '*.md' ':!CHANGELOG.md' \
+                        | grep -vF "VoXR-Speech-Recognition.git#v$VERSION" || true)"
+          if [[ -n "$STALE_PINS" ]]; then
+            echo "::error::Install pins still point at an older release. Roll them to #v$VERSION on main, then re-run."
+            echo "$STALE_PINS"
+            exit 1
+          fi
+
           if [[ ! -f "Runtime/Plugins/Android/arm64-v8a/libvosk-bridge.so" ]]; then
             echo "::error::Prebuilt Runtime/Plugins/Android/arm64-v8a/libvosk-bridge.so is missing."; exit 1
           fi


### PR DESCRIPTION
Follow-up to the v1.4.0 release. CI-only change — no package code touched.

## Problem

The docs pin an install URL that must be rolled by hand each release, and nothing enforced it. Replaying the check over past tags shows the drift ran for **three consecutive releases**:

| Release | `README.md` | `Documentation~/getting-started.md` |
|---|---|---|
| v1.2.1 | `#v1.2.0` | `#v1.0.0` |
| v1.2.2 | `#v1.2.0` | `#v1.0.0` |
| v1.3.0 | `#v1.2.0` | `#v1.0.0` |

Anyone following the getting-started guide was pinned three minor versions behind the release they'd just read about. Rolled to `#v1.4.0` during the last release; this stops it recurring.

## Change

One precondition added to the existing `Validate release preconditions` step: grep every tracked `*.md` for a pinned package URL, fail if any names a version other than the one being released, and print the offending `file:line`.

- **Generic, not a file list** — a doc added later is covered without touching the workflow.
- **`CHANGELOG.md` excluded** — its entries are a historical record and may legitimately name older versions.
- Header comment updated so the documented manual prep matches what's now enforced.

## Verification

Ran the real step (extracted from the YAML, GH expression substituted) against scratch worktrees simulating a 1.5.0 release:

| Case | Result |
|---|---|
| Pins stale at `#v1.4.0` | blocks, exit 1, lists all 4 offending lines |
| Pins rolled to `#v1.5.0` | passes |
| No pins anywhere (docs reorganised) | passes — does not trip `set -euo pipefail` |

That last case is the one worth noting: `git grep` exits 1 on no-match, so without the trailing `|| true` the step would have crashed rather than passed. Also confirmed the YAML still parses and the step body passes `bash -n`.

## Note on scope

I did **not** add a matching check for the README version table. That table lists milestones, not every release — 1.2.1 and 1.2.2 deliberately have no row — so a hard check there would produce false failures on patch releases.