### PR TITLE
Keep the PlayMode test assembly out of Android players (#55)

### DIFF
--- a/Tests~/Runtime/Jinwoo1601.VoXR.Tests.Runtime.asmdef
+++ b/Tests~/Runtime/Jinwoo1601.VoXR.Tests.Runtime.asmdef
@@ -7,7 +7,9 @@
         "UnityEditor.TestRunner"
     ],
     "includePlatforms": [],
-    "excludePlatforms": [],
+    "excludePlatforms": [
+        "Android"
+    ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [


### PR DESCRIPTION
Fixes #55.

`Tests~/Runtime`'s asmdef had an empty `excludePlatforms`, so the PlayMode suite was built for every platform. That is inert today — the tests only ever run in the Windows editor — but it blocks on-device test runs, because every fixture would be shipped into the player and `vosk_bridge_destroy()` is process-global (details and file references in #55).

### The change

One field: `"excludePlatforms": ["Android"]`.

### Why this mechanism

`includePlatforms: ["Editor"]` is the more obvious-looking fix and is wrong here: Unity classifies a test assembly whose only platform is Editor as an **EditMode** assembly, which would move all 304 PlayMode tests into EditMode and change how the `[UnityTest]` coroutines run. Excluding Android instead keeps the assembly a PlayMode assembly while dropping it from Android players.

### Verification

Full suite on the host project (Unity 6000.4.7f1), both platforms, after the change:

| Platform | Total | Passed | Failed | Inconclusive |
|---|---|---|---|---|
| EditMode | 116 | 116 | 0 | 0 |
| PlayMode | 304 | 304 | 0 | 0 |

Unchanged from the recorded baseline, which is the point — the split is preserved.

### Not verified

The runs above had the editor's active build target on Windows Standalone. I did not verify that the assembly still compiles for the editor while the **active build target is Android** — the configuration an on-device run leaves behind. The platform filter should not affect editor compilation (Editor remains in the assembly's effective platform set), but that is reasoning, not a measurement, and it belongs to the on-device rig's runbook rather than this fix.

### Left alone deliberately

The underlying `ReleaseNativeResources()` behaviour is also a product-level bug — two `VoxrSpeechRecogniser` components in a user's scene share one process-global bridge, so destroying either frees the other's recognizer and model. That is a shipped-runtime semantics change and wants its own issue; this PR only stops the test suite from tripping over it.
