### PR TITLE
Add PlayMode coverage for VoxrPushToTalkController.OnApplicationPause (#49)

### DIFF
--- a/Runtime/VoxrSpeechRecogniser.cs
+++ b/Runtime/VoxrSpeechRecogniser.cs
@@ -87,7 +87,16 @@ namespace VoXR
             }
         }
 
-        public bool IsRecognising
+        public bool IsRecognising => IsRecognisingCore;
+
+        // Test seam (issue #49). VoxrPushToTalkController's lifecycle state machine
+        // reads recognition state and drives start/stop only through these three
+        // internal virtual members, so a test double can subclass this component and
+        // count the calls — "resume must not double-start" is a call-count assertion
+        // no IsRecognising reading can express. Internal keeps the public surface
+        // free of an extension point; overriding needs the InternalsVisibleTo grant
+        // in Runtime/AssemblyInfo.cs.
+        internal virtual bool IsRecognisingCore
         {
             get
             {
@@ -198,7 +207,9 @@ namespace VoXR
             IsModelReady = false;
         }
 
-        public void StartRecognition()
+        public void StartRecognition() => StartRecognitionCore();
+
+        internal virtual void StartRecognitionCore()
         {
             _ = StartRecognitionAsync();
         }
@@ -282,7 +293,9 @@ namespace VoXR
 #endif
         }
 
-        public void StopRecognition()
+        public void StopRecognition() => StopRecognitionCore();
+
+        internal virtual void StopRecognitionCore()
         {
             _isRecognising = false;
 #if UNITY_EDITOR_WIN

--- a/Tests~/Runtime/VoxrPushToTalkPauseTests.cs
+++ b/Tests~/Runtime/VoxrPushToTalkPauseTests.cs
@@ -1,0 +1,329 @@
+// ============================================================================
+// Purpose:  PlayMode tests for the VoxrPushToTalkController.OnApplicationPause state machine
+// Layer:    Tests.Runtime
+// Owns:     VoxrPushToTalkPauseTests (public class), FakeSpeechRecogniser (nested test double)
+// Depends:  VoxrPushToTalkController, VoxrSpeechRecogniser, VoxrListeningMode
+// ============================================================================
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace VoXR.Tests.Runtime
+{
+    public class VoxrPushToTalkPauseTests
+    {
+        // Subclasses the real component through the internal seam
+        // (VoxrSpeechRecogniser.IsRecognisingCore/StartRecognitionCore/StopRecognitionCore)
+        // so the controller cannot tell the difference, while the test counts calls
+        // and stages recognition state. No override calls base, so nothing here
+        // touches a model, the native bridge, or a microphone.
+        sealed class FakeSpeechRecogniser : VoxrSpeechRecogniser
+        {
+            internal int StartCalls { get; private set; }
+            internal int StopCalls { get; private set; }
+
+            // What IsRecognising reports. Settable so a test can stage a session the
+            // controller did not start itself.
+            internal bool Running { get; set; }
+
+            internal override bool IsRecognisingCore => Running;
+
+            internal override void StartRecognitionCore()
+            {
+                StartCalls++;
+                Running = true;
+            }
+
+            internal override void StopRecognitionCore()
+            {
+                StopCalls++;
+                Running = false;
+            }
+
+            internal void ResetCalls()
+            {
+                StartCalls = 0;
+                StopCalls = 0;
+            }
+        }
+
+        GameObject _recogniserGo;
+        GameObject _controllerGo;
+        FakeSpeechRecogniser _fake;
+        VoxrPushToTalkController _controller;
+
+        int _startedCount;
+        int _endedCount;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _recogniserGo = new GameObject("PauseTestFakeRecogniser");
+            _fake = _recogniserGo.AddComponent<FakeSpeechRecogniser>();
+
+            // The controller lives on its own GameObject so SendMessage("OnApplicationPause")
+            // reaches the state machine under test and nothing else.
+            _controllerGo = new GameObject("PauseTestController");
+            _controller = _controllerGo.AddComponent<VoxrPushToTalkController>();
+            _controller.SpeechRecogniser = _fake;
+            _controller.InitialiseOnStart = false;
+
+            _startedCount = 0;
+            _endedCount = 0;
+            _controller.OnTalkStarted.AddListener(() => _startedCount++);
+            _controller.OnTalkEnded.AddListener(() => _endedCount++);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_controllerGo != null)
+                Object.DestroyImmediate(_controllerGo);
+            if (_recogniserGo != null)
+                Object.DestroyImmediate(_recogniserGo);
+        }
+
+        // -------- Drivers --------
+
+        // OnApplicationPause is private, so drive it the way the OS does.
+        void Pause() => _controllerGo.SendMessage("OnApplicationPause", true);
+
+        void Resume() => _controllerGo.SendMessage("OnApplicationPause", false);
+
+        // Continuous mode is how _wantRecognising gets set without a button press.
+        // The mode setter starts recognition, so call counts are cleared afterwards
+        // and every assertion below is absolute.
+        void ArrangeContinuousAndRunning()
+        {
+            _controller.ListeningMode = VoxrListeningMode.Continuous;
+            Assume.That(
+                _fake.Running,
+                Is.True,
+                "Precondition: switching to continuous mode should have started recognition"
+            );
+            _fake.ResetCalls();
+        }
+
+        // -------- Pause --------
+
+        [Test]
+        public void Pause_WhileRecognisingInContinuousMode_StopsRecognition()
+        {
+            ArrangeContinuousAndRunning();
+
+            Pause();
+
+            Assert.AreEqual(
+                1,
+                _fake.StopCalls,
+                "Pause while recognising must stop recognition exactly once"
+            );
+            Assert.IsFalse(_fake.Running);
+            Assert.AreEqual(0, _fake.StartCalls);
+            Assert.AreEqual(
+                0,
+                _endedCount,
+                "Pause is a lifecycle event — OnTalkEnded must not fire"
+            );
+        }
+
+        [Test]
+        public void Pause_WhilePushToTalkIdle_DoesNotStopAndPreservesState()
+        {
+            Assume.That(_controller.ListeningMode, Is.EqualTo(VoxrListeningMode.PushToTalk));
+            Assume.That(
+                _fake.Running,
+                Is.False,
+                "Precondition: an untouched push-to-talk controller must not be recognising"
+            );
+
+            Pause();
+
+            Assert.AreEqual(0, _fake.StopCalls, "Pause must not stop what was never started");
+            Assert.AreEqual(0, _fake.StartCalls);
+
+            Resume();
+
+            Assert.AreEqual(
+                0,
+                _fake.StartCalls,
+                "Resume must not start recognition the user never asked for"
+            );
+
+            // _wantRecognising is private; a press that still takes effect proves the
+            // pause/resume pair left it false rather than corrupting it.
+            _controller.PressTalk();
+
+            Assert.AreEqual(
+                1,
+                _fake.StartCalls,
+                "PressTalk after an idle pause/resume cycle must still start recognition"
+            );
+            Assert.AreEqual(1, _startedCount);
+        }
+
+        [Test]
+        public void Pause_WithNullRecogniser_IsNoOp()
+        {
+            _controller.SpeechRecogniser = null;
+
+            Assert.DoesNotThrow(() =>
+            {
+                Pause();
+                Resume();
+            });
+            Assert.AreEqual(0, _fake.StartCalls);
+            Assert.AreEqual(0, _fake.StopCalls);
+        }
+
+        // -------- Resume --------
+
+        [Test]
+        public void Resume_WithWantRecognisingSet_RestartsRecognition()
+        {
+            ArrangeContinuousAndRunning();
+            Pause();
+            Assume.That(
+                _fake.Running,
+                Is.False,
+                "Precondition: pause should have stopped recognition"
+            );
+            _fake.ResetCalls();
+
+            Resume();
+
+            Assert.AreEqual(
+                1,
+                _fake.StartCalls,
+                "Resume must restart recognition when the user still wants it"
+            );
+            Assert.IsTrue(_fake.Running);
+            Assert.AreEqual(
+                1,
+                _startedCount,
+                "Resume is a lifecycle event — OnTalkStarted must not re-fire "
+                    + "(the 1 is the continuous-mode switch)"
+            );
+        }
+
+        [Test]
+        public void Resume_WhenAlreadyRecognising_DoesNotDoubleStart()
+        {
+            // A resume that arrives while the session is still up — the guard at
+            // VoxrPushToTalkController.cs:144 is the only thing preventing a second
+            // native start, and only a call count can prove it held.
+            ArrangeContinuousAndRunning();
+
+            Resume();
+
+            Assert.AreEqual(
+                0,
+                _fake.StartCalls,
+                "Resume must not start a second session over a running one"
+            );
+            Assert.IsTrue(_fake.Running);
+            Assert.AreEqual(0, _fake.StopCalls);
+        }
+
+        [Test]
+        public void PauseResume_WhilePushToTalkHeld_StopsThenRestarts()
+        {
+            _controller.PressTalk();
+            Assume.That(
+                _fake.Running,
+                Is.True,
+                "Precondition: PressTalk should have started recognition"
+            );
+            _fake.ResetCalls();
+
+            Pause();
+
+            Assert.AreEqual(
+                1,
+                _fake.StopCalls,
+                "Pause while the talk button is held must stop capture"
+            );
+            Assert.IsFalse(_fake.Running);
+
+            Resume();
+
+            Assert.AreEqual(1, _fake.StartCalls, "Resume must restore the still-held talk session");
+            Assert.IsTrue(_fake.Running);
+            Assert.AreEqual(
+                1,
+                _startedCount,
+                "A lifecycle pause/resume must not re-fire OnTalkStarted"
+            );
+            Assert.AreEqual(0, _endedCount, "A lifecycle pause/resume must not fire OnTalkEnded");
+        }
+
+        // -------- Interaction with the Update() permission-race reconciliation --------
+
+        [UnityTest]
+        public IEnumerator Resume_ThenUpdate_ReconcilerLeavesTheResumedSessionRunning()
+        {
+            ArrangeContinuousAndRunning();
+            Pause();
+            _fake.ResetCalls();
+
+            Resume();
+            Assume.That(
+                _fake.StartCalls,
+                Is.EqualTo(1),
+                "Precondition: resume should have restarted"
+            );
+
+            // Let Update() run the reconciliation (VoxrPushToTalkController.cs:149-155).
+            yield return null;
+            yield return null;
+
+            Assert.AreEqual(
+                0,
+                _fake.StopCalls,
+                "The reconciler must not stop a session the resume just restarted"
+            );
+            Assert.IsTrue(_fake.Running);
+            Assert.AreEqual(
+                1,
+                _fake.StartCalls,
+                "The reconciler must not start a second session either"
+            );
+        }
+
+        [UnityTest]
+        public IEnumerator PauseResume_WhileIdleWithRecogniserRunning_ReconcilerStopsItNextFrame()
+        {
+            // Stages the Android mic-permission race the reconciler exists for: the
+            // permission coroutine fired a native start after the user already
+            // released, so the recogniser is running while _wantRecognising is false.
+            _fake.Running = true;
+            _fake.ResetCalls();
+
+            Pause();
+
+            Assert.AreEqual(
+                0,
+                _fake.StopCalls,
+                "Pause keys off _wantRecognising, not the recogniser's own state"
+            );
+
+            Resume();
+
+            Assert.AreEqual(
+                0,
+                _fake.StartCalls,
+                "Resume must not adopt a session the user never asked for"
+            );
+
+            yield return null;
+
+            Assert.AreEqual(
+                1,
+                _fake.StopCalls,
+                "The reconciler must still stop the orphaned session on the next frame"
+            );
+            Assert.IsFalse(_fake.Running);
+        }
+    }
+}


### PR DESCRIPTION
Closes #49

Tier A of the locked automated-verification design (`Planning~/design-docs/automated-verification.md` §5, routed to the issue lane by its DR-1). Tiers B (#50) and C (#51) are already merged; A was scheduled first and slipped.

## Mechanism decision

The issue left the observation mechanism open: **(a)** drive a real initialised recogniser and assert `IsRecognising` transitions, or **(b)** add a minimal internal seam. **Decided (b)**, for a reason sharper than "needs a mic in batchmode":

- **Two of the five required cases are call-count assertions, which no `IsRecognising` reading can express.** "Resume when already recognising → no double-start" and "pause while idle → no stop call" are about calls the controller must *not* make. `IsRecognising` is a bool: after a correct resume and after a double-start it reads `true` either way. Mechanism (a) cannot distinguish them, even with a perfectly working recogniser and a real microphone.
- `StartRecognition()` is fire-and-forget (`_ = StartRecognitionAsync()`) and awaits `InitialiseAsync()` when uninitialised, so under (a) a pause/resume assertion would race model extraction. Tier B's `StartPlayback` seam does not rescue this: playback is armed directly on `EditorMicBackend` and bypasses `StartRecognition()` entirely, so it cannot make the controller's own start path observable.

## What

**Seam — `Runtime/VoxrSpeechRecogniser.cs` (+16/−3).** `IsRecognising`, `StartRecognition()` and `StopRecognition()` now delegate to three new `internal virtual` members `IsRecognisingCore` / `StartRecognitionCore()` / `StopRecognitionCore()`; the existing bodies moved into them unchanged.

- Public signatures and runtime behaviour are byte-identical — pure indirection. No new public API, and no new public extension point: the overridable surface is `internal`, reachable only through the `InternalsVisibleTo` grants already in `Runtime/AssemblyInfo.cs`. The class was already unsealed (`public class VoxrSpeechRecogniser`), so nothing was unsealed for this.
- **The controller is not touched.** The state machine under test ships exactly as tested — that is why the seam went on the collaborator rather than on `VoxrPushToTalkController` (extract-and-override there would have changed the code under test) and rather than on an internal control interface (a second, interface-typed field alongside `[SerializeField] VoxrSpeechRecogniser` can desync, and Unity's fake-null semantics make `== null` unreliable through an interface reference to a destroyed component).

**Tests — `Tests~/Runtime/VoxrPushToTalkPauseTests.cs` (new, 8 PlayMode tests).** A nested `FakeSpeechRecogniser : VoxrSpeechRecogniser` overrides the three cores to count `Start`/`Stop` calls and to stage what `IsRecognising` reports. No override calls `base`, so no test touches a model, the native bridge, or a microphone; the suite is deterministic and platform-agnostic. `OnApplicationPause` is driven via `SendMessage("OnApplicationPause", true/false)` per the issue, on a GameObject holding only the controller.

The five cases from the issue map to tests as follows:

| Issue case | Test |
|---|---|
| Pause while recognising (continuous) → stops | `Pause_WhileRecognisingInContinuousMode_StopsRecognition` |
| Resume with `_wantRecognising` set → restarts | `Resume_WithWantRecognisingSet_RestartsRecognition` |
| Resume when already recognising → no double-start | `Resume_WhenAlreadyRecognising_DoesNotDoubleStart` |
| Pause while not recognising (PTT idle) → no stop, no corruption | `Pause_WhilePushToTalkIdle_DoesNotStopAndPreservesState` |
| Resume ordering vs the `Update()` reconciliation (`:149-155`) | `Resume_ThenUpdate_ReconcilerLeavesTheResumedSessionRunning` **and** `PauseResume_WhileIdleWithRecogniserRunning_ReconcilerStopsItNextFrame` |

Plus two that fell out of the same fixture: `Pause_WithNullRecogniser_IsNoOp` (the `:135` guard) and `PauseResume_WhilePushToTalkHeld_StopsThenRestarts` (the realistic doff-while-holding path, and the other way `_wantRecognising` becomes true).

Two notes on how the assertions are made:

- The reconciliation case is covered in **both** directions, because "doesn't fight the reconciler" has two failure modes: the reconciler must not stop a session the resume just restarted (`_wantRecognising == true`), and it must still stop an orphaned session after an idle pause/resume (`_wantRecognising == false`, recogniser running — the staged permission-race state). Both are `[UnityTest]` so real frames elapse and `Update()` actually runs.
- `_wantRecognising` is private, so "no state corruption" is proved behaviourally: after an idle pause/resume, a subsequent `PressTalk()` must still start recognition — the same indirect-probe idiom the existing `OnDisable_InContinuousMode_PreservesWantRecognisingFlag` test uses.

The lifecycle-silence contract documented in `Documentation~/push-to-talk.md:79` (resume must not re-fire `OnTalkStarted`/`OnTalkEnded`) is now asserted rather than assumed.

## Validation

- [x] **PlayMode: 304 tests, 0 failures, 0 skipped** (Unity exit 0) — host project `VoXR TestGround`, Unity 6000.4.7f1, batchmode.
- [x] **EditMode: 116 tests, 0 failures, 0 skipped** (Unity exit 0) — same host project.
- [x] All 8 new tests confirmed **present and passing** in the PlayMode result XML — the `VoxrPushToTalkPauseTests` fixture reports `total=8 passed=8 failed=0`. Checked by name, because a fixture that failed to compile would be *absent* from the XML rather than red.
- [x] Baseline before this change was 116 EditMode + 296 PlayMode; the delta is 296 → 304 PlayMode and EditMode unchanged — the 8 new tests and nothing else.
- [x] Two compile-time risks in this approach were unknowns before the run and are now settled empirically, not assumed: `internal override` **does** bind across the `InternalsVisibleTo` boundary under Unity's Roslyn (no CS0507/CS0115/CS0122; the test assembly rebuilt and ran), and `AddComponent<T>()` **does** work for a private *nested* MonoBehaviour subclass in a file whose name doesn't match the class (Unity's filename rule constrains serialization-based loading, not generic `AddComponent`).
- [ ] **On-device (Quest) check not needed for this PR, and deliberately not claimed.** Whether Android actually *delivers* `OnApplicationPause` on HMD doff or system-menu entry is Tier D's lifecycle test (design §8.3.4), explicitly out of scope per the issue's scope note. This PR verifies the C# state machine only. That split is the point of landing A before D: a later Tier D failure isolates to callback *delivery* rather than state-machine *logic*.

No `NativeBridge~/` change, so no bridge rebuild and no `.so` to commit.

**No `CHANGELOG.md` entry**, deliberately: public API, public behaviour and the shipped package are unchanged (`Tests~/` is stripped at release, and the seam is `internal`), so there is nothing user-facing to record. Flagging it so the omission reads as a decision rather than an oversight.

## Follow-ups noticed, not fixed here

- `Documentation~/push-to-talk.md:75` says the permission-race guard "cannot fire in the editor test runner — without the native DLL, `IsRecognising` is always false … Verification is manual, on a Quest device". That was already imprecise before this PR (the Windows editor backend can report `IsRecognising == true`), and this PR now covers the guard's *logic* in the editor — while the real dialog race still needs a device, since the permission coroutine is Android-only. Left alone to keep this diff surgical; worth a one-line issue if you want the doc tightened.
- The seam is deliberately scoped to the three members Tier A needs. If Tier D's rig wants the same interception for observability (e.g. asserting the controller's calls on-device), it extends this pattern rather than replacing it — but I have not designed for that here, and no Tier D requirement exists yet.
