### PR TITLE
Tidy the #49 pause-test fixture per PR #52 review (#53)

### DIFF
--- a/Tests~/Runtime/VoxrPushToTalkPauseTests.cs
+++ b/Tests~/Runtime/VoxrPushToTalkPauseTests.cs
@@ -5,6 +5,7 @@
 // Depends:  VoxrPushToTalkController, VoxrSpeechRecogniser, VoxrListeningMode
 // ============================================================================
 using System.Collections;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -16,8 +17,18 @@ namespace VoXR.Tests.Runtime
         // Subclasses the real component through the internal seam
         // (VoxrSpeechRecogniser.IsRecognisingCore/StartRecognitionCore/StopRecognitionCore)
         // so the controller cannot tell the difference, while the test counts calls
-        // and stages recognition state. No override calls base, so nothing here
-        // touches a model, the native bridge, or a microphone.
+        // and stages recognition state.
+        //
+        // Overriding the cores is not on its own what keeps this fixture off the model,
+        // the native bridge and the microphone. Inertness rests on all three of:
+        //   - no override calling base, so nothing the seam covers reaches native code;
+        //   - the empty OnDestroy() below, because a base class's privately-declared
+        //     Unity messages still run on a subclass and the real one releases native
+        //     resources (benign only under UNITY_EDITOR_WIN, a live
+        //     vosk_bridge_destroy() P/Invoke off it). The base Update() needs no such
+        //     shim — it returns early while the base's own _isRecognising stays false;
+        //   - SetUp's InitialiseOnStart = false, since Initialise()/InitialiseAsync()/
+        //     StartRecognitionAsync() are public non-virtual and the seam misses them.
         sealed class FakeSpeechRecogniser : VoxrSpeechRecogniser
         {
             internal int StartCalls { get; private set; }
@@ -46,6 +57,11 @@ namespace VoXR.Tests.Runtime
                 StartCalls = 0;
                 StopCalls = 0;
             }
+
+            // Keeps the base's private OnDestroy — and its ReleaseNativeResources() call
+            // (VoxrSpeechRecogniser.cs:515) — off this double. No `new` keyword: the base
+            // declaration is private, so nothing is being hidden as far as C# is concerned.
+            void OnDestroy() { }
         }
 
         GameObject _recogniserGo;
@@ -67,6 +83,8 @@ namespace VoXR.Tests.Runtime
             _controllerGo = new GameObject("PauseTestController");
             _controller = _controllerGo.AddComponent<VoxrPushToTalkController>();
             _controller.SpeechRecogniser = _fake;
+            // Load-bearing, not tidiness: Initialise() is public and non-virtual, so the
+            // seam does not cover it. Without this, Start() loads the real model.
             _controller.InitialiseOnStart = false;
 
             _startedCount = 0;
@@ -91,16 +109,32 @@ namespace VoXR.Tests.Runtime
 
         void Resume() => _controllerGo.SendMessage("OnApplicationPause", false);
 
+        // Same message, called directly. Only the null-guard test needs this: SendMessage
+        // may log a receiver exception rather than propagate it, which would leave
+        // Assert.DoesNotThrow unable to see the very throw it exists to rule out.
+        // Reflection's TargetInvocationException wrapper still fails DoesNotThrow.
+        void PauseDirect(bool paused) =>
+            typeof(VoxrPushToTalkController)
+                .GetMethod("OnApplicationPause", BindingFlags.Instance | BindingFlags.NonPublic)
+                .Invoke(_controller, new object[] { paused });
+
         // Continuous mode is how _wantRecognising gets set without a button press.
         // The mode setter starts recognition, so call counts are cleared afterwards
         // and every assertion below is absolute.
+        //
+        // Assert rather than Assume, unlike the other preconditions in this file: this is
+        // the only check anywhere in Tests~ that continuous mode starts recognition at all.
+        // VoxrPushToTalkController.cs:59 is a separate statement from the :60 event that
+        // the sibling ListeningMode_SetToContinuous_FiresOnTalkStarted covers, so deleting
+        // :59 is invisible everywhere else. An unsatisfied Assume reports Inconclusive,
+        // which this project's failed="0" green criterion would report as a pass.
         void ArrangeContinuousAndRunning()
         {
             _controller.ListeningMode = VoxrListeningMode.Continuous;
-            Assume.That(
+            Assert.That(
                 _fake.Running,
                 Is.True,
-                "Precondition: switching to continuous mode should have started recognition"
+                "Switching to continuous mode must start recognition"
             );
             _fake.ResetCalls();
         }
@@ -166,15 +200,20 @@ namespace VoXR.Tests.Runtime
         [Test]
         public void Pause_WithNullRecogniser_IsNoOp()
         {
+            // The guard at VoxrPushToTalkController.cs:135 only carries weight when the
+            // user still wants recognition: both branches of the state machine are gated
+            // on _wantRecognising (:139, :144), so from the PushToTalk-idle default this
+            // test would pass with the whole method body deleted. Arrange the wanting
+            // state first, then drop the reference — now deleting :135 dereferences null
+            // on the pause branch and again on the resume branch.
+            ArrangeContinuousAndRunning();
             _controller.SpeechRecogniser = null;
 
             Assert.DoesNotThrow(() =>
             {
-                Pause();
-                Resume();
+                PauseDirect(true);
+                PauseDirect(false);
             });
-            Assert.AreEqual(0, _fake.StartCalls);
-            Assert.AreEqual(0, _fake.StopCalls);
         }
 
         // -------- Resume --------


### PR DESCRIPTION
Closes #53

## What

Four test-power and rationale-accuracy defects in `Tests~/Runtime/VoxrPushToTalkPauseTests.cs`, confirmed by PR #52's review and merged unfixed. **No production code changes** — the diff touches exactly one test file.

1. **`Pause_WithNullRecogniser_IsNoOp` was vacuous.** `SetUp` leaves the controller in its `PushToTalk` default, so `_wantRecognising` is false and both branches of `OnApplicationPause` short-circuit before ever dereferencing the recogniser — the test passed with the entire method body deleted. It now calls `ArrangeContinuousAndRunning()` before nulling the reference, and drops the two assertions that were tautological once `SpeechRecogniser = null` detached the fake.

   The issue flagged one limb as UNSETTLED: whether `SendMessage` logs a receiver exception instead of propagating it, which would make `Assert.DoesNotThrow` decorative even in a throwing state. Rather than settle it, the test now sidesteps it — a new `PauseDirect(bool)` driver invokes the private message by reflection, so the throw is visible to the assertion either way (reflection's `TargetInvocationException` wrapper still fails `DoesNotThrow`). The other seven tests keep the `SendMessage` drivers.

2 & 3. **The fixture stated a false reason for its own safety.** "No override calls `base`, so nothing here touches a model, the native bridge, or a microphone" was wrong twice over: a base class's privately-declared Unity messages still run on a subclass, so `TearDown`'s `DestroyImmediate` reached the real `OnDestroy → ReleaseNativeResources()` on every test — benign only on the `#if UNITY_EDITOR_WIN` branch, a live `vosk_bridge_destroy()` P/Invoke off it. And not calling `base` neutralises only the three overridden cores; `Initialise()` and friends are public non-virtual, so what actually keeps the suite off the model is `InitialiseOnStart = false`.

   The header comment now names the real load-bearing set, `InitialiseOnStart = false` is annotated as a safety line, and an empty `void OnDestroy() { }` on the double makes inertness structural rather than resting on a compile-time platform define. No `IsModelReady` tripwire — the issue disproved it.

4. **One `Assume` could mask a real red.** `ArrangeContinuousAndRunning`'s `Assume.That` → `Assert.That`. It is the only check in the whole `Tests~` tree that continuous mode starts recognition at all, and an unsatisfied `Assume` reports *Inconclusive*, which this project's `failed="0"` green criterion reports as a pass. The other five `Assume` sites are left alone deliberately, per the issue.

## Why

All four are test-power defects, not behaviour defects. The production seam is sound and the five state-machine cases issue #49 required are genuinely asserted — but three of these four defects meant a future regression could land green.

## Validation

Unity 6000.4.7f1, host project `VoXR TestGround`, both platforms per the project's verification bindings:

- [x] **EditMode: 116/116 passed** — 0 failed, 0 inconclusive, 0 skipped
- [x] **PlayMode: 304/304 passed** — 0 failed, 0 inconclusive, 0 skipped
- [x] Combined 420/420, exact match with the PR #52 baseline (this change adds and removes no tests). `inconclusive` checked explicitly on both platforms, per finding 4 — it is a distinct NUnit attribute from `failed` and the reason finding 4 exists.
- [x] Zero `error CS` in both logs, so the totals are real runs rather than empty ones.

**Both fixes verified by mutation testing rather than by inspection** — the point of this issue is that these tests looked like they asserted things they did not, so "it still passes" is not evidence:

- [x] **Mutation A** — deleted the `if (_speechRecogniser == null) return;` guard at `VoxrPushToTalkController.cs:135`. Result: **exactly 1 failure**, `Pause_WithNullRecogniser_IsNoOp`, with an inner `NullReferenceException` at `:140` (the precise line the guard protected) wrapped in `TargetInvocationException`. The other 7 tests in the fixture stayed green, so the failure is causally tied to the mutation. Under the old version this test survived deleting the whole method body.
- [x] **Mutation B** — deleted `_speechRecogniser?.StartRecognition();` at `VoxrPushToTalkController.cs:59`. Result: **5 failed, 0 inconclusive**, all five with the message `Switching to continuous mode must start recognition`, all originating in `ArrangeContinuousAndRunning`. The `failed`/`inconclusive` split is the whole point: under `Assume` these would have been inconclusive and reported green.
- [x] Mutation B also **confirmed the coverage hole** finding 4 describes: the sibling `VoxrPushToTalkControllerTests.ListeningMode_SetToContinuous_FiresOnTalkStarted` **passed** under the same mutation (that suite stayed 16/16 green), because it asserts only the event count while `:59` and `:60` are separate statements. Recognition never starts and it still reports green.

Both mutations were reverted; the branch diff touches no production file (`git diff origin/main --name-only` outside `Tests~/` returns nothing).

### Not verified

- **The `OnDestroy()` shim's shadowing is not empirically proven.** Whether redeclaring a Unity message on a subclass suppresses the base's privately-declared one cannot be demonstrated from the only platform available here: on `UNITY_EDITOR_WIN` the base's `OnDestroy` is already benign (`_editorBackend?.Release()` on a null backend), so a green run is consistent with either outcome. The shim is correct-or-inert — it cannot make things worse — but its benefit lands on Android/macOS/Linux and is unverified there.
- **On-device (Quest) verification: not applicable, not claimed.** No production code changed, so shipped pause behaviour is untouched by this PR. The fixture remains a headless proxy for a real OS pause callback, exactly as it was before.
