### PR TITLE
Pin the absence of extra logs in warning-asserting tests (#68)

### DIFF
--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -1372,6 +1372,7 @@ namespace VoXR.Tests.Runtime
                 parser,
                 "the shape is a warning, not an error — construction still succeeds"
             );
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -1394,6 +1395,7 @@ namespace VoXR.Tests.Runtime
                 result.Command.HasSlot("burn_level"),
                 "the spoken burn level is discarded with nothing to signal it"
             );
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -1471,6 +1473,7 @@ namespace VoXR.Tests.Runtime
             );
 
             Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
         }
 
         // Mirrors the shipped set_heading grammar (DemoGrammar / CommandDemo /
@@ -1572,6 +1575,7 @@ namespace VoXR.Tests.Runtime
             );
 
             Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -1600,6 +1604,7 @@ namespace VoXR.Tests.Runtime
                 "the bare intent wins and the spoken burn level is stranded"
             );
             Assert.IsFalse(result.Command.HasSlot("burn_level"));
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -1637,6 +1642,7 @@ namespace VoXR.Tests.Runtime
                 "the bare form wins at 1.0 and the target is stranded"
             );
             Assert.IsFalse(result.Command.HasSlot("target"));
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }

--- a/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
+++ b/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
@@ -72,6 +72,7 @@ namespace VoXR.Tests.Runtime
             LogAssert.Expect(LogType.Warning, new Regex("InjectText called before parser is ready"));
 
             Assert.DoesNotThrow(() => _recogniser.InjectText("anything"));
+            LogAssert.NoUnexpectedReceived();
         }
 
         [TestCase(null)]
@@ -668,7 +669,17 @@ namespace VoXR.Tests.Runtime
 
         void ConfigureForUnanalysableGrammar(float prefixHold)
         {
-            // Construction is where the over-limit pattern is reported now.
+            // Construction is where the over-limit pattern is reported now. Two warnings land
+            // here, not one: the prefix-hold grammar this builds on is itself a droppable-
+            // required-literal shape ("status" is a bare form of "status report {target}"),
+            // which is the very thing the hold exists to exercise, so the #42 check fires too.
+            // Expectations are matched in queue order against the logs in emission order, and
+            // the ctor runs the #42 scan before the optional-expansion one — so this pair must
+            // stay in this order.
+            LogAssert.Expect(
+                LogType.Warning,
+                new Regex(@"""status"" \(intent 'status'\) is a bare form of")
+            );
             LogAssert.Expect(LogType.Warning, new Regex("more than the 12"));
 
             _recogniser.Configure(PrefixHoldSlots(), UnanalysableCommands());
@@ -697,6 +708,7 @@ namespace VoXR.Tests.Runtime
                 "nothing commits early on a grammar the eligibility analysis never vetted"
             );
             Assert.AreEqual(0.6f, _recogniser.TestEffectiveBufferWindow, 1e-4f);
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -708,6 +720,7 @@ namespace VoXR.Tests.Runtime
             _recogniser.InjectText("cease fire");
 
             Assert.AreEqual(2.0f, _recogniser.TestEffectiveBufferWindow, 1e-4f);
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -720,6 +733,7 @@ namespace VoXR.Tests.Runtime
             _recogniser.InjectText("cease");
 
             Assert.AreEqual(2.0f, _recogniser.TestEffectiveBufferWindow, 1e-4f);
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -345,6 +345,7 @@ namespace VoXR.Tests.Runtime
             Assert.IsFalse(overLimit, "the over-limit pattern is disabled");
             Assert.IsFalse(normal,
                 "a normal command in the same set is also disabled (whole-parser, never partial)");
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -364,6 +365,7 @@ namespace VoXR.Tests.Runtime
             );
 
             Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -495,6 +497,7 @@ namespace VoXR.Tests.Runtime
                 parser.TryEagerCommit(Tok("cease fire"), null, 0.6f, 0.4f),
                 "an un-analysable grammar holds — it never commits early"
             );
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -519,6 +522,7 @@ namespace VoXR.Tests.Runtime
                 parser.TryEagerCommit(Tok("banana"), null, 0.6f, 0.4f),
                 "speech matching nothing must not arm the shortened hold"
             );
+            LogAssert.NoUnexpectedReceived();
         }
 
         // ---------- Tie-break parity with ParseInternal (Review MF-5) ----------
@@ -826,6 +830,7 @@ namespace VoXR.Tests.Runtime
                 parser.TryEagerCommit(Tok("launch all missiles target"), null, 0.6f, 0.4f),
                 "an incomplete command must not reach the degrade's hold either"
             );
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }

--- a/Tests~/Runtime/VoxrSpeechRecogniserOwnershipTests.cs
+++ b/Tests~/Runtime/VoxrSpeechRecogniserOwnershipTests.cs
@@ -99,6 +99,7 @@ namespace VoXR.Tests.Runtime
                 _ownerErrors,
                 $"Owner must see no error: [{string.Join("; ", _ownerErrors)}]"
             );
+            LogAssert.NoUnexpectedReceived();
         }
 
         [UnityTest]
@@ -138,6 +139,7 @@ namespace VoXR.Tests.Runtime
                 $"Expected exactly one rejection: [{string.Join("; ", _secondErrors)}]"
             );
             Assert.IsTrue(_owner.IsInitialised, "Owner must still hold the bridge.");
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -153,6 +155,7 @@ namespace VoXR.Tests.Runtime
                 $"Expected exactly one rejection: [{string.Join("; ", _secondErrors)}]"
             );
             Assert.IsTrue(_owner.IsInitialised, "Owner must still hold the bridge.");
+            LogAssert.NoUnexpectedReceived();
         }
 
         [UnityTest]


### PR DESCRIPTION
Closes #68

## What

Adds `LogAssert.NoUnexpectedReceived()` to every test that asserts an authoring-time warning — **option 1** of the three the issue offered — matching the three uses already in the suite. One test also gained a missing second expectation (below).

Tests only; no runtime code touched. No `CHANGELOG` entry: `Tests~` is excluded from the shipped package, so nothing here is user-facing.

## Why

`LogAssert.Expect` has two halves. It asserts the named message **arrived**, and it suppresses that message from failing the test. For a `LogType.Warning` the suppression half is a no-op — the Test Framework only auto-fails on `Error`/`Assert`/`Exception` — so only the arrival assertion was load-bearing, and an additional unrelated warning fired completely undetected.

## Which option, and why the issue's decision tree does not survive contact

The issue said to measure first: count the tests emitting incidental logs, and let that number pick between (2) fixture-level and (3) assembly-level `TestMustExpectAllLogs`.

Measured with `[assembly: TestMustExpectAllLogs]` on the runtime test assembly: **81 of 343 PlayMode tests fail**, all `UnhandledLogMessageException`, all on `[Warning]`-level logs, zero other breakage. Not small — but the shape matters more than the count:

| Fixture | Failures | Contains warning-asserting tests? |
|---|---|---|
| `VoxrCommandParserTests` | 66 | yes (6) |
| `VoxrCommandRecogniserInjectionTests` | 11 | yes (4) |
| `VoxrEagerCommitTests` | 3 | yes (5) |
| `VoxrAssetConversionTests` | 1 | no |

The issue's rule was "if large, (2) gets the coverage without a broad migration." It does not: the incidental warnings sit **inside exactly the fixtures option 2 would annotate**, so option 2 costs the same ~80-test migration as option 3. And the noise is not per-test — it comes from shared grammar helpers, with a single-character alias `"a"` in one slot driving 56 of the 81. Those cannot be cleaned up without changing what the tests exercise; `Alias_QuantityA_ResolvesToOne` exists precisely to test that alias.

So the decision tree runs off the end and lands on its own stated fallback, (1).

## Two corrections to the issue's inventory

Both surfaced by re-deriving the call-site map, as the issue advised.

**1. It is 18 warning-asserting tests, not 16.** The expectation the issue attributed to `PrefixHold_ClearedOnFlush` is actually in the shared helper `ConfigureForUnanalysableGrammar`, which serves three `UnanalysableGrammar_*` tests. `PrefixHold_ClearedOnFlush` has no `Expect` of its own — it is an ordinary incidental-warning test, not one of the targets.

**2. The measurement caught a live instance of the defect.** Those three tests expected only `"more than the 12"`, while their grammar emits a **second** warning first: the #42 droppable-required-literal check fires because `"status"` is a bare form of `"status report {target}"` — which is the very shape the prefix-hold fixture exists to exercise, so it is correct and cannot be designed away. Both warnings are now expected.

Order is load-bearing there: `LogScope.ExpectedLogs` is a **queue**, matched against logs in emission order (`LogScope.cs:206-227`), and the parser ctor runs the #42 scan (`VoxrCommandParser.cs:229`) before the optional-expansion one (`:230`). The new expectation had to go *before* the existing one. A comment in the helper records this so a future edit does not reorder them.

## Validation

- [x] Unity **EditMode** — 116/116 passed, 0 failed, exit 0 (baseline match)
- [x] Unity **PlayMode** — 343/343 passed, 0 failed, exit 0 (baseline match)
- [x] Both runs verified fresh, not stale XML — a tests-only change reproduces baseline counts exactly, so stale artifacts were moved aside first and each result's UTC `start-time` confirmed after the cutoff
- [x] Zero `Unhandled log message` failures in the PlayMode log
- [x] No compile errors in either assembly
- [x] Working tree reverted after the run: `Tests` → `Tests~`, all 58 generated `.meta` orphans plus root `Tests.meta` deleted, host manifest untouched
- N/A NativeBridge gates — `NativeBridge~/` is unchanged by this branch
- N/A On-device (Quest) check — no runtime code changed; nothing here can affect device behaviour

## Note for whoever picks up the follow-up

Unity's own doc comment for `TestMustExpectAllLogsAttribute` — and the issue's option 3, which quotes it — shows the opt-out as `[TestMustExpectAllLogs(MustExpect=false)]`. **That does not compile.** `MustExpect` is a get-only property (`TestMustExpectAllLogsAttribute.cs:33`); the opt-out has to be positional, `[TestMustExpectAllLogs(false)]`. Worth knowing before anyone attempts the broader migration.

Also worth recording while the data is fresh: the 262 PlayMode tests that already pass under assembly-wide strictness could be locked in cheaply, since only 4 fixtures are dirty. That is a larger behavioural change than this issue asked for, so it is left as a decision rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsetkJVeu9sRguysZZj1oS