### PR TITLE
Charge candidates for what they leave unexplained, inside selection (#65 §5.2, DR-4)

### DIFF
--- a/Editor/VoxrDebugSessionLog.cs
+++ b/Editor/VoxrDebugSessionLog.cs
@@ -49,7 +49,8 @@ namespace VoXR.Editor
             + "numbers embedded in rejectReason text are formatted with the Editor's current "
             + "culture, so the decimal separator may be ',' — match on the surrounding words, "
             + "not the whole literal. The scoring model behind these numbers — the score "
-            + "formula, the skipped-word penalty, selection order, the two gates, and worked "
+            + "formula, the coverage weight charged for in-grammar words a match leaves "
+            + "unexplained before AND after it, selection order, the two gates, and worked "
             + "examples — is documented in Documentation~/scoring.md in the com.jinwoo1601.voxr "
             + "package.";
 

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -149,8 +149,8 @@ namespace VoXR.Commands
 
         // Per-utterance coverage tables, rebuilt by BuildCoverageTables at the top of every
         // parse and reused across that parse's extraction rounds. Grown on demand and never
-        // shrunk, matching the _matchSlotBuf / _resultBuf pooling discipline — coverage adds
-        // no per-utterance allocation.
+        // shrunk. Like _matchSlotBuf / _resultBuf they are allocated off the parse path, so
+        // coverage adds no per-utterance allocation (those two are sized once instead).
         //
         //   _recognisedPrefix[i]  — non-[unk] tokens in [0, i), so the words a round's sliding
         //                           start walked past are one subtraction instead of a scan.
@@ -208,8 +208,18 @@ namespace VoXR.Commands
             public int WordCount;
         }
 
+        // additionalGrammarWords are words the caller also put in the DECODER's grammar but
+        // that appear in no pattern — in practice the confirm/cancel follow-up vocabulary
+        // (VoxrCommandRecogniser.GetFollowUpGrammarWords). They matter to coverage because the
+        // decoder returns them as real tokens rather than [unk], so without them the trailing
+        // term charges a speaker for saying "disengage, yes": nothing can begin a match at
+        // "yes", so it reads as an orphan and sinks a command that used to fire. They can
+        // legitimately begin something — a follow-up — so they terminate an orphan run exactly
+        // as a pattern start does. Null is correct for a caller that registered no follow-up
+        // vocabulary with the decoder either.
         public VoxrCommandParser(VoxrSlotDefinition[] slots, VoxrCommandDefinition[] commands,
-            float coverageWeight = DefaultCoverageWeight
+            float coverageWeight = DefaultCoverageWeight,
+            string[] additionalGrammarWords = null
         )
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
@@ -217,7 +227,11 @@ namespace VoXR.Commands
 
             _slots = slots;
             _commands = commands;
-            _coverageWeight = coverageWeight > 0f ? coverageWeight : 0f;
+            // Rejects negatives and NaN, and also non-finite positives: at +infinity a
+            // candidate with nothing unexplained computes 0 * infinity = NaN, and NaN slips
+            // through every `<= 0f` floor because those comparisons are false for NaN.
+            _coverageWeight =
+                coverageWeight > 0f && !float.IsInfinity(coverageWeight) ? coverageWeight : 0f;
 
             // Build slot name -> index mapping
             _slotIndex = new Dictionary<string, int>(slots.Length, StringComparer.Ordinal);
@@ -334,6 +348,19 @@ namespace VoXR.Commands
                     }
                 }
             }
+            // Words the decoder can return that begin no pattern but do begin a follow-up.
+            // Folded in here rather than kept separate because the predicate's question is
+            // "could anything the grammar knows about start here?", and the answer for a
+            // confirm/cancel word is yes.
+            if (additionalGrammarWords != null)
+            {
+                foreach (string word in additionalGrammarWords)
+                {
+                    if (!string.IsNullOrEmpty(word))
+                        _startLiterals.Add(word);
+                }
+            }
+
             _startSlots = startSlots.ToArray();
 
             // Compute max slots per pattern to size reusable buffers.
@@ -1258,7 +1285,7 @@ namespace VoXR.Commands
             // requiredAfterLastMatch selects WHICH orphan table to read (Amendment A3): a
             // candidate whose own next required element failed at this position owns the token
             // it mis-predicted and may not claim some other pattern could have begun there.
-            // Both tables are built once per utterance, so this is two array reads.
+            // Both tables are built once per utterance, so coverage is three array reads.
             AssertCoverageTablesMatch(tokens);
 
             float coverage =
@@ -1473,18 +1500,6 @@ namespace VoXR.Commands
             // ordering of the two.
             _coverageTokens = tokens;
 
-            // Nothing is charged at zero weight, so skip the predicate sweep entirely rather
-            // than compute a table that will be multiplied away. The tables are still cleared
-            // rather than left stale, so the accessors keep answering honestly ("nothing is
-            // charged") instead of returning the previous utterance's counts.
-            if (_coverageWeight <= 0f)
-            {
-                Array.Clear(_recognisedPrefix, 0, n + 1);
-                Array.Clear(_orphanRun, 0, n + 1);
-                Array.Clear(_forcedOrphanRun, 0, n + 1);
-                return;
-            }
-
             _recognisedPrefix[0] = 0;
             for (int i = 0; i < n; i++)
                 _recognisedPrefix[i + 1] = _recognisedPrefix[i] + (tokens[i] == UnkToken ? 0 : 1);
@@ -1531,7 +1546,7 @@ namespace VoXR.Commands
 
         // Guards the precondition that BuildCoverageTables ran over the array being scored.
         // Editor-only: the coupling is real but the check is not worth a branch in a shipped
-        // build, and every production caller is two lines away from its own build call.
+        // build, and both production callers build the tables at the top of the same method.
         [System.Diagnostics.Conditional("UNITY_EDITOR")]
         void AssertCoverageTablesMatch(string[] tokens)
         {
@@ -1571,6 +1586,12 @@ namespace VoXR.Commands
 
         // Could any registered active pattern begin a match at tokens[idx]? Deliberately
         // CONSERVATIVE: where the answer is uncertain it must be yes, and nothing is charged.
+        // Corrected by Amendment A3: the asymmetry below held only while coverage sat BELOW
+        // the selection barrier. Once coverage reorders, under-charging ONE candidate relative
+        // to a sibling is not "today's behaviour" — it is how the wrong command came to beat
+        // the right one, which is what A3 exists to close. The conservative default stands;
+        // the argument for it does not extend to the reordering regime.
+        //
         // The failure modes are not symmetric — over-charging destroys sequential extraction,
         // while under-charging merely leaves a score where it already is today.
         //

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -69,12 +69,26 @@ namespace VoXR.Commands
         // stops the command firing.
         const float RequiredLiteralMissPenalty = 0f;
 
-        // Weight added to the score denominator per in-grammar word the sliding start skips
-        // before a match begins (issue #31). At 1.0 the score becomes the fraction of the
-        // utterance the pattern actually covers, so a lone one-element pattern found in the
-        // tail of a longer utterance scores 0.5 instead of a full 1.0 and falls below the
-        // default minScore. 0 restores the previous behaviour (skipped words cost nothing).
-        internal const float DefaultSkippedWordPenalty = 1.0f;
+        // Weight added to the score denominator per in-grammar token a match leaves
+        // unexplained: those the sliding start skipped to reach it (issue #31) and those left
+        // orphaned after it (issue #65 §5.2). At 1.0 the score is exactly the fraction of the
+        // utterance the pattern accounts for, so a lone one-element pattern found in the tail
+        // of a longer utterance scores 0.5 and falls below the default minScore.
+        //
+        // Renamed from skippedWordPenalty by DR-4, because one weight now governs both sides
+        // and the old name described only the leading half. The rename also stops hiding a
+        // coupling: setting this to 0 restores pre-#31 behaviour AND silently switches off
+        // the issue #42 fix, which "coverage weight" at least admits to.
+        internal const float DefaultCoverageWeight = 1.0f;
+
+        // Kept one minor version as DR-4 prescribes. Inert in practice: the type is internal
+        // and InternalsVisibleTo names only first-party assemblies, so there is no external
+        // call site for the warning to reach.
+        [Obsolete(
+            "Renamed to DefaultCoverageWeight — the weight governs orphaned trailing tokens "
+                + "as well as leading skipped ones (issue #65 §5.2)."
+        )]
+        internal const float DefaultSkippedWordPenalty = DefaultCoverageWeight;
 
         // Upper bound on optional elements in a single pattern for eager-commit analysis
         // (issue #25). ExpandOptionals enumerates 2^optionals concrete forms; past this the
@@ -88,7 +102,7 @@ namespace VoXR.Commands
 
         readonly VoxrSlotDefinition[] _slots;
         readonly VoxrCommandDefinition[] _commands;
-        readonly float _skippedWordPenalty;
+        readonly float _coverageWeight;
 
         // Per-slot lookup: first word -> list of (fullValue, wordCount), sorted longest first.
         readonly Dictionary<string, List<SlotValueEntry>>[] _slotLookups;
@@ -106,6 +120,42 @@ namespace VoXR.Commands
 
         // Pre-computed set of optional slot elements (e.g. "{?target}").
         readonly HashSet<string> _optionalSlotElements;
+
+        // Grammar-derived answer to "could any active pattern begin a match at this token?"
+        // (issue #65 §5.2). Coverage charges a candidate for the in-grammar tokens it leaves
+        // unexplained AFTER its match, and that count stops at the first token which could
+        // begin some other pattern. Stopping there is what keeps sequential extraction
+        // intact: "cease fire launch missiles target hotel one" must charge cease_fire
+        // nothing, not five, because the launch is a command in its own right.
+        //
+        // Derived from the registered patterns ALONE, never from which candidates survived
+        // admission. Defining it over admitted candidates is the tempting shortcut — the
+        // selection loop already has them in hand — but it would couple coverage to the
+        // admission rule: rejecting one candidate would withdraw a pattern's claim on a
+        // token, turn that token into an orphan, and lower a DIFFERENT candidate's score.
+        //
+        // Built here in the constructor rather than alongside the _canCommitEarly analysis,
+        // which is lazy and reached only from the eager entry points. Those are never
+        // touched at the shipped default (eagerFlushOnCompleteMatch = false), so caches
+        // built there would be empty on an ordinary parse, every trailing token would be
+        // charged, and sequential extraction would break exactly as above. Invalidation is
+        // automatic: an active-set change rebuilds the whole parser.
+        readonly HashSet<string> _startLiterals;
+        readonly int[] _startSlots;
+
+        // Per-utterance coverage tables, rebuilt by BuildCoverageTables at the top of every
+        // parse and reused across that parse's extraction rounds. Grown on demand and never
+        // shrunk, matching the _matchSlotBuf / _resultBuf pooling discipline — coverage adds
+        // no per-utterance allocation.
+        //
+        //   _recognisedPrefix[i] — non-[unk] tokens in [0, i), so the words a round's sliding
+        //                          start walked past are one subtraction instead of a scan.
+        //   _orphanRun[i]        — tokens left unexplained in the run starting at i.
+        //
+        // Both are functions of the token array and the grammar alone and are complete before
+        // any candidate is scored, so no candidate's score depends on evaluation order.
+        int[] _recognisedPrefix;
+        int[] _orphanRun;
 
         // Pre-allocated slot match buffers — avoids per-call List allocations in TryMatchScored/Parse.
         readonly int _maxSlotsPerPattern;
@@ -148,14 +198,15 @@ namespace VoXR.Commands
         }
 
         public VoxrCommandParser(VoxrSlotDefinition[] slots, VoxrCommandDefinition[] commands,
-            float skippedWordPenalty = DefaultSkippedWordPenalty)
+            float coverageWeight = DefaultCoverageWeight
+        )
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (commands == null) throw new ArgumentNullException(nameof(commands));
 
             _slots = slots;
             _commands = commands;
-            _skippedWordPenalty = skippedWordPenalty > 0f ? skippedWordPenalty : 0f;
+            _coverageWeight = coverageWeight > 0f ? coverageWeight : 0f;
 
             // Build slot name -> index mapping
             _slotIndex = new Dictionary<string, int>(slots.Length, StringComparer.Ordinal);
@@ -231,6 +282,48 @@ namespace VoXR.Commands
                     }
                 }
             }
+
+            // Which literals and slots can be the FIRST thing a pattern matches. The walk
+            // takes each element from index 0 and continues past it only while that element
+            // is OPTIONAL — an omitted optional lets the element behind it legitimately begin
+            // the match — stopping at and including the first required one.
+            _startLiterals = new HashSet<string>(StringComparer.Ordinal);
+            var startSlots = new List<int>();
+            foreach (var command in commands)
+            {
+                foreach (var pattern in command.Patterns)
+                {
+                    foreach (string element in pattern)
+                    {
+                        bool optional;
+                        if (_slotNameCache.TryGetValue(element, out string slotName))
+                        {
+                            optional = _optionalSlotElements.Contains(element);
+                            // Slot references were validated above, so this cannot miss.
+                            int slotIdx = _slotIndex[slotName];
+                            if (!startSlots.Contains(slotIdx))
+                                startSlots.Add(slotIdx);
+                        }
+                        else if (IsOptionalLiteral(element))
+                        {
+                            optional = true;
+                            // The STRIPPED form: "?mark" can only ever match the token "mark",
+                            // and storing the raw element would add a string no utterance can
+                            // contain, silently weakening the predicate.
+                            _startLiterals.Add(_optionalLiteralCache[element]);
+                        }
+                        else
+                        {
+                            optional = false;
+                            _startLiterals.Add(element);
+                        }
+
+                        if (!optional)
+                            break;
+                    }
+                }
+            }
+            _startSlots = startSlots.ToArray();
 
             // Compute max slots per pattern to size reusable buffers.
             int maxSlots = 0;
@@ -339,11 +432,27 @@ namespace VoXR.Commands
         // element's credit while still counting it in its denominator, so it drops below the
         // perfectly-matching P, which wins and the spoken slot content is discarded with
         // nothing to signal it. Issue #65 §5.1 reduced that loss (a drop now costs 1/N rather
-        // than 1.5/N) but cannot close this, and no penalty tuning can: P scores a clean 1.0
-        // and nothing normalized to 1.0 can beat it. Marking the literal optional does — an
-        // omitted optional leaves both sides of the ratio, so the longer pattern reaches 1.0
-        // whether or not the literal was spoken and takes the consumed-span tie-break
+        // than 1.5/N) but could not close it, and no penalty tuning could: P scored a clean
+        // 1.0 and nothing normalized to 1.0 can beat it. Marking the literal optional does —
+        // an omitted optional leaves both sides of the ratio, so the longer pattern reaches
+        // 1.0 whether or not the literal was spoken and takes the consumed-span tie-break
         // (issue #41) over the bare form.
+        //
+        // §5.2 CLOSED THE COMMON CASE, so the paragraph above is now the history of this
+        // detector rather than its reason. Coverage charges P for what it leaves unexplained,
+        // which is exactly the stranded slot value: bare "decelerate" on "decelerate hard
+        // burn" falls from 1.0 to 1/(1+2) and loses to the longer pattern's 2/3.
+        //
+        // The hazard is REDUCED, not eliminated, and the residue is what this still warns
+        // about. An orphan run stops at the first token that could begin some other pattern,
+        // so when the stranded value's first word happens to start one, P is charged nothing
+        // and strands the value exactly as before — register ["hard","stop"] beside the pair
+        // above and "hard" becomes such a token.
+        //
+        // Deliberately NOT narrowed to that residue, though _startLiterals/_startSlots could
+        // now answer it. The remedy is the better authoring either way: an optional literal
+        // reaches 1.0 rather than 2/3, so it wins by more, and it also wins in the residual
+        // case where coverage alone does not.
         //
         // The scan mirrors what ParseInternal actually compares, which is why it is this wide:
         //   - ACROSS COMMANDS, not just within one. Selection runs over every pattern of every
@@ -485,13 +594,16 @@ namespace VoXR.Commands
 
             return $"[VoxrCommandParser] {sameIntent}, which extends it with {gap} in front of "
                 + $"slot \"{slot}\". If that literal is dropped, the longer pattern loses that "
-                + "element's credit while the bare one still matches perfectly — so the bare one "
-                + "wins and the slot value the speaker did say is discarded silently. Make the literal "
-                + $"optional (\"?{firstRequired}\") so an otherwise-complete match reaches the same "
-                + "score with or without the word and wins on consumed span. That trade is not "
-                + "free: an optional literal also lowers the score of matches that are already "
-                + "missing something, and stops anchoring the slot behind it, which can then "
-                + "claim adjacent tokens.";
+                + "element's credit while the bare one still matches perfectly. The bare one is "
+                + "now charged for the words it leaves unexplained (issue #65 §5.2), so it "
+                + "usually loses that exchange — but not when the stranded value's first word "
+                + "could itself begin some pattern, which stops the charge and hands the bare "
+                + "form the win with the value the speaker did say discarded silently. Make the "
+                + $"literal optional (\"?{firstRequired}\") to close the case that remains: an "
+                + "otherwise-complete match then reaches the same score with or without the word "
+                + "and wins on consumed span. That trade is not free: an optional literal also "
+                + "lowers the score of matches that are already missing something, and stops "
+                + "anchoring the slot behind it, which can then claim adjacent tokens.";
         }
 
         // The other hazard the eager-flush analysis carries (issue #44): one pattern past
@@ -579,6 +691,8 @@ namespace VoXR.Commands
                 return 0;
             }
 
+            BuildCoverageTables(tokens);
+
             int searchStart = 0;
 #if UNITY_EDITOR
             var diagnosticEntries = new List<ParseDiagnosticEntry>();
@@ -587,8 +701,6 @@ namespace VoXR.Commands
             while (searchStart < tokens.Length)
             {
                 float bestScore = float.MinValue;
-                float bestRawScore = 0f;
-                float bestDenominator = 0f;
                 int bestLiteralCount = -1;
                 int bestCommandIdx = -1;
                 int bestPatternIdx = -1;
@@ -607,7 +719,12 @@ namespace VoXR.Commands
                             if (tokens[startIdx] == UnkToken)
                                 continue;
 
-                            var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
+                            var matchResult = TryMatchScored(
+                                tokens,
+                                startIdx,
+                                patterns[pi],
+                                searchStart
+                            );
 
                             if (
                                 IsBetterCandidate(
@@ -621,8 +738,6 @@ namespace VoXR.Commands
                             )
                             {
                                 bestScore = matchResult.Score;
-                                bestRawScore = matchResult.RawScore;
-                                bestDenominator = matchResult.Denominator;
                                 bestLiteralCount = matchResult.LiteralCount;
                                 bestCommandIdx = ci;
                                 bestPatternIdx = pi;
@@ -651,25 +766,11 @@ namespace VoXR.Commands
                 if (bestEndIdx <= searchStart)
                     break;
 
-                // Charge the winner for the in-grammar words the sliding start walked past
-                // (issue #31). Skipped words cost nothing on their own, so a short pattern
-                // found in the tail of a stray utterance ("thrusters report" matching the
-                // one-word "report" command) used to score a full 1.0 and fire. Adding them
-                // to the denominator makes the score the fraction of the utterance the
-                // pattern covers, which only bites patterns short enough to be swallowed
-                // whole. [unk] runs are excluded — tolerating out-of-grammar preamble and
-                // hesitation is what the sliding start is for. The penalty is applied after
-                // selection so it filters via minScore without changing which pattern wins,
-                // and it measures from searchStart, so a second command in a multi-command
-                // utterance starts clean.
-                if (_skippedWordPenalty > 0f && bestStartIdx > searchStart)
-                {
-                    int skipped = CountRecognisedTokens(tokens, searchStart, bestStartIdx);
-                    if (skipped > 0)
-                        bestScore = bestRawScore
-                            / (bestDenominator + skipped * _skippedWordPenalty);
-                }
-
+                // No post-selection adjustment. The skipped-word charge that used to sit here
+                // (issue #31) now lives in TryMatchScored alongside the trailing term, so the
+                // score a candidate was SELECTED on is the score it is reported with. It was
+                // here in the first place to keep it from reordering anything; issue #65 §5.2
+                // is the finding that reordering is exactly what symptom 2 needs.
                 float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
 
                 VoxrSlotMatch[] slotsArray;
@@ -868,8 +969,6 @@ namespace VoXR.Commands
         struct MatchResult
         {
             public float Score;
-            public float RawScore;
-            public float Denominator;
             public int LiteralCount;
             public int SlotCount;
 
@@ -1007,7 +1106,11 @@ namespace VoXR.Commands
         internal ParseDiagnosticEntry[] LastParseDiagnostics;
 #endif
 
-        MatchResult TryMatchScored(string[] tokens, int startIdx, string[] pattern)
+        // searchStart is where this extraction round began, and only the leading coverage
+        // term reads it: the words charged are those between the round's origin and where
+        // this candidate starts, so a second command in a multi-command utterance is never
+        // charged for the tokens the first one consumed.
+        MatchResult TryMatchScored(string[] tokens, int startIdx, string[] pattern, int searchStart)
         {
             int tokenIdx = startIdx;
             float rawScore = 0f;
@@ -1130,13 +1233,65 @@ namespace VoXR.Commands
             }
 
             _matchSlotCount = slotCount;
-            float normalizedScore = denominator > 0f ? rawScore / denominator : 0f;
+
+            // Coverage (issue #65 §5.2): charge the candidate for the in-grammar tokens it
+            // leaves unexplained on EITHER side — the words the sliding start walked past to
+            // reach it, and the run after its last match that no pattern could begin. One
+            // weight governs both, so the score reads as the fraction of the utterance this
+            // pattern actually accounts for rather than as how neatly it matched wherever it
+            // happened to land.
+            //
+            // Computed HERE, before the caller compares candidates, and that relocation is
+            // the whole change. The leading term used to be applied to the winner alone
+            // (issue #31), deliberately placed after selection so it could only filter via
+            // minScore and never reorder. Symptom 2 of issue #65 cannot be fixed under that
+            // constraint: register "decelerate" alongside "decelerate by {burn_level}", drop
+            // the "by", and the bare form matches perfectly at 1.0 — nothing normalised to
+            // 1.0 can beat it, at any penalty setting. Only charging it for the "hard burn"
+            // it failed to explain demotes it, and only a term inside selection can.
+            //
+            // Both terms come from tables built once per utterance, so this stays two array
+            // indexes inside a triple-nested loop. Adding to the denominator cannot change
+            // the sign of a negative rawScore, so the Score <= 0f floors above and in
+            // IsBetterCandidate behave exactly as before; and since rawScore <= denominator
+            // always holds, a strictly larger denominator keeps the score inside [0, 1].
+            // One exception to the orphan run's start, at its first position only (Amendment
+            // A3). Where this candidate's OWN next required element failed to match, that
+            // token is charged outright instead of being tested against the start predicate:
+            // a candidate that just mis-predicted a token may not then claim some other
+            // pattern could have begun there.
+            //
+            // Without it the rule rewards matching LESS. Take ["switch","to","weapons"] and
+            // ["switch","to","navigation"] on "switch to weapons target hotel". The
+            // navigation pattern MISSES its final element, so its consumed span stops at
+            // "weapons" — which begins ["weapons","mode"], terminating its orphan run at zero
+            // for a tidy 2/3. The weapons pattern MATCHES that element, so its origin moves
+            // past the very token that would have terminated its own run, and it pays for
+            // "target hotel": 3/(3+2) = 0.6. The wrong command wins by 0.067 and fires.
+            // Measured: safe at one leftover token, flips at two.
+            int orphanedAfter;
+            if (requiredAfterLastMatch > 0)
+            {
+                int mispredicted = consumedEndIdx;
+                while (mispredicted < tokens.Length && tokens[mispredicted] == UnkToken)
+                    mispredicted++;
+
+                orphanedAfter =
+                    mispredicted < tokens.Length ? 1 + OrphanedAfter(mispredicted + 1) : 0;
+            }
+            else
+            {
+                orphanedAfter = OrphanedAfter(consumedEndIdx);
+            }
+
+            float coverage =
+                (SkippedBefore(searchStart, startIdx) + orphanedAfter) * _coverageWeight;
+
+            float normalizedScore = denominator > 0f ? rawScore / (denominator + coverage) : 0f;
 
             return new MatchResult
             {
                 Score = normalizedScore,
-                RawScore = rawScore,
-                Denominator = denominator,
                 LiteralCount = literalCount,
                 SlotCount = slotCount,
                 MissedRequiredSlot = missedRequiredSlot,
@@ -1191,15 +1346,24 @@ namespace VoXR.Commands
             return null;
         }
 
-        string TryMatchNumberSequence(string[] tokens, int startIdx, int minWords, int maxWords, out int consumed)
+        // Consecutive digit words starting at startIdx (after the leading [unk] skip), capped
+        // at maxWords. Shared by TryMatchNumberSequence and CanStartPattern's slot probe so
+        // the two cannot drift on what counts as a number sequence — and so the probe, which
+        // only needs to know whether enough digits are there, never builds the joined string
+        // it would immediately throw away.
+        static int CountNumberSequenceWords(
+            string[] tokens,
+            int startIdx,
+            int maxWords,
+            out int matchStart
+        )
         {
-            consumed = 0;
             int idx = startIdx;
 
             while (idx < tokens.Length && tokens[idx] == UnkToken)
                 idx++;
 
-            int matchStart = idx;
+            matchStart = idx;
             int count = 0;
             while (count < maxWords && idx < tokens.Length
                 && VoxrNumberParser.DigitVocabulary.Contains(tokens[idx]))
@@ -1208,10 +1372,24 @@ namespace VoXR.Commands
                 idx++;
             }
 
+            return count;
+        }
+
+        string TryMatchNumberSequence(
+            string[] tokens,
+            int startIdx,
+            int minWords,
+            int maxWords,
+            out int consumed
+        )
+        {
+            consumed = 0;
+            int count = CountNumberSequenceWords(tokens, startIdx, maxWords, out int matchStart);
+
             if (count < minWords)
                 return null;
 
-            consumed = idx - startIdx;
+            consumed = matchStart + count - startIdx;
 
             if (count == 1)
                 return tokens[matchStart];
@@ -1273,6 +1451,11 @@ namespace VoXR.Commands
 
         // Tokens in [startIdx, endIdx) that VOSK resolved to a grammar word, i.e. excluding
         // the [unk] filler the sliding start is meant to skip for free.
+        //
+        // No longer on the parse path — issue #65 §5.2 replaced the scan with a prefix-sum
+        // subtraction (SkippedBefore) because coverage moved inside the candidate loop, where
+        // an O(n) scan per candidate would multiply parse cost by utterance length. Kept as
+        // the reference implementation that optimisation is pinned against.
         internal static int CountRecognisedTokens(string[] tokens, int startIdx, int endIdx)
         {
             int count = 0;
@@ -1280,6 +1463,94 @@ namespace VoXR.Commands
                 if (tokens[i] != UnkToken)
                     count++;
             return count;
+        }
+
+        // -------- Coverage tables (issue #65 §5.2) --------
+
+        // Rebuilds the per-utterance coverage tables. Every path that reaches TryMatchScored
+        // — ParseInternal's extraction loop and TryEagerCommit's scan — calls this first, over
+        // the token array it is about to score, and the tables then stay valid for that whole
+        // parse: the leading term re-bases per round through the searchStart subtraction, and
+        // the trailing term is searchStart-independent by construction.
+        internal void BuildCoverageTables(string[] tokens)
+        {
+            int n = tokens.Length;
+            if (_recognisedPrefix == null || _recognisedPrefix.Length < n + 1)
+            {
+                _recognisedPrefix = new int[n + 1];
+                _orphanRun = new int[n + 1];
+            }
+
+            _recognisedPrefix[0] = 0;
+            for (int i = 0; i < n; i++)
+                _recognisedPrefix[i + 1] = _recognisedPrefix[i] + (tokens[i] == UnkToken ? 0 : 1);
+
+            // Backwards in one pass, three cases. The [unk] line carries both halves of that
+            // token's rule at once: never charged, and TRANSPARENT rather than a run
+            // terminator. A stopper would let one noise token shield every real orphan behind
+            // it, so "decelerate [unk] hard burn" must cost exactly what "decelerate hard
+            // burn" costs.
+            _orphanRun[n] = 0;
+            for (int i = n - 1; i >= 0; i--)
+            {
+                if (tokens[i] == UnkToken)
+                    _orphanRun[i] = _orphanRun[i + 1];
+                else if (CanStartPattern(tokens, i))
+                    _orphanRun[i] = 0;
+                else
+                    _orphanRun[i] = 1 + _orphanRun[i + 1];
+            }
+        }
+
+        // In-grammar words the sliding start walked past this round — the count
+        // CountRecognisedTokens produces by scanning, in O(1). Coverage sits inside a triple
+        // nested loop (commands x patterns x start index), so a scan here would multiply
+        // parse cost by utterance length.
+        internal int SkippedBefore(int searchStart, int startIdx)
+        {
+            return _recognisedPrefix[startIdx] - _recognisedPrefix[searchStart];
+        }
+
+        // Tokens left unexplained in the run starting where the candidate's last match ended.
+        // Measured from ConsumedEndIdx rather than EndIdx: the two provably agree today (the
+        // only thing that moves the cursor without recording a match is the [unk] skip, and
+        // [unk] is transparent above), but ConsumedEndIdx is the index whose correctness does
+        // not depend on that staying true.
+        internal int OrphanedAfter(int consumedEndIdx)
+        {
+            return _orphanRun[consumedEndIdx];
+        }
+
+        // Could any registered active pattern begin a match at tokens[idx]? Deliberately
+        // CONSERVATIVE: where the answer is uncertain it must be yes, and nothing is charged.
+        // The failure modes are not symmetric — over-charging destroys sequential extraction,
+        // while under-charging merely leaves a score where it already is today.
+        //
+        // Callers must not pass an [unk] index; BuildCoverageTables settles those first.
+        internal bool CanStartPattern(string[] tokens, int idx)
+        {
+            if (_startLiterals.Contains(tokens[idx]))
+                return true;
+
+            for (int s = 0; s < _startSlots.Length; s++)
+            {
+                int slotIdx = _startSlots[s];
+                if (_slots[slotIdx].Type == VoxrSlotType.NumberSequence)
+                {
+                    // Capped at minWords, not maxWords: the question is only whether enough
+                    // digits are present to satisfy the slot, so there is no reason to walk
+                    // the rest of the run.
+                    int minWords = _slots[slotIdx].MinWords;
+                    if (CountNumberSequenceWords(tokens, idx, minWords, out _) >= minWords)
+                        return true;
+                }
+                else if (TryMatchSlot(tokens, idx, slotIdx, out _) != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static float ComputeConfidence(string[] tokens, int startIdx, int endIdx,
@@ -1473,6 +1744,7 @@ namespace VoXR.Commands
                 return EagerCommitVerdict.None;
 
             EnsureCanCommitEarly();
+            BuildCoverageTables(tokens);
 
             float bestScore = float.MinValue;
             int bestLiteralCount = -1;
@@ -1494,7 +1766,8 @@ namespace VoXR.Commands
                         if (tokens[startIdx] == UnkToken)
                             continue;
 
-                        var matchResult = TryMatchScored(tokens, startIdx, patterns[pi]);
+                        // searchStart is 0: this scan mirrors ParseInternal's first round.
+                        var matchResult = TryMatchScored(tokens, startIdx, patterns[pi], 0);
 
                         if (
                             IsBetterCandidate(

--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -71,9 +71,13 @@ namespace VoXR.Commands
 
         // Weight added to the score denominator per in-grammar token a match leaves
         // unexplained: those the sliding start skipped to reach it (issue #31) and those left
-        // orphaned after it (issue #65 §5.2). At 1.0 the score is exactly the fraction of the
-        // utterance the pattern accounts for, so a lone one-element pattern found in the tail
+        // orphaned after it (issue #65 §5.2). At 1.0 a one-element pattern found in the tail
         // of a longer utterance scores 0.5 and falls below the default minScore.
+        //
+        // Close to "the fraction of the utterance the pattern accounts for", but not exactly:
+        // trailing tokens that could begin another pattern are not charged, so "cease fire"
+        // keeps a full 1.0 in "cease fire launch missiles target hotel one" while accounting
+        // for two tokens of seven. That amnesty is what makes multi-command utterances work.
         //
         // Renamed from skippedWordPenalty by DR-4, because one weight now governs both sides
         // and the old name described only the leading half. The rename also stops hiding a
@@ -148,14 +152,21 @@ namespace VoXR.Commands
         // shrunk, matching the _matchSlotBuf / _resultBuf pooling discipline — coverage adds
         // no per-utterance allocation.
         //
-        //   _recognisedPrefix[i] — non-[unk] tokens in [0, i), so the words a round's sliding
-        //                          start walked past are one subtraction instead of a scan.
-        //   _orphanRun[i]        — tokens left unexplained in the run starting at i.
+        //   _recognisedPrefix[i]  — non-[unk] tokens in [0, i), so the words a round's sliding
+        //                           start walked past are one subtraction instead of a scan.
+        //   _orphanRun[i]         — tokens left unexplained in the run starting at i.
+        //   _forcedOrphanRun[i]   — the same, under Amendment A3, for a candidate that
+        //                           mis-predicted the token at i (see BuildCoverageTables).
         //
-        // Both are functions of the token array and the grammar alone and are complete before
+        // All are functions of the token array and the grammar alone and are complete before
         // any candidate is scored, so no candidate's score depends on evaluation order.
         int[] _recognisedPrefix;
         int[] _orphanRun;
+        int[] _forcedOrphanRun;
+
+        // The array the tables above were built for, so the coupling between them can be
+        // asserted rather than merely described. Not used for scoring.
+        string[] _coverageTokens;
 
         // Pre-allocated slot match buffers — avoids per-call List allocations in TryMatchScored/Parse.
         readonly int _maxSlotsPerPattern;
@@ -766,11 +777,8 @@ namespace VoXR.Commands
                 if (bestEndIdx <= searchStart)
                     break;
 
-                // No post-selection adjustment. The skipped-word charge that used to sit here
-                // (issue #31) now lives in TryMatchScored alongside the trailing term, so the
-                // score a candidate was SELECTED on is the score it is reported with. It was
-                // here in the first place to keep it from reordering anything; issue #65 §5.2
-                // is the finding that reordering is exactly what symptom 2 needs.
+                // No post-selection adjustment: the score a candidate was SELECTED on is the
+                // score it is reported with.
                 float confidence = ComputeConfidence(tokens, bestStartIdx, bestEndIdx, wordConfidence);
 
                 VoxrSlotMatch[] slotsArray;
@@ -1183,11 +1191,12 @@ namespace VoXR.Commands
                         denominator += MatchScore;
                         missedRequired++;
                         missedRequiredSlot = true;
-                        // Currently dominated: missedRequiredSlot refuses an eager commit one
-                        // guard earlier, so this increment can never be the sole cause of a
-                        // refusal. Kept so the field stays true to its name — "any required
-                        // ELEMENT after the last match" — and so the tail condition does not
-                        // quietly depend on the slot guard's existence or its placement.
+                        // Dominated as an eager-REFUSAL cause: missedRequiredSlot refuses one
+                        // guard earlier, so this increment is never the sole reason a commit
+                        // is refused. It is NOT dominated generally — Amendment A3 gave it a
+                        // second consumer, and there it acts alone: a non-zero value here
+                        // selects the forced orphan table and so changes the flush-path score.
+                        // Narrowing this increment would move scores grammar-wide.
                         requiredAfterLastMatch++;
                     }
                     // Unmatched optional slot: contributes nothing to score or denominator.
@@ -1234,58 +1243,29 @@ namespace VoXR.Commands
 
             _matchSlotCount = slotCount;
 
-            // Coverage (issue #65 §5.2): charge the candidate for the in-grammar tokens it
-            // leaves unexplained on EITHER side — the words the sliding start walked past to
-            // reach it, and the run after its last match that no pattern could begin. One
-            // weight governs both, so the score reads as the fraction of the utterance this
-            // pattern actually accounts for rather than as how neatly it matched wherever it
-            // happened to land.
+            // Coverage (issue #65 §5.2), computed HERE — before the caller compares
+            // candidates — which is the whole of the change. The leading term used to be
+            // applied to the winner alone, after selection, so that it could only filter via
+            // minScore and never reorder; symptom 2 cannot be fixed under that constraint,
+            // because a bare pattern that matches perfectly scores 1.0 and nothing normalised
+            // to 1.0 can beat it. See DefaultCoverageWeight for what the weight means.
             //
-            // Computed HERE, before the caller compares candidates, and that relocation is
-            // the whole change. The leading term used to be applied to the winner alone
-            // (issue #31), deliberately placed after selection so it could only filter via
-            // minScore and never reorder. Symptom 2 of issue #65 cannot be fixed under that
-            // constraint: register "decelerate" alongside "decelerate by {burn_level}", drop
-            // the "by", and the bare form matches perfectly at 1.0 — nothing normalised to
-            // 1.0 can beat it, at any penalty setting. Only charging it for the "hard burn"
-            // it failed to explain demotes it, and only a term inside selection can.
+            // Adding to the denominator cannot change the sign of a negative rawScore, so the
+            // Score <= 0f floors above and in IsBetterCandidate behave exactly as before; and
+            // since rawScore <= denominator always holds, a strictly larger denominator keeps
+            // the score inside [0, 1].
             //
-            // Both terms come from tables built once per utterance, so this stays two array
-            // indexes inside a triple-nested loop. Adding to the denominator cannot change
-            // the sign of a negative rawScore, so the Score <= 0f floors above and in
-            // IsBetterCandidate behave exactly as before; and since rawScore <= denominator
-            // always holds, a strictly larger denominator keeps the score inside [0, 1].
-            // One exception to the orphan run's start, at its first position only (Amendment
-            // A3). Where this candidate's OWN next required element failed to match, that
-            // token is charged outright instead of being tested against the start predicate:
-            // a candidate that just mis-predicted a token may not then claim some other
-            // pattern could have begun there.
-            //
-            // Without it the rule rewards matching LESS. Take ["switch","to","weapons"] and
-            // ["switch","to","navigation"] on "switch to weapons target hotel". The
-            // navigation pattern MISSES its final element, so its consumed span stops at
-            // "weapons" — which begins ["weapons","mode"], terminating its orphan run at zero
-            // for a tidy 2/3. The weapons pattern MATCHES that element, so its origin moves
-            // past the very token that would have terminated its own run, and it pays for
-            // "target hotel": 3/(3+2) = 0.6. The wrong command wins by 0.067 and fires.
-            // Measured: safe at one leftover token, flips at two.
-            int orphanedAfter;
-            if (requiredAfterLastMatch > 0)
-            {
-                int mispredicted = consumedEndIdx;
-                while (mispredicted < tokens.Length && tokens[mispredicted] == UnkToken)
-                    mispredicted++;
-
-                orphanedAfter =
-                    mispredicted < tokens.Length ? 1 + OrphanedAfter(mispredicted + 1) : 0;
-            }
-            else
-            {
-                orphanedAfter = OrphanedAfter(consumedEndIdx);
-            }
+            // requiredAfterLastMatch selects WHICH orphan table to read (Amendment A3): a
+            // candidate whose own next required element failed at this position owns the token
+            // it mis-predicted and may not claim some other pattern could have begun there.
+            // Both tables are built once per utterance, so this is two array reads.
+            AssertCoverageTablesMatch(tokens);
 
             float coverage =
-                (SkippedBefore(searchStart, startIdx) + orphanedAfter) * _coverageWeight;
+                (
+                    SkippedBefore(searchStart, startIdx)
+                    + OrphanedAfter(consumedEndIdx, requiredAfterLastMatch > 0)
+                ) * _coverageWeight;
 
             float normalizedScore = denominator > 0f ? rawScore / (denominator + coverage) : 0f;
 
@@ -1477,28 +1457,90 @@ namespace VoXR.Commands
             int n = tokens.Length;
             if (_recognisedPrefix == null || _recognisedPrefix.Length < n + 1)
             {
+                // All three grow together and are only ever read below their built length, so
+                // one capacity test covers them. Adding a fourth outside this block would
+                // reintroduce the per-utterance allocation the pooling exists to avoid.
                 _recognisedPrefix = new int[n + 1];
                 _orphanRun = new int[n + 1];
+                _forcedOrphanRun = new int[n + 1];
+            }
+
+            // Binds the tables to the array they describe, so a future entry point that
+            // reaches TryMatchScored without building them fails loudly instead of reading
+            // another utterance's answers. The arrays are grown and never shrunk, so a stale
+            // longer table returns in-range numbers for the wrong tokens — silently wrong on
+            // a shorter utterance, and only out-of-range on a longer one, which is the worse
+            // ordering of the two.
+            _coverageTokens = tokens;
+
+            // Nothing is charged at zero weight, so skip the predicate sweep entirely rather
+            // than compute a table that will be multiplied away. The tables are still cleared
+            // rather than left stale, so the accessors keep answering honestly ("nothing is
+            // charged") instead of returning the previous utterance's counts.
+            if (_coverageWeight <= 0f)
+            {
+                Array.Clear(_recognisedPrefix, 0, n + 1);
+                Array.Clear(_orphanRun, 0, n + 1);
+                Array.Clear(_forcedOrphanRun, 0, n + 1);
+                return;
             }
 
             _recognisedPrefix[0] = 0;
             for (int i = 0; i < n; i++)
                 _recognisedPrefix[i + 1] = _recognisedPrefix[i] + (tokens[i] == UnkToken ? 0 : 1);
 
-            // Backwards in one pass, three cases. The [unk] line carries both halves of that
-            // token's rule at once: never charged, and TRANSPARENT rather than a run
-            // terminator. A stopper would let one noise token shield every real orphan behind
-            // it, so "decelerate [unk] hard burn" must cost exactly what "decelerate hard
-            // burn" costs.
+            // Backwards in one pass. _orphanRun's three cases are the ordinary rule; the
+            // [unk] line carries both halves of that token's exemption at once — never
+            // charged, and TRANSPARENT rather than a run terminator. A stopper would let one
+            // noise token shield every real orphan behind it, so "decelerate [unk] hard burn"
+            // must cost exactly what "decelerate hard burn" costs.
+            //
+            // _forcedOrphanRun is the same quantity under Amendment A3, for a candidate whose
+            // own next required element failed at this position: the first non-[unk] token is
+            // charged outright instead of being tested against the start predicate, and the
+            // run continues normally after it.
+            //
+            // Without that, the rule rewards matching LESS. Take ["switch","to","weapons"] and
+            // ["switch","to","navigation"] on "switch to weapons target hotel". The navigation
+            // pattern MISSES its final element, so its consumed span stops at "weapons" —
+            // which begins ["weapons","mode"], terminating its orphan run at zero for a tidy
+            // 2/3. The weapons pattern MATCHES that element, so its origin moves past the very
+            // token that would have terminated its own run, and pays for "target hotel":
+            // 3/(3+2) = 0.6. The wrong command wins by 0.067 and fires. Measured: safe at one
+            // leftover token, flips at two.
+            //
+            // Tabulated here rather than branched at the call site because the A3 rule is a
+            // function of the token array alone — requiredAfterLastMatch only selects WHICH
+            // table to read — which keeps the per-candidate cost at one array index and keeps
+            // both forms of the rule at the one site that defines them.
             _orphanRun[n] = 0;
+            _forcedOrphanRun[n] = 0;
             for (int i = n - 1; i >= 0; i--)
             {
                 if (tokens[i] == UnkToken)
+                {
                     _orphanRun[i] = _orphanRun[i + 1];
-                else if (CanStartPattern(tokens, i))
-                    _orphanRun[i] = 0;
-                else
-                    _orphanRun[i] = 1 + _orphanRun[i + 1];
+                    _forcedOrphanRun[i] = _forcedOrphanRun[i + 1];
+                    continue;
+                }
+
+                _orphanRun[i] = CanStartPattern(tokens, i) ? 0 : 1 + _orphanRun[i + 1];
+                _forcedOrphanRun[i] = 1 + _orphanRun[i + 1];
+            }
+        }
+
+        // Guards the precondition that BuildCoverageTables ran over the array being scored.
+        // Editor-only: the coupling is real but the check is not worth a branch in a shipped
+        // build, and every production caller is two lines away from its own build call.
+        [System.Diagnostics.Conditional("UNITY_EDITOR")]
+        void AssertCoverageTablesMatch(string[] tokens)
+        {
+            if (!ReferenceEquals(_coverageTokens, tokens))
+            {
+                throw new InvalidOperationException(
+                    "Coverage tables were not built for this token array — call "
+                        + "BuildCoverageTables(tokens) before scoring candidates over it."
+                );
             }
         }
 
@@ -1511,14 +1553,20 @@ namespace VoXR.Commands
             return _recognisedPrefix[startIdx] - _recognisedPrefix[searchStart];
         }
 
-        // Tokens left unexplained in the run starting where the candidate's last match ended.
+        // Tokens left unexplained in the run starting where the candidate's last match ended,
+        // under whichever of the two rules applies to it.
+        //
         // Measured from ConsumedEndIdx rather than EndIdx: the two provably agree today (the
         // only thing that moves the cursor without recording a match is the [unk] skip, and
         // [unk] is transparent above), but ConsumedEndIdx is the index whose correctness does
         // not depend on that staying true.
-        internal int OrphanedAfter(int consumedEndIdx)
+        //
+        // `ownsTheNextToken` is Amendment A3: pass true when the candidate's own next required
+        // element failed at this position, so it may not claim that some OTHER pattern could
+        // have begun on the token it just mis-predicted.
+        internal int OrphanedAfter(int consumedEndIdx, bool ownsTheNextToken = false)
         {
-            return _orphanRun[consumedEndIdx];
+            return ownsTheNextToken ? _forcedOrphanRun[consumedEndIdx] : _orphanRun[consumedEndIdx];
         }
 
         // Could any registered active pattern begin a match at tokens[idx]? Deliberately
@@ -1849,11 +1897,13 @@ namespace VoXR.Commands
             // preamble ("Helm, coast") is skipped rather than blocking the commit (issue #43),
             // matching the sliding start that already absorbs it for free everywhere else.
             //
-            // Only [unk] may precede the match. ParseInternal charges skipped *recognised*
-            // words against the score after selection (issue #31) and this scan does not, so
-            // relaxing this to tolerate any leading leftover would let the gate commit a
-            // buffer the subsequent flush then scores below minScore. [unk] is exempt from
-            // that penalty, which is what keeps the two scores identical here.
+            // Only [unk] may precede the match. This scan and the flush now compute the SAME
+            // score — both charge leading skipped words through TryMatchScored (issue #65
+            // §5.2), where the flush path once applied that charge after selection and this
+            // scan omitted it — so the two can no longer diverge, and this condition is not
+            // what keeps them aligned. What it still buys is completeness: a leading run of
+            // recognised words the match did not consume means the buffer holds more than
+            // this command, and committing would fire on part of it.
             int firstRecognisedIdx = 0;
             while (firstRecognisedIdx < tokens.Length && tokens[firstRecognisedIdx] == UnkToken)
                 firstRecognisedIdx++;

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace VoXR.Commands
 {
@@ -29,14 +30,25 @@ namespace VoXR.Commands
                  "Prevents partial or garbled matches.")]
         [SerializeField] float minScore = 0.6f;
 
-        [Tooltip("How much each in-grammar word the parser skips before a match starts " +
-                 "counts against the score. The parser slides its start point through the " +
-                 "utterance, so without this a short pattern found in the tail of a stray " +
-                 "sentence scores a full 1.0 and fires. At 1.0 the score becomes the " +
-                 "fraction of the utterance the pattern covers, so a one-word command " +
-                 "needs to be most of what was said. Unrecognised ([unk]) filler is never " +
-                 "charged. Set to 0 to disable.")]
-        [SerializeField] float skippedWordPenalty = VoxrCommandParser.DefaultSkippedWordPenalty;
+        [Tooltip(
+            "How much each in-grammar word a match leaves unexplained counts against "
+                + "the score — both the words the parser skipped to reach the match and the "
+                + "ones left over after it. The parser slides its start point through the "
+                + "utterance, so without this a short pattern found anywhere inside a longer "
+                + "sentence scores a full 1.0 and fires, discarding the rest. At 1.0 the "
+                + "score becomes the fraction of the utterance the pattern covers, so a "
+                + "one-word command needs to be most of what was said. Unrecognised ([unk]) "
+                + "filler is never charged, and leftover words that could begin another "
+                + "command are not either, so chained commands still work. Set to 0 to "
+                + "disable — note that this also restores the behaviour where a spoken "
+                + "argument can be silently dropped in favour of a shorter pattern."
+        )]
+        // DR-4: carries the value across the rename, so a scene or prefab that set the old
+        // field keeps its tuning. The field is private, so this covers the whole serialized
+        // surface — there is no public property or constant to forward from.
+        [FormerlySerializedAs("skippedWordPenalty")]
+        [SerializeField]
+        float coverageWeight = VoxrCommandParser.DefaultCoverageWeight;
 
         [Tooltip("Time in seconds to wait for additional speech before parsing. " +
                  "Longer values recover split commands but add latency. " +
@@ -170,7 +182,7 @@ namespace VoXR.Commands
             EnsureAcceptedBuffer(commands.Length);
 
             _parser = new VoxrCommandParser(_slotManager.BuildEffectiveSlots(_slots), commands,
-                skippedWordPenalty);
+                coverageWeight);
             _grammar.Rebuild(_slots, commands, GetFollowUpGrammarWords());
 
             if (!freeSpeechMode && speechRecogniser != null && speechRecogniser.IsModelReady)
@@ -272,7 +284,7 @@ namespace VoXR.Commands
                     "Configure must be called before RebuildParser().");
 
             _parser = new VoxrCommandParser(_slotManager.BuildEffectiveSlots(_slots), _activeCommands,
-                skippedWordPenalty);
+                coverageWeight);
         }
 
         public void RebuildGrammar()

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -36,12 +36,14 @@ namespace VoXR.Commands
                 + "ones left over after it. The parser slides its start point through the "
                 + "utterance, so without this a short pattern found anywhere inside a longer "
                 + "sentence scores a full 1.0 and fires, discarding the rest. At 1.0 the "
-                + "score becomes the fraction of the utterance the pattern covers, so a "
+                + "score is close to the fraction of the utterance the pattern covers, so a "
                 + "one-word command needs to be most of what was said. Unrecognised ([unk]) "
-                + "filler is never charged, and leftover words that could begin another "
-                + "command are not either, so chained commands still work. Set to 0 to "
-                + "disable — note that this also restores the behaviour where a spoken "
-                + "argument can be silently dropped in favour of a shorter pattern."
+                + "filler is never charged, and a leftover word that could begin another "
+                + "command or a confirm/cancel reply usually is not either, so chained "
+                + "commands still work — the exception is a word the pattern itself tried "
+                + "and failed to match, which is always charged. Set to 0 to disable — note "
+                + "that this also restores the behaviour where a spoken argument can be "
+                + "silently dropped in favour of a shorter pattern."
         )]
         // DR-4: carries the value across the rename for this field's OWN serialized data, so
         // a scene or asset that set the old name deserializes onto the new one. The field is
@@ -191,8 +193,13 @@ namespace VoXR.Commands
             _setManager.BuildLookup(commands);
             EnsureAcceptedBuffer(commands.Length);
 
+            // Same word list to both: the decoder can return follow-up vocabulary as real
+            // tokens, so the parser's coverage rule has to know those words are legitimate
+            // rather than charge them as unexplained (issue #65 §5.2).
             _parser = new VoxrCommandParser(_slotManager.BuildEffectiveSlots(_slots), commands,
-                coverageWeight);
+                coverageWeight,
+                GetFollowUpGrammarWords()
+            );
             _grammar.Rebuild(_slots, commands, GetFollowUpGrammarWords());
 
             if (!freeSpeechMode && speechRecogniser != null && speechRecogniser.IsModelReady)
@@ -294,7 +301,9 @@ namespace VoXR.Commands
                     "Configure must be called before RebuildParser().");
 
             _parser = new VoxrCommandParser(_slotManager.BuildEffectiveSlots(_slots), _activeCommands,
-                coverageWeight);
+                coverageWeight,
+                GetFollowUpGrammarWords()
+            );
         }
 
         public void RebuildGrammar()

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -43,9 +43,19 @@ namespace VoXR.Commands
                 + "disable — note that this also restores the behaviour where a spoken "
                 + "argument can be silently dropped in favour of a shorter pattern."
         )]
-        // DR-4: carries the value across the rename, so a scene or prefab that set the old
-        // field keeps its tuning. The field is private, so this covers the whole serialized
-        // surface — there is no public property or constant to forward from.
+        // DR-4: carries the value across the rename for this field's OWN serialized data, so
+        // a scene or asset that set the old name deserializes onto the new one. The field is
+        // private, so there is no public property or constant needing a separate forwarder.
+        //
+        // Scope, deliberately narrow: [FormerlySerializedAs] governs field deserialization.
+        // A prefab-INSTANCE override is stored as a literal propertyPath string in the
+        // instance's m_Modifications and applied against the already-loaded prefab, and the
+        // same is true of .preset assets and of any editor script calling FindProperty with
+        // the old name. Whether Unity remaps those paths through this attribute is not
+        // established here and no automated instrument in this package can settle it — it
+        // needs a real prefab-override round-trip in a host project. Nothing shipped in this
+        // package is affected: no prefab, no preset, no CustomEditor, and no sample scene
+        // serializes this field at all.
         [FormerlySerializedAs("skippedWordPenalty")]
         [SerializeField]
         float coverageWeight = VoxrCommandParser.DefaultCoverageWeight;

--- a/Runtime/Testing/VoxrBatchTestRunner.cs
+++ b/Runtime/Testing/VoxrBatchTestRunner.cs
@@ -20,12 +20,12 @@ namespace VoXR.Testing
 
         public VoxrBatchTestRunner(VoxrSlotDefinition[] slots, VoxrCommandDefinition[] commands,
             float minScore = 0.6f, float minConfidence = 0.4f,
-            float skippedWordPenalty = VoxrCommandParser.DefaultSkippedWordPenalty)
+            float coverageWeight = VoxrCommandParser.DefaultCoverageWeight)
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (commands == null) throw new ArgumentNullException(nameof(commands));
 
-            _parser = new VoxrCommandParser(slots, commands, skippedWordPenalty);
+            _parser = new VoxrCommandParser(slots, commands, coverageWeight);
             _defsByIntent = IndexByIntent(commands);
             _minScore = minScore;
             _minConfidence = minConfidence;
@@ -33,7 +33,7 @@ namespace VoXR.Testing
 
         public VoxrBatchTestRunner(VoxrSlotDefinition[] slots, VoxrCommandSet[] sets,
             string[] activeSetNames, float minScore = 0.6f, float minConfidence = 0.4f,
-            float skippedWordPenalty = VoxrCommandParser.DefaultSkippedWordPenalty)
+            float coverageWeight = VoxrCommandParser.DefaultCoverageWeight)
         {
             if (slots == null) throw new ArgumentNullException(nameof(slots));
             if (sets == null) throw new ArgumentNullException(nameof(sets));
@@ -60,7 +60,7 @@ namespace VoXR.Testing
                 offset += c.Length;
             }
 
-            _parser = new VoxrCommandParser(slots, commands, skippedWordPenalty);
+            _parser = new VoxrCommandParser(slots, commands, coverageWeight);
             _defsByIntent = IndexByIntent(commands);
             _minScore = minScore;
             _minConfidence = minConfidence;

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -1256,8 +1256,9 @@ namespace VoXR.Tests.Runtime
                 }
             );
 
+            // No BuildCoverageTables call: CanStartPattern reads only the constructor-built
+            // start caches and the token argument. It is what FILLS the tables, not a reader.
             var tokens = "please fire missiles two hotel".Split(' ');
-            parser.BuildCoverageTables(tokens);
 
             Assert.IsTrue(
                 parser.CanStartPattern(tokens, 0),
@@ -1290,7 +1291,6 @@ namespace VoXR.Tests.Runtime
             );
 
             var tokens = "halt two seven banana".Split(' ');
-            parser.BuildCoverageTables(tokens);
 
             Assert.IsTrue(parser.CanStartPattern(tokens, 0), "literal-initial pattern");
             Assert.IsTrue(parser.CanStartPattern(tokens, 1), "two digits available, minWords 2");
@@ -1303,12 +1303,12 @@ namespace VoXR.Tests.Runtime
 
         // --- [unk] handling on the trailing side (issue #65 §5.2) ---
         //
-        // Written before the trailing coverage term exists. Both tests are stated as
-        // EQUALITIES rather than values, which is what lets them stand on both sides of
-        // the change: today every score below is 1.0 because nothing after a match is
-        // charged, and afterwards the charged pairs move together. What they discriminate
-        // is an implementation that gets [unk] wrong, which is invisible either way if the
-        // assertion is a bare number.
+        // Written before the trailing coverage term existed, and deliberately kept in that
+        // form. Both tests are stated as EQUALITIES rather than values, which is what let
+        // them stand on both sides of the change: before, every score here was 1.0 because
+        // nothing after a match was charged; now the charged pairs move together. What they
+        // discriminate is an implementation that gets [unk] wrong — invisible either way if
+        // the assertion is a bare number.
 
         [Test]
         public void TrailingUnk_DoesNotTerminateTheOrphanRun()
@@ -1519,7 +1519,7 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
-        public void LongerSpanPatternWins_NowOnScoreRatherThanTheSpanKey()
+        public void SpanTieBreak_LongerSpanPatternNowWinsOnScore()
         {
             // Span sits ABOVE literal count, so it also settles equal-score candidates whose
             // literal counts differ — outcomes literal count used to decide on its own,
@@ -1550,13 +1550,13 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(
                 1,
                 result.Command.MatchedPatternIndex,
-                "the 2-literal/4-token pattern must beat the 3-literal/3-token one"
+                "the slot pattern wins on score now — the literal one strands \"one\""
             );
             Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
         }
 
         [Test]
-        public void LongerSpanCommandWins_AcrossCommands_NowOnScore()
+        public void SpanTieBreak_LongerSpanCommandNowWinsOnScore_AcrossCommands()
         {
             // The comparison runs across the whole command list, so a span tie changes which
             // *intent* fires, not merely which pattern index within one command.
@@ -2161,16 +2161,175 @@ namespace VoXR.Tests.Runtime
                         "decelerate_by",
                         new[] { new[] { "decelerate", "by", "{burn_level}" } }
                     ),
-                    new VoxrCommandDefinition("hard_stop", new[] { new[] { "hard", "stop" } }),
+                    // Three elements, so on "hard burn" it matches 1 required and misses 2 —
+                    // DR-7 REFUSES it. That is deliberate: the orphan test is defined over
+                    // registered patterns, not over admitted candidates, so "hard" must
+                    // terminate the run even though no candidate starting there survives. An
+                    // earlier two-element version of this fixture was DR-7-admitted, so it
+                    // passed identically under both definitions and pinned neither.
+                    new VoxrCommandDefinition(
+                        "hard_stop",
+                        new[] { new[] { "hard", "stop", "now" } }
+                    ),
                 }
             );
 
             var results = parser.Parse("decelerate hard burn");
 
+            Assert.AreEqual(1, results.Length, "the hard_stop candidate is refused by DR-7");
             Assert.AreEqual("decelerate", results[0].Command.Intent);
             Assert.AreEqual(1.0f, results[0].Command.Score, 0.001f);
             Assert.IsFalse(results[0].Command.HasSlot("burn_level"));
             LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void Coverage_LeadingTerm_ReordersSiblingsAtTheSameStart()
+        {
+            // The leading half of "coverage is computed before candidates are compared" — and
+            // the only shape that can demonstrate it. Earliest start outranks score, and
+            // SkippedBefore is the same constant for every candidate at a given start index,
+            // so the leading term can only decide between siblings that START TOGETHER and
+            // whose denominators differ.
+            //
+            // Without such a case the whole leading half can be reverted to post-selection
+            // application with the suite staying green — verified by building that mutant and
+            // finding zero failures across the suite and 1095 utterances.
+            //
+            // "burn_now" makes "hard" a pattern start so both trailing terms are zero;
+            // "set target mode" makes "target" in-grammar filler that begins nothing. Two
+            // leading skips then separate 1/(1+2) = 0.333 from 2/(3+2) = 0.400, inverting the
+            // 1.0-vs-0.667 order the un-charged scores would have given.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("required literal \"by\""));
+
+            var parser = new VoxrCommandParser(
+                new[] { new VoxrSlotDefinition("burn", new[] { "hard" }) },
+                new[]
+                {
+                    new VoxrCommandDefinition("decelerate", new[] { new[] { "decelerate" } }),
+                    new VoxrCommandDefinition(
+                        "decelerate_by",
+                        new[] { new[] { "decelerate", "by", "{burn}" } }
+                    ),
+                    new VoxrCommandDefinition("burn_now", new[] { new[] { "{burn}", "now" } }),
+                    new VoxrCommandDefinition(
+                        "set_target_mode",
+                        new[] { new[] { "set", "target", "mode" } }
+                    ),
+                }
+            );
+
+            var results = parser.Parse("target target decelerate hard");
+
+            Assert.AreEqual(
+                1,
+                results.Length,
+                "the bare form would strand \"hard\" and split this into two commands"
+            );
+            Assert.AreEqual("decelerate_by", results[0].Command.Intent);
+            Assert.AreEqual("hard", results[0].Command.GetSlot("burn"));
+            Assert.AreEqual(2f / 5f, results[0].Command.Score, 0.001f);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void Coverage_MisPredictedTokenCharge_StopsAtTheNextPatternStart()
+        {
+            // A3 charges the mis-predicted token and then hands back to the ordinary run — it
+            // is an exception at ONE position, not a licence to charge everything after.
+            //
+            // "switch to navigation" misses its final element against "weapons", so A3 charges
+            // that token; the run then stops at "halt", which begins a pattern. 2/(3+1) = 0.5.
+            // Charging the whole tail instead would give 2/(3+2) = 0.4 — which is exactly what
+            // the second parse shows, where nothing after the mis-predicted token is a start.
+            var parser = new VoxrCommandParser(
+                Array.Empty<VoxrSlotDefinition>(),
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "mode_navigation",
+                        new[] { new[] { "switch", "to", "navigation" } }
+                    ),
+                    new VoxrCommandDefinition("halt", new[] { new[] { "halt" } }),
+                }
+            );
+
+            Assert.AreEqual(
+                0.5f,
+                parser.Parse("switch to weapons halt")[0].Command.Score,
+                0.001f,
+                "the run stops at \"halt\", so only the mis-predicted token is charged"
+            );
+            Assert.AreEqual(
+                0.4f,
+                parser.Parse("switch to weapons stuff")[0].Command.Score,
+                0.001f,
+                "with no start to stop at, the run continues and charges both"
+            );
+        }
+
+        [Test]
+        public void Coverage_FractionalWeight_ScalesBothTermsAlike()
+        {
+            // The only assertions on the weight were at 0 and 1, where many inequivalent
+            // formulas agree — Ceil(w), w squared, or a weight applied to one term only all
+            // pass. One leading skip ("zulu") and one trailing orphan ("yankee") over a
+            // one-element pattern make the arithmetic 1/(1 + 2w), which separates them.
+            var commands = new[] { new VoxrCommandDefinition("solo", new[] { new[] { "alpha" } }) };
+
+            foreach (var (weight, expected) in new[] { (0f, 1f), (0.5f, 0.5f), (1f, 1f / 3f) })
+            {
+                var parser = new VoxrCommandParser(
+                    Array.Empty<VoxrSlotDefinition>(),
+                    commands,
+                    weight
+                );
+
+                Assert.AreEqual(
+                    expected,
+                    ParseOne(parser, "zulu alpha yankee").Command.Score,
+                    0.001f,
+                    $"1 / (1 + 2 x {weight})"
+                );
+            }
+        }
+
+        [Test]
+        public void Coverage_FollowUpVocabulary_IsNotChargedAsAnOrphan()
+        {
+            // The recogniser puts confirm/cancel words in the DECODER's grammar, so VOSK
+            // returns them as real tokens rather than [unk] — and they begin no pattern. Left
+            // out of the parser's view they read as orphans, and "disengage, yes" drops from
+            // 1.0 to 0.5, under minScore, firing nothing: a working utterance broken by the
+            // package's own vocabulary.
+            //
+            // The two parsers below differ only in whether the parser was told what the
+            // decoder was told, which is the whole of the fix.
+            var commands = new[]
+            {
+                new VoxrCommandDefinition("cease_fire", new[] { new[] { "disengage" } }),
+            };
+
+            var informed = new VoxrCommandParser(
+                Array.Empty<VoxrSlotDefinition>(),
+                commands,
+                VoxrCommandParser.DefaultCoverageWeight,
+                new[] { "yes", "confirm", "cancel" }
+            );
+            var uninformed = new VoxrCommandParser(Array.Empty<VoxrSlotDefinition>(), commands);
+
+            Assert.AreEqual(
+                1.0f,
+                ParseOne(informed, "disengage yes").Command.Score,
+                0.001f,
+                "a follow-up word can legitimately begin something, so it ends the orphan run"
+            );
+            Assert.AreEqual(
+                0.5f,
+                ParseOne(uninformed, "disengage yes").Command.Score,
+                0.001f,
+                "and this is what it costs when the parser is not told — the defect being fixed"
+            );
         }
 
         [Test]

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -1164,6 +1164,269 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
         }
 
+        // --- Coverage tables (issue #65 §5.2) ---
+        //
+        // The two tables and the pattern-start predicate, driven directly rather than
+        // inferred from scores. They sit inside a triple-nested loop, so they are built once
+        // per utterance and read as array indexes; testing them through Parse() alone would
+        // leave the interesting cases (an orphan run stopped mid-utterance, an optional
+        // leading element) reachable only by contrived grammars.
+
+        [Test]
+        public void OrphanRun_StopsAtATokenThatCouldBeginAPattern()
+        {
+            // The whole reason the count is a RUN and not a total. "launch" begins a pattern,
+            // so cease_fire — which consumes through token 2 — is charged nothing for the
+            // five tokens after it, and the multi-command utterance survives. Charging them
+            // would take it from 2/2 to 2/7.
+            var parser = CreateParser();
+            var tokens = "cease fire launch missiles target hotel one".Split(' ');
+
+            parser.BuildCoverageTables(tokens);
+
+            Assert.AreEqual(0, parser.OrphanedAfter(2), "\"launch\" begins a pattern");
+            Assert.AreEqual(4, parser.OrphanedAfter(3), "missiles target hotel one");
+            Assert.AreEqual(3, parser.OrphanedAfter(4));
+            Assert.AreEqual(1, parser.OrphanedAfter(6));
+            Assert.AreEqual(0, parser.OrphanedAfter(7), "past the end");
+        }
+
+        [Test]
+        public void OrphanRun_TreatsUnkAsTransparent_NotAsAStopper()
+        {
+            var parser = CreateParser();
+            var tokens = "cease fire [unk] target".Split(' ');
+
+            parser.BuildCoverageTables(tokens);
+
+            Assert.AreEqual(
+                1,
+                parser.OrphanedAfter(2),
+                "the [unk] is free but must not hide the \"target\" behind it"
+            );
+            Assert.AreEqual(parser.OrphanedAfter(3), parser.OrphanedAfter(2));
+        }
+
+        [Test]
+        public void RecognisedPrefix_AgreesWithTheScanItReplaces()
+        {
+            // The leading term is the same quantity issue #31 already charges, computed by
+            // subtraction instead of by walking. Pinned against the original scan so the
+            // optimisation cannot drift from it.
+            var parser = CreateParser();
+            var tokens = "[unk] target [unk] disengage resume fire".Split(' ');
+
+            parser.BuildCoverageTables(tokens);
+
+            for (int from = 0; from <= tokens.Length; from++)
+            {
+                for (int to = from; to <= tokens.Length; to++)
+                {
+                    Assert.AreEqual(
+                        VoxrCommandParser.CountRecognisedTokens(tokens, from, to),
+                        parser.SkippedBefore(from, to),
+                        $"range [{from}, {to})"
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void CanStartPattern_WalksPastLeadingOptionals_ToTheFirstRequiredElement()
+        {
+            // "First matchable element" is not "element zero". An omitted optional lets the
+            // element behind it legitimately begin the match, so the walk continues through
+            // optionals and stops at (and includes) the first required one.
+            var parser = new VoxrCommandParser(
+                new[]
+                {
+                    new VoxrSlotDefinition("weapon", new[] { "missiles" }),
+                    new VoxrSlotDefinition("quantity", new[] { "two" }),
+                },
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "fire_weapon",
+                        new[] { new[] { "?please", "fire", "{weapon}" } }
+                    ),
+                    new VoxrCommandDefinition(
+                        "ready_weapon",
+                        new[] { new[] { "{?quantity}", "{weapon}" } }
+                    ),
+                }
+            );
+
+            var tokens = "please fire missiles two hotel".Split(' ');
+            parser.BuildCoverageTables(tokens);
+
+            Assert.IsTrue(
+                parser.CanStartPattern(tokens, 0),
+                "the optional literal is stored stripped, so \"please\" can start a match"
+            );
+            Assert.IsTrue(parser.CanStartPattern(tokens, 1), "the required literal after it");
+            Assert.IsTrue(
+                parser.CanStartPattern(tokens, 2),
+                "{weapon} is reachable first once {?quantity} is omitted"
+            );
+            Assert.IsTrue(parser.CanStartPattern(tokens, 3), "{?quantity} itself");
+            Assert.IsFalse(parser.CanStartPattern(tokens, 4), "in no pattern at all");
+        }
+
+        [Test]
+        public void CanStartPattern_NumberSequenceInitialPattern_MakesEveryDigitAStart()
+        {
+            // D4's degenerate case, pinned as tested behaviour rather than left as a
+            // surprise: a slot-initial pattern over a permissive slot makes a large class of
+            // tokens a potential start, which drives trailing orphan counts toward zero for
+            // the whole grammar. That is SAFE — it reverts to pre-coverage behaviour — but it
+            // silently weakens the feature, and an author has no way to see it.
+            var parser = new VoxrCommandParser(
+                new[] { VoxrSlotDefinition.NumberSequence("heading", minWords: 2, maxWords: 3) },
+                new[]
+                {
+                    new VoxrCommandDefinition("set_heading", new[] { new[] { "{heading}" } }),
+                    new VoxrCommandDefinition("halt", new[] { new[] { "halt" } }),
+                }
+            );
+
+            var tokens = "halt two seven banana".Split(' ');
+            parser.BuildCoverageTables(tokens);
+
+            Assert.IsTrue(parser.CanStartPattern(tokens, 0), "literal-initial pattern");
+            Assert.IsTrue(parser.CanStartPattern(tokens, 1), "two digits available, minWords 2");
+            Assert.IsFalse(
+                parser.CanStartPattern(tokens, 2),
+                "only one digit left, which cannot satisfy minWords 2"
+            );
+            Assert.IsFalse(parser.CanStartPattern(tokens, 3));
+        }
+
+        // --- [unk] handling on the trailing side (issue #65 §5.2) ---
+        //
+        // Written before the trailing coverage term exists. Both tests are stated as
+        // EQUALITIES rather than values, which is what lets them stand on both sides of
+        // the change: today every score below is 1.0 because nothing after a match is
+        // charged, and afterwards the charged pairs move together. What they discriminate
+        // is an implementation that gets [unk] wrong, which is invisible either way if the
+        // assertion is a bare number.
+
+        [Test]
+        public void TrailingUnk_DoesNotTerminateTheOrphanRun()
+        {
+            // [unk] is the decoder's marker for a token it could not place in the grammar,
+            // so no pattern element can equal it. It is free — but it must also be
+            // TRANSPARENT: if it stopped the scan of what a match left unexplained, a single
+            // noise token would shield every real leftover behind it. "X [unk] Y" therefore
+            // has to cost exactly what "X Y" costs.
+            //
+            // "target" is the orphan here: it appears in the grammar (as the required
+            // literal in "launch ... target {target}") but begins no pattern, and every
+            // candidate anchored on it scores <= 0, so it is left over rather than becoming
+            // a second command.
+            var parser = CreateParser();
+
+            var clean = ParseOne(parser, "cease fire target");
+            var noisy = ParseOne(parser, "cease fire [unk] target");
+
+            Assert.AreEqual("cease_fire", clean.Command.Intent);
+            Assert.AreEqual("cease_fire", noisy.Command.Intent);
+            Assert.AreEqual(
+                clean.Command.Score,
+                noisy.Command.Score,
+                0.001f,
+                "an [unk] sitting between the match and a leftover token must not change the charge"
+            );
+        }
+
+        [Test]
+        public void UnkFlankingTheMatch_IsFreeOnBothSides()
+        {
+            // The leading half is issue #31's existing rule (CountRecognisedTokens skips
+            // [unk]); the trailing half is the new side. Pinned together so the two stay
+            // symmetric — one weight, one rule, not two mechanisms.
+            var parser = CreateParser();
+
+            var bare = ParseOne(parser, "cease fire");
+            var flanked = ParseOne(parser, "[unk] [unk] cease fire [unk]");
+
+            Assert.AreEqual(1.0f, bare.Command.Score, 0.001f);
+            Assert.AreEqual(
+                1.0f,
+                flanked.Command.Score,
+                0.001f,
+                "out-of-grammar filler before and after a complete match costs nothing"
+            );
+        }
+
+        // "fire {?mode}" leaves EndIdx past a trailing [unk] it never consumed — the skip
+        // loop runs before EVERY element, including a trailing optional that then matches
+        // nothing — while ConsumedEndIdx stays at the last token actually matched. "now" is
+        // in the grammar as the tail literal of the track pattern, so it begins no pattern
+        // and every candidate anchored on it scores <= 0.
+        static VoxrCommandParser CreateTrailingOptionalParser()
+        {
+            return new VoxrCommandParser(
+                new[]
+                {
+                    new VoxrSlotDefinition("mode", new[] { "silent" }),
+                    new VoxrSlotDefinition("target", new[] { "hotel one" }),
+                },
+                new[]
+                {
+                    new VoxrCommandDefinition("fire", new[] { new[] { "fire", "{?mode}" } }),
+                    new VoxrCommandDefinition(
+                        "track",
+                        new[] { new[] { "track", "{target}", "now" } }
+                    ),
+                }
+            );
+        }
+
+        [Test]
+        public void TrailingUnk_AbsorbedIntoEndIdx_ShedsNoLeftover()
+        {
+            // A pattern must not be able to buy itself a cheaper score by swallowing noise:
+            // what it left unexplained is measured from the last token it actually MATCHED,
+            // not from wherever the [unk] skip happened to leave the cursor.
+            //
+            // Note what this can and cannot catch. Because [unk] is transparent (the test
+            // above), the count from ConsumedEndIdx and the count from EndIdx are provably
+            // equal whenever the gap between them is all-[unk] — which it always is, since
+            // the only thing that advances the cursor without recording a match is that skip
+            // loop. So this pins the CONJUNCTION: it fails if [unk] ever stops being
+            // transparent while the origin stays at ConsumedEndIdx, which is the shape that
+            // would let absorption pay.
+            var parser = CreateTrailingOptionalParser();
+
+            var clean = ParseOne(parser, "fire now");
+            var absorbing = ParseOne(parser, "fire [unk] now");
+
+            Assert.AreEqual("fire", clean.Command.Intent);
+            Assert.AreEqual("fire", absorbing.Command.Intent);
+            Assert.AreEqual(
+                clean.Command.Score,
+                absorbing.Command.Score,
+                0.001f,
+                "trailing [unk] the pattern never matched must not reduce what it is charged for"
+            );
+        }
+
+        [Test]
+        public void TrailingOptional_MatchesPastUnk_ProvingTheEndIdxGapIsReal()
+        {
+            // Guards the fixture above rather than the feature: it shows {?mode} really is
+            // evaluated at the token AFTER the [unk], which is why "fire [unk] now" leaves
+            // EndIdx one past ConsumedEndIdx. Without this, a change to the skip loop could
+            // silently turn the previous test into a comparison of two identical shapes.
+            var parser = CreateTrailingOptionalParser();
+
+            var absorbed = ParseOne(parser, "fire [unk] silent");
+
+            Assert.AreEqual("fire", absorbed.Command.Intent);
+            Assert.AreEqual("silent", absorbed.Command.GetSlot("mode"));
+            Assert.AreEqual(1.0f, absorbed.Command.Score, 0.001f);
+        }
+
         // --- Equal-score span tie-break (issue #41) ---
 
         // A tailed pattern and its bare sibling both score 1.0 with equal literal counts
@@ -1260,8 +1523,13 @@ namespace VoXR.Tests.Runtime
         {
             // Span sits ABOVE literal count, so it also settles equal-score candidates whose
             // literal counts differ — outcomes literal count used to decide on its own,
-            // deterministically, in either declaration order. Both patterns score 1.0 at
-            // token 0; the slot pattern has fewer literals but covers one more token.
+            // deterministically, in either declaration order.
+            //
+            // NO LONGER A TIE, since issue #65 §5.2. "one" is left unexplained by the
+            // 3-literal pattern, so it scores 3/(3+1) = 0.75 against the slot pattern's
+            // 3/3 = 1.0 and loses on score before span is ever consulted. The assertion below
+            // still passes and now proves nothing about the span key — see
+            // SpanTieBreak_StillDecidesAGenuineScoreTie for the version that does.
             var parser = new VoxrCommandParser(
                 new[] { new VoxrSlotDefinition("target", new[] { "hotel one" }) },
                 new[]
@@ -1291,8 +1559,11 @@ namespace VoXR.Tests.Runtime
         public void SpanTieBreak_ChoosesBetweenCommands_NotJustPatterns()
         {
             // The comparison runs across the whole command list, so a span tie changes which
-            // *intent* fires, not merely which pattern index within one command. Both match
-            // fully at token 0 with one literal each; go_place covers one more token.
+            // *intent* fires, not merely which pattern index within one command.
+            //
+            // NO LONGER A TIE either, for the same reason: go_dir strands "pole" and scores
+            // 2/(2+1) = 0.667 against go_place's 2/2 = 1.0. Kept because the cross-command
+            // outcome is still worth pinning, but the span key is no longer what produces it.
             var parser = new VoxrCommandParser(
                 new[]
                 {
@@ -1312,6 +1583,140 @@ namespace VoXR.Tests.Runtime
                 "go_place",
                 result.Command.Intent,
                 "the longer-span command wins even though it is declared second"
+            );
+            Assert.AreEqual("north pole", result.Command.GetSlot("place"));
+        }
+
+        [Test]
+        public void SpanTieBreak_StillDecidesAGenuineScoreTie()
+        {
+            // F10: the consumed-span key (issue #41) demotes to a real tie-break now that the
+            // score carries coverage — preserved, not superseded. The two tests above used to
+            // be its coverage and are now decided on score, so this restores a case where the
+            // scores are genuinely equal and span is what breaks them.
+            //
+            // The trick is that a tie needs both candidates to leave nothing chargeable
+            // behind. Registering "one niner" makes "one" a token that could begin a pattern,
+            // so the orphan run after the shorter match is empty and both candidates reach a
+            // full 1.0. That is established by parsing each pattern ALONE below rather than
+            // being assumed — if either stopped reaching 1.0 the tie would evaporate and the
+            // combined assertion would go vacuous again without anything failing.
+            //
+            // Span sits above literal count, so the 2-literal/4-token pattern must beat the
+            // 3-literal/3-token one. Remove the span key and literal count would flip it.
+            var target = new VoxrSlotDefinition("target", new[] { "hotel one" });
+            var counting = new VoxrCommandDefinition(
+                "count_off",
+                new[] { new[] { "one", "niner" } }
+            );
+
+            var literalOnly = new VoxrCommandParser(
+                new[] { target },
+                new[]
+                {
+                    new VoxrCommandDefinition("fire_at", new[] { new[] { "fire", "at", "hotel" } }),
+                    counting,
+                }
+            );
+            var slotted = new VoxrCommandParser(
+                new[] { target },
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "fire_at",
+                        new[] { new[] { "fire", "at", "{target}" } }
+                    ),
+                    counting,
+                }
+            );
+
+            Assert.AreEqual(
+                1.0f,
+                literalOnly.Parse("fire at hotel one")[0].Command.Score,
+                0.001f,
+                "the shorter pattern is charged nothing — \"one\" could begin another pattern"
+            );
+            Assert.AreEqual(
+                1.0f,
+                slotted.Parse("fire at hotel one")[0].Command.Score,
+                0.001f,
+                "and the longer one explains the whole utterance"
+            );
+
+            var both = new VoxrCommandParser(
+                new[] { target },
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "fire_at",
+                        new[]
+                        {
+                            new[] { "fire", "at", "hotel" },
+                            new[] { "fire", "at", "{target}" },
+                        }
+                    ),
+                    counting,
+                }
+            );
+
+            var result = ParseOne(both, "fire at hotel one");
+
+            Assert.AreEqual(
+                1,
+                result.Command.MatchedPatternIndex,
+                "equal scores, so the longer consumed span decides — over the higher literal count"
+            );
+            Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
+        }
+
+        [Test]
+        public void SpanTieBreak_GenuineTie_AlsoDecidesBetweenCommands()
+        {
+            // The same restoration across two intents rather than two patterns of one, since
+            // that is the half SpanTieBreak_ChoosesBetweenCommands_NotJustPatterns used to
+            // cover. "pole star" makes "pole" a possible start, so go_dir keeps its 1.0.
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("dir", new[] { "north" }),
+                new VoxrSlotDefinition("place", new[] { "north pole" }),
+            };
+            var poleStar = new VoxrCommandDefinition(
+                "pole_star",
+                new[] { new[] { "pole", "star" } }
+            );
+
+            var dirOnly = new VoxrCommandParser(
+                slots,
+                new[]
+                {
+                    new VoxrCommandDefinition("go_dir", new[] { new[] { "go", "{dir}" } }),
+                    poleStar,
+                }
+            );
+
+            Assert.AreEqual(
+                1.0f,
+                dirOnly.Parse("go north pole")[0].Command.Score,
+                0.001f,
+                "go_dir strands nothing chargeable, so the tie is real"
+            );
+
+            var both = new VoxrCommandParser(
+                slots,
+                new[]
+                {
+                    new VoxrCommandDefinition("go_dir", new[] { new[] { "go", "{dir}" } }),
+                    new VoxrCommandDefinition("go_place", new[] { new[] { "go", "{place}" } }),
+                    poleStar,
+                }
+            );
+
+            var result = ParseOne(both, "go north pole");
+
+            Assert.AreEqual(
+                "go_place",
+                result.Command.Intent,
+                "the longer-span command wins the tie even though it is declared second"
             );
             Assert.AreEqual("north pole", result.Command.GetSlot("place"));
         }
@@ -1376,25 +1781,32 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
-        public void RequiredLiteralDropped_BarePatternWinsAndDiscardsTheSpokenSlot()
+        public void RequiredLiteralDropped_SlotFilledPatternNowWins()
         {
-            // The behaviour the warning names. VOSK drops short unstressed function words
-            // more than any other token, and when "by" goes the slot-filled pattern is
-            // charged for the miss while the bare one still matches perfectly.
+            // The behaviour the warning names, INVERTED by issue #65 §5.2 — the same fix as
+            // the two cross-intent cases above, reached here within a single intent, so the
+            // sibling that wins is a pattern index rather than a different command.
+            //
+            // VOSK drops short unstressed function words more than any other token. When "by"
+            // goes, the slot-filled pattern is still charged for the miss — 2 / 3 = 0.667 —
+            // but the bare pattern is now charged for the two tokens it cannot explain:
+            // 1 / (1 + 2) = 0.333. The burn level survives.
             LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("required literal \"by\""));
             var parser = new VoxrCommandParser(BurnSlots(), DecelerateCommands("by"));
 
             var result = ParseOne(parser, "decelerate hard burn");
 
             Assert.AreEqual(
-                0,
+                1,
                 result.Command.MatchedPatternIndex,
-                "the bare pattern scores a clean 1.0 and wins"
+                "the slot-filled pattern wins on coverage despite the dropped literal"
             );
-            Assert.IsFalse(
-                result.Command.HasSlot("burn_level"),
-                "the spoken burn level is discarded with nothing to signal it"
+            Assert.AreEqual(
+                "hard burn",
+                result.Command.GetSlot("burn_level"),
+                "the spoken burn level reaches the handler instead of being discarded"
             );
+            Assert.AreEqual(2f / 3f, result.Command.Score, 0.001f);
             LogAssert.NoUnexpectedReceived();
         }
 
@@ -1402,8 +1814,14 @@ namespace VoXR.Tests.Runtime
         public void OptionalLiteralBeforeSlot_KeepsTheSlotWhenTheLiteralIsDropped()
         {
             // The remedy the warning recommends: with the literal optional the slot-filled
-            // pattern scores 1.0 whether or not the word was spoken, so it takes the
-            // consumed-span tie-break (issue #41) over the bare form instead of losing to it.
+            // pattern scores 1.0 whether or not the word was spoken.
+            //
+            // It used to win by taking the consumed-span tie-break (issue #41) over a bare
+            // form that also scored 1.0. Since issue #65 §5.2 it wins outright on score —
+            // the bare form is charged for the burn level it cannot explain (1/(1+2) = 0.333)
+            // — so span is no longer consulted here. The remedy still earns its place: it
+            // reaches 1.0 rather than 2/3, and it is the only thing that fixes the residual
+            // case where the stranded value's first word could itself begin a pattern.
             var parser = new VoxrCommandParser(BurnSlots(), DecelerateCommands("?by"));
 
             var dropped = ParseOne(parser, "decelerate hard burn");
@@ -1458,9 +1876,13 @@ namespace VoXR.Tests.Runtime
         {
             // The stranded value need not be required to be lost. For this grammar, "orient
             // mark one five" with "mark" dropped scores (1 + 0 + 1) / 3 = 0.667 against the
-            // bare pattern's 1.0, so the elevation goes the same way the burn level does.
-            // Issue #65 §5.1 raised that 0.5 to 0.667 and it changes nothing here: the hazard
-            // is that nothing normalized to 1.0 can be beaten, which is symptom 2's territory.
+            // bare pattern's 1.0, so the elevation went the same way the burn level did.
+            //
+            // Issue #65 §5.2 is what finally reverses that comparison — the bare pattern is
+            // now charged 1/(1+2) = 0.333 for the two tokens it strands — but the detector
+            // still fires, because the hazard survives wherever the stranded value's first
+            // word could begin some other pattern. This test only checks that the shape is
+            // reported at construction, which is unchanged either way.
             LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("required literal \"mark\""));
 
             var parser = new VoxrCommandParser(
@@ -1600,12 +2022,26 @@ namespace VoXR.Tests.Runtime
             );
 
             var result = ParseOne(parser, "decelerate hard burn");
+
+            // INVERTED by issue #65 §5.2, and the arithmetic is the argument rather than the
+            // emitted output. Bare "decelerate" explains one of three spoken tokens, so it is
+            // charged for the two it leaves orphaned: 1 / (1 + 2) = 0.333. The longer pattern
+            // drops "by" — credit 1 for "decelerate" and 1 for the slot, nothing for the
+            // missed literal, over a denominator of 3 — and leaves nothing unexplained:
+            // 2 / (3 + 0) = 0.667. A perfect match of too little now loses to an imperfect
+            // match of everything, which is the whole of issue #42.
             Assert.AreEqual(
-                "decelerate",
+                "decelerate_by",
                 result.Command.Intent,
-                "the bare intent wins and the spoken burn level is stranded"
+                "coverage demotes the bare form below its slot-filled sibling"
             );
-            Assert.IsFalse(result.Command.HasSlot("burn_level"));
+            Assert.AreEqual("hard burn", result.Command.GetSlot("burn_level"));
+            Assert.AreEqual(2f / 3f, result.Command.Score, 0.001f);
+            Assert.Greater(
+                result.Command.Score,
+                0.6f,
+                "and it clears the default minScore, so the command actually fires"
+            );
             LogAssert.NoUnexpectedReceived();
         }
 
@@ -1638,13 +2074,249 @@ namespace VoXR.Tests.Runtime
             );
 
             var result = ParseOne(parser, "fire missiles hotel one");
+
+            // INVERTED for the same reason. "fire {?quantity} {weapon}" matches perfectly
+            // across two of the four tokens: 2 / (2 + 2) = 0.5. "fire {weapon} at {target}"
+            // drops only the "at" and accounts for everything: 3 / (4 + 0) = 0.75. The bare
+            // form's perfect 1.0 no longer protects it, because what coverage measures is
+            // how much of the utterance the pattern explains, not how neatly it matched the
+            // part it chose.
             Assert.AreEqual(
-                0,
+                1,
                 result.Command.MatchedPatternIndex,
-                "the bare form wins at 1.0 and the target is stranded"
+                "the longer pattern wins and the spoken target survives"
             );
-            Assert.IsFalse(result.Command.HasSlot("target"));
+            Assert.AreEqual("hotel one", result.Command.GetSlot("target"));
+            Assert.AreEqual(0.75f, result.Command.Score, 0.001f);
             LogAssert.NoUnexpectedReceived();
+        }
+
+        // --- Coverage inside selection (issue #65 §5.2) ---
+        //
+        // The two tests above are the fix itself, inverted in place. These are the
+        // consequences of it — the guard that must NOT move, the knob that turns it off, the
+        // hazard that survives it, and the change in behaviour it buys at a price.
+
+        [Test]
+        public void Coverage_SequentialExtraction_ChargesNothingForALaterCommand()
+        {
+            // The fork-F5 guard, and the reason the trailing count is a RUN that stops at the
+            // first token which could begin a pattern rather than a total of everything left
+            // over. "launch" begins one, so cease_fire is charged nothing and keeps 2/2 =
+            // 1.00. Charging every trailing token instead would give it 2/7 = 0.29, sink it
+            // below minScore, and destroy multi-command utterances outright — which is
+            // exactly why design §6 rejected that form.
+            var parser = CreateParser();
+
+            var results = parser.Parse("cease fire launch missiles target hotel one");
+
+            Assert.AreEqual(2, results.Length);
+            Assert.AreEqual("cease_fire", results[0].Command.Intent);
+            Assert.AreEqual(1.0f, results[0].Command.Score, 0.001f);
+            Assert.AreEqual("launch_weapon", results[1].Command.Intent);
+            Assert.AreEqual(1.0f, results[1].Command.Score, 0.001f);
+            Assert.AreEqual("hotel one", results[1].Command.GetSlot("target"));
+        }
+
+        [Test]
+        public void Coverage_WeightZero_RevertsBothSidesTogether()
+        {
+            // One weight governs leading and trailing alike, so setting it to 0 reduces the
+            // score to rawScore / denominator exactly and symptom 2 comes back. Under the old
+            // field name that was a hidden coupling — a user who zeroed the skipped-word
+            // penalty also silently disabled the issue #42 fix without being told. It is the
+            // same coupling now, but the field admits to it.
+            var parser = new VoxrCommandParser(BurnSlots(), DecelerateCommands("by"), 0f);
+
+            var result = ParseOne(parser, "decelerate hard burn");
+
+            Assert.AreEqual(0, result.Command.MatchedPatternIndex, "the bare form wins again");
+            Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
+            Assert.IsFalse(result.Command.HasSlot("burn_level"));
+        }
+
+        [Test]
+        public void Coverage_ResidualHazard_WhenTheStrandedValueBeginsAPattern()
+        {
+            // What §5.2 does NOT fix, pinned so it is a known limit rather than a surprise.
+            // The orphan run stops at the first token that could begin some pattern. Register
+            // ["hard","stop"] and "hard" becomes such a token, so bare "decelerate" is charged
+            // nothing, keeps its 1.0, and strands the burn level exactly as before — while the
+            // slot-filled sibling still sits at 2/3.
+            //
+            // This is why WarnOnDroppableRequiredLiteral survives this feature: its stated
+            // rationale ("nothing normalized to 1.0 can beat it") is now false in general, but
+            // the hazard it warns about is real in precisely this residue.
+            var parser = new VoxrCommandParser(
+                BurnSlots(),
+                new[]
+                {
+                    new VoxrCommandDefinition("decelerate", new[] { new[] { "decelerate" } }),
+                    new VoxrCommandDefinition(
+                        "decelerate_by",
+                        new[] { new[] { "decelerate", "by", "{burn_level}" } }
+                    ),
+                    new VoxrCommandDefinition("hard_stop", new[] { new[] { "hard", "stop" } }),
+                }
+            );
+
+            var results = parser.Parse("decelerate hard burn");
+
+            Assert.AreEqual("decelerate", results[0].Command.Intent);
+            Assert.AreEqual(1.0f, results[0].Command.Score, 0.001f);
+            Assert.IsFalse(results[0].Command.HasSlot("burn_level"));
+        }
+
+        [Test]
+        public void Coverage_BarePatternWithNoSibling_FallsBelowTheThreshold()
+        {
+            // Requirements §8's open question, pinned as a measured consequence rather than
+            // left to be discovered. The demotion that fixes symptom 2 does not check whether
+            // a sibling exists to win instead: a grammar registering only "decelerate", asked
+            // to hear "decelerate hard burn", now scores 1/(1+2) = 0.333 and fires NOTHING
+            // where it used to fire at 1.0.
+            //
+            // Defensible — the utterance contains two words the grammar cannot explain, and
+            // this is the same logic issue #31 already applies on the leading side. But it is
+            // a real change for single-pattern grammars whose users add natural trailing words
+            // ("decelerate now"), and the locked design never names it.
+            var parser = new VoxrCommandParser(
+                BurnSlots(),
+                new[] { new VoxrCommandDefinition("decelerate", new[] { new[] { "decelerate" } }) }
+            );
+
+            var result = ParseOne(parser, "decelerate hard burn");
+
+            Assert.AreEqual(1f / 3f, result.Command.Score, 0.001f);
+            Assert.Less(
+                result.Command.Score,
+                0.6f,
+                "below the default minScore, so nothing fires at all"
+            );
+        }
+
+        // Two patterns sharing a prefix and differing only in their final element, where that
+        // element is itself a pattern start. This is ordinary command-grammar authoring — the
+        // shipped demo grammar has exactly this shape in "switch to weapons" / "switch to
+        // navigation" alongside "weapons mode" — and it is what forced Amendment A3.
+        static VoxrCommandParser CreateModeSwitchParser()
+        {
+            return new VoxrCommandParser(
+                Array.Empty<VoxrSlotDefinition>(),
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "mode_weapons",
+                        new[] { new[] { "weapons", "mode" }, new[] { "switch", "to", "weapons" } }
+                    ),
+                    new VoxrCommandDefinition(
+                        "mode_navigation",
+                        new[]
+                        {
+                            new[] { "navigation", "mode" },
+                            new[] { "switch", "to", "navigation" },
+                        }
+                    ),
+                }
+            );
+        }
+
+        [Test]
+        public void Coverage_MisPredictedToken_IsChargedNotExcused()
+        {
+            // Amendment A3, pinned by the case that produced it. The orphan run may not be
+            // terminated by a token the candidate's OWN next required element just failed to
+            // match — otherwise a pattern is rewarded for matching LESS.
+            //
+            // "switch to navigation" misses its final element against this utterance, so its
+            // consumed span stops at "weapons". That token begins ["weapons","mode"], so
+            // under the unamended rule its orphan run terminated at zero and it scored a tidy
+            // 2/3 = 0.667. "switch to weapons" matched that element, moving its origin past
+            // the very token that would have terminated its own run, so it paid for "target
+            // hotel": 3/(3+2) = 0.6. The WRONG command won by 0.067, cleared minScore, and
+            // fired.
+            //
+            // Charging the mis-predicted token puts navigation at 2/(3+3) = 0.333 and leaves
+            // weapons at 0.6, which is both correct and above the gate.
+            var parser = CreateModeSwitchParser();
+
+            var results = parser.Parse("switch to weapons target hotel");
+
+            Assert.AreEqual(
+                "mode_weapons",
+                results[0].Command.Intent,
+                "the command the speaker actually said must win"
+            );
+            Assert.AreEqual(3f / 5f, results[0].Command.Score, 0.001f);
+            Assert.GreaterOrEqual(
+                results[0].Command.Score,
+                0.6f,
+                "and it must still clear the default minScore"
+            );
+        }
+
+        [Test]
+        public void Coverage_MisPredictedToken_ChargeIsSymmetricAcrossThePair()
+        {
+            // The same utterance with the two commands swapped. Pinned separately because a
+            // rule that happened to favour whichever pattern was registered first would pass
+            // the test above and still be wrong.
+            var parser = CreateModeSwitchParser();
+
+            var results = parser.Parse("switch to navigation target hotel");
+
+            Assert.AreEqual("mode_navigation", results[0].Command.Intent);
+            Assert.AreEqual(3f / 5f, results[0].Command.Score, 0.001f);
+        }
+
+        [Test]
+        public void Coverage_MisPredictedTokenCharge_DoesNotBiteACompleteMatch()
+        {
+            // The exception applies only where a required element actually failed. A pattern
+            // that matched everything it asked for is charged by the ordinary run rule, so
+            // the utterance the grammar was written for is untouched.
+            var parser = CreateModeSwitchParser();
+
+            Assert.AreEqual(
+                1.0f,
+                ParseOne(parser, "switch to weapons").Command.Score,
+                0.001f,
+                "a complete match still scores a clean 1.0"
+            );
+        }
+
+        [Test]
+        public void Coverage_CannotLiftACandidateTheAdmissionRuleRefused()
+        {
+            // DR-7 is a unary count filter — more required elements missed than matched — and
+            // it never reads the score. Coverage is a ranking term ON the score. A filter and
+            // a sort key do not compete, so no weight can un-reject a DR-7 casualty, and the
+            // two rules stay orthogonal however the weight is set.
+            //
+            // ["alpha","bravo","charlie"] heard as "alpha" matches 1 and misses 2, scoring
+            // 1/3 — above zero, so the Score <= 0 floor is not what stops it. DR-7 is.
+            var commands = new[]
+            {
+                new VoxrCommandDefinition(
+                    "triple",
+                    new[] { new[] { "alpha", "bravo", "charlie" } }
+                ),
+            };
+
+            foreach (float weight in new[] { 0f, 1f, 5f })
+            {
+                var parser = new VoxrCommandParser(
+                    Array.Empty<VoxrSlotDefinition>(),
+                    commands,
+                    weight
+                );
+
+                Assert.AreEqual(
+                    0,
+                    parser.Parse("alpha").Length,
+                    $"admission is independent of the score at coverageWeight {weight}"
+                );
+            }
         }
 
         // --- Required-literal miss cost (issue #65 §5.1) ---

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -1519,7 +1519,7 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
-        public void SpanTieBreak_LongerSpanBeatsHigherLiteralCount()
+        public void LongerSpanPatternWins_NowOnScoreRatherThanTheSpanKey()
         {
             // Span sits ABOVE literal count, so it also settles equal-score candidates whose
             // literal counts differ — outcomes literal count used to decide on its own,
@@ -1556,7 +1556,7 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
-        public void SpanTieBreak_ChoosesBetweenCommands_NotJustPatterns()
+        public void LongerSpanCommandWins_AcrossCommands_NowOnScore()
         {
             // The comparison runs across the whole command list, so a span tie changes which
             // *intent* fires, not merely which pattern index within one command.
@@ -1582,7 +1582,7 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(
                 "go_place",
                 result.Command.Intent,
-                "the longer-span command wins even though it is declared second"
+                "go_place wins outright on score — go_dir is charged for the \"pole\" it strands"
             );
             Assert.AreEqual("north pole", result.Command.GetSlot("place"));
         }
@@ -2126,6 +2126,7 @@ namespace VoXR.Tests.Runtime
             // field name that was a hidden coupling — a user who zeroed the skipped-word
             // penalty also silently disabled the issue #42 fix without being told. It is the
             // same coupling now, but the field admits to it.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("required literal \"by\""));
             var parser = new VoxrCommandParser(BurnSlots(), DecelerateCommands("by"), 0f);
 
             var result = ParseOne(parser, "decelerate hard burn");
@@ -2133,6 +2134,7 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(0, result.Command.MatchedPatternIndex, "the bare form wins again");
             Assert.AreEqual(1.0f, result.Command.Score, 0.001f);
             Assert.IsFalse(result.Command.HasSlot("burn_level"));
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -2146,7 +2148,10 @@ namespace VoXR.Tests.Runtime
             //
             // This is why WarnOnDroppableRequiredLiteral survives this feature: its stated
             // rationale ("nothing normalized to 1.0 can beat it") is now false in general, but
-            // the hazard it warns about is real in precisely this residue.
+            // the hazard it warns about is real in precisely this residue — which is also why
+            // the warning below is expected rather than incidental.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("is a bare form of"));
+
             var parser = new VoxrCommandParser(
                 BurnSlots(),
                 new[]
@@ -2165,6 +2170,7 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual("decelerate", results[0].Command.Intent);
             Assert.AreEqual(1.0f, results[0].Command.Score, 0.001f);
             Assert.IsFalse(results[0].Command.HasSlot("burn_level"));
+            LogAssert.NoUnexpectedReceived();
         }
 
         [Test]
@@ -2270,6 +2276,30 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
+        public void Coverage_MisPredictedToken_IsChargedEvenWhenItIsAnUnkRunAway()
+        {
+            // The [unk] exemption survives A3. The token the candidate mis-predicted is the
+            // first REAL one at or after its consumed end, not the [unk] sitting there — so
+            // "switch to [unk] target hotel" charges "target" and "hotel" (2), never the
+            // [unk] as well (3).
+            //
+            // Pinned on the SCORE rather than the intent: both candidates tie at 2/(3+2) here
+            // and the winner is decided by registration order, so an intent assertion would
+            // pin the tie-break instead of the exemption. Charging the [unk] would give
+            // 2/(3+3) = 0.333, which this catches.
+            var parser = CreateModeSwitchParser();
+
+            var results = parser.Parse("switch to [unk] target hotel");
+
+            Assert.AreEqual(
+                2f / 5f,
+                results[0].Command.Score,
+                0.001f,
+                "the [unk] is skipped over, not charged alongside the real leftovers"
+            );
+        }
+
+        [Test]
         public void Coverage_MisPredictedTokenCharge_DoesNotBiteACompleteMatch()
         {
             // The exception applies only where a required element actually failed. A pattern
@@ -2293,8 +2323,17 @@ namespace VoXR.Tests.Runtime
             // a sort key do not compete, so no weight can un-reject a DR-7 casualty, and the
             // two rules stay orthogonal however the weight is set.
             //
-            // ["alpha","bravo","charlie"] heard as "alpha" matches 1 and misses 2, scoring
-            // 1/3 — above zero, so the Score <= 0 floor is not what stops it. DR-7 is.
+            // ["alpha","bravo","charlie"] heard as "zulu alpha yankee" matches 1 required
+            // element and misses 2, so DR-7 refuses it — while its score stays above zero, so
+            // the Score <= 0 floor (checked first, and which would mask what this pins) is not
+            // what stops it.
+            //
+            // The filler on both sides is what makes the loop mean something: one leading skip
+            // and one trailing orphan, so the candidate's score genuinely moves with the
+            // weight — 1/3 at 0, 1/5 at 1, 1/13 at 5 — while admission does not budge. An
+            // earlier version of this test used a fixture whose coverage was identically zero,
+            // so all three iterations were the same arithmetic and a rule that DID couple
+            // admission to coverage would have passed it.
             var commands = new[]
             {
                 new VoxrCommandDefinition(
@@ -2313,10 +2352,18 @@ namespace VoXR.Tests.Runtime
 
                 Assert.AreEqual(
                     0,
-                    parser.Parse("alpha").Length,
+                    parser.Parse("zulu alpha yankee").Length,
                     $"admission is independent of the score at coverageWeight {weight}"
                 );
             }
+
+            // Direct pin that the charge really is live on this fixture, so a future change
+            // cannot re-zero coverage and silently restore the vacuity described above.
+            var probe = new VoxrCommandParser(Array.Empty<VoxrSlotDefinition>(), commands);
+            probe.BuildCoverageTables(new[] { "zulu", "alpha", "yankee" });
+
+            Assert.AreEqual(1, probe.SkippedBefore(0, 1), "\"zulu\" is a leading skip");
+            Assert.AreEqual(1, probe.OrphanedAfter(2), "\"yankee\" is a trailing orphan");
         }
 
         // --- Required-literal miss cost (issue #65 §5.1) ---

--- a/Tests~/Runtime/VoxrCoverageWeightRenameTests.cs
+++ b/Tests~/Runtime/VoxrCoverageWeightRenameTests.cs
@@ -1,3 +1,9 @@
+// ============================================================================
+// Purpose:  PlayMode tests for the DR-4 skippedWordPenalty -> coverageWeight rename
+// Layer:    Tests.Runtime
+// Owns:     VoxrCoverageWeightRenameTests (public class)
+// Depends:  VoxrCommandRecogniser, VoxrCommandParser
+// ============================================================================
 using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;

--- a/Tests~/Runtime/VoxrCoverageWeightRenameTests.cs
+++ b/Tests~/Runtime/VoxrCoverageWeightRenameTests.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Serialization;
+using VoXR.Commands;
+
+namespace VoXR.Tests.Runtime
+{
+    // DR-4 (issue #65 §5.2): skippedWordPenalty became coverageWeight once the weight started
+    // governing orphaned trailing tokens as well as leading skipped ones.
+    //
+    // The field is a private [SerializeField], so [FormerlySerializedAs] is the WHOLE of the
+    // compatibility story — there is no public property or constant to forward from, and the
+    // only code-level break is a named-argument call on VoxrBatchTestRunner's constructors.
+    //
+    // WHAT IS NOT TESTED HERE, and why. The natural test is the end-to-end one: author a
+    // scene with the old key, upgrade, read the new field. It is not automatable from this
+    // harness. JsonUtility matches JSON keys to field names literally and does NOT consult
+    // [FormerlySerializedAs] — measured, not assumed: feeding it {"skippedWordPenalty":0.25}
+    // leaves the field at its default rather than at 0.25. Only Unity's native YAML
+    // serializer honours the attribute, which needs a real asset round-trip through
+    // AssetDatabase in a host project, not a unit test.
+    //
+    // So the coverage below is deliberately split: that Unity honours the attribute is a
+    // platform contract this package does not re-verify, while that WE DECLARED IT CORRECTLY
+    // is ours and is pinned. That is not a hypothetical distinction — a blanket rename during
+    // this change rewrote the attribute's argument to the new name, which would have silently
+    // destroyed every upgrading project's tuning while leaving the shim looking present.
+    public class VoxrCoverageWeightRenameTests
+    {
+        const string OldFieldName = "skippedWordPenalty";
+        const string NewFieldName = "coverageWeight";
+
+        GameObject _go;
+        VoxrCommandRecogniser _recogniser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("TestCoverageWeightRename");
+            _recogniser = _go.AddComponent<VoxrCommandRecogniser>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+                UnityEngine.Object.DestroyImmediate(_go);
+        }
+
+        static FieldInfo CoverageWeightField()
+        {
+            var field = typeof(VoxrCommandRecogniser).GetField(
+                NewFieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+
+            Assert.IsNotNull(field, $"the serialized field must be named {NewFieldName}");
+            return field;
+        }
+
+        [Test]
+        public void CoverageWeight_CarriesFormerlySerializedAsTheOldName()
+        {
+            // The upgrade path in one assertion: the attribute must be present AND must name
+            // the OLD field. An attribute naming the new field compiles, looks right in a
+            // diff, and does nothing.
+            var attribute = CoverageWeightField()
+                .GetCustomAttribute<FormerlySerializedAsAttribute>();
+
+            Assert.IsNotNull(
+                attribute,
+                "without it, every project that tuned the old field silently resets to default"
+            );
+            Assert.AreEqual(
+                OldFieldName,
+                attribute.oldName,
+                "it has to name the field being migrated FROM, not the current one"
+            );
+        }
+
+        [Test]
+        public void CoverageWeight_IsSerializedUnderTheNewName()
+        {
+            // Guards the other half of the pair: the attribute is only worth anything if the
+            // field is actually serialized under the new name.
+            JsonUtility.FromJsonOverwrite($"{{\"{NewFieldName}\":0.75}}", _recogniser);
+
+            Assert.AreEqual(0.75f, (float)CoverageWeightField().GetValue(_recogniser), 0.0001f);
+        }
+
+        [Test]
+        public void CoverageWeight_DefaultsToTheParserConstant()
+        {
+            Assert.AreEqual(
+                VoxrCommandParser.DefaultCoverageWeight,
+                (float)CoverageWeightField().GetValue(_recogniser),
+                0.0001f,
+                "an unauthored field still starts at the documented default"
+            );
+        }
+    }
+}

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -540,8 +540,17 @@ namespace VoXR.Tests.Runtime
                 Commands(Cmd("cease_fire", P("cease", "fire", "{?mode}")))
             );
 
+            // Both verdicts are named outright rather than compared to each other: an equality
+            // would hold just as well if both regressed to None, which is one of the failures
+            // this is meant to catch. HoldExtendable rather than Commit because the trailing
+            // optional means more speech could still extend the match.
             Assert.AreEqual(
+                EagerCommitVerdict.HoldExtendable,
                 parser.TryEagerCommit(Tok("cease fire"), null, 0.6f, 0.4f),
+                "the gapless buffer holds"
+            );
+            Assert.AreEqual(
+                EagerCommitVerdict.HoldExtendable,
                 parser.TryEagerCommit(Tok("cease fire [unk]"), null, 0.6f, 0.4f),
                 "a trailing [unk] the pattern never consumed must not change the verdict"
             );

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -450,6 +450,104 @@ namespace VoXR.Tests.Runtime
                 "a prefix command matches fully but could still grow, so it is held, not committed");
         }
 
+        // ---------- Coverage and the eager gate (issue #65 §5.2) ----------
+        //
+        // Design §5.4 claimed the trailing coverage term "cannot destabilise the eager gate,
+        // structurally", on the ground that anything reaching a verdict already spans the
+        // buffer and so has no trailing orphans. The premise is right and the conclusion is
+        // wrong: the term does not change the WINNER'S score, but it changes which candidate
+        // IS the winner, and the completeness gates are applied to whoever that is.
+        //
+        // The movement is one-way, and the reason is worth stating because it is what makes
+        // the change safe rather than merely small. A candidate that clears the gates starts
+        // at the first recognised token (so no leading skips) and ends at the buffer end (so
+        // its orphan run is empty, the ConsumedEndIdx..EndIdx gap being all-[unk] and [unk]
+        // free). Its score is therefore IDENTICAL before and after. Every other candidate's
+        // score can only fall. So a verdict above None can never be withdrawn and a committed
+        // command can never change identity — the only available move is None -> Commit or
+        // None -> HoldExtendable, when the bare sibling that used to outrank the real command
+        // is demoted out of the way.
+
+        [Test]
+        public void TryEagerCommit_MedialDropWithEverySlotFilled_NowCommits()
+        {
+            // Design §5.4's counter-example. "at" is dropped, so before coverage the bare
+            // "fire" won at 1.0, spanned only one token of three, and the gate refused —
+            // correctly, but for the wrong command. Now bare "fire" is charged for the two
+            // tokens it cannot explain (1/(1+2) = 0.333), "fire at {target}" wins on 2/3, and
+            // it clears every gate in turn: no required slot missed, no required element
+            // after the last match, starts at token 0, ends at the buffer end.
+            //
+            // The new verdict is the one DR-6 already blesses as safe — a medial drop with
+            // every argument present — so the gate now fires the right command early instead
+            // of waiting out the full buffer window to fire the wrong one.
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("target", new[] { "hotel one" })),
+                Commands(Cmd("fire", P("fire")), Cmd("fire_at", P("fire", "at", "{target}")))
+            );
+
+            Assert.AreEqual(
+                EagerCommitVerdict.Commit,
+                parser.TryEagerCommit(Tok("fire hotel one"), null, 0.6f, 0.4f)
+            );
+        }
+
+        [Test]
+        public void TryEagerCommit_VerdictNamesTheCommandTheFlushFires()
+        {
+            // The invariant the whole eager path rests on, checked on the utterance that
+            // newly moves. Both paths call the same scorer over the same token array, so they
+            // cannot disagree — but that is true by construction only while a single method
+            // computes the score, which is exactly why coverage went into TryMatchScored
+            // rather than into each caller.
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("target", new[] { "hotel one" })),
+                Commands(Cmd("fire", P("fire")), Cmd("fire_at", P("fire", "at", "{target}")))
+            );
+
+            var verdict = parser.TryEagerCommit(Tok("fire hotel one"), null, 0.6f, 0.4f);
+            var flushed = parser.Parse("fire hotel one");
+
+            Assert.AreEqual(EagerCommitVerdict.Commit, verdict);
+            Assert.AreEqual(1, flushed.Length);
+            Assert.AreEqual(
+                "fire_at",
+                flushed[0].Command.Intent,
+                "the flush must fire the command the verdict was computed on"
+            );
+            Assert.AreEqual("hotel one", flushed[0].Command.GetSlot("target"));
+            Assert.AreEqual(2f / 3f, flushed[0].Command.Score, 0.001f);
+            Assert.Greater(
+                flushed[0].Command.Score,
+                0.6f,
+                "and it must clear the same threshold the gate applied"
+            );
+        }
+
+        [Test]
+        public void TryEagerCommit_TrailingUnkGap_CostsTheCandidateNothing()
+        {
+            // The gate's end-of-buffer condition is over EndIdx while orphans count from
+            // ConsumedEndIdx, so "spans the buffer" does not by itself mean "explains the
+            // buffer". What closes that gap is that the region between the two indices is
+            // only ever reached by the [unk] skip loop, and [unk] is never charged.
+            //
+            // "cease fire [unk]" leaves ConsumedEndIdx at 2 and EndIdx at 3 — the skip runs
+            // before the trailing optional, which then matches nothing. The candidate must
+            // still score a full 1.0 and reach the same verdict as the gapless buffer.
+            var parser = new VoxrCommandParser(
+                Slots(new VoxrSlotDefinition("mode", new[] { "silent" })),
+                Commands(Cmd("cease_fire", P("cease", "fire", "{?mode}")))
+            );
+
+            Assert.AreEqual(
+                parser.TryEagerCommit(Tok("cease fire"), null, 0.6f, 0.4f),
+                parser.TryEagerCommit(Tok("cease fire [unk]"), null, 0.6f, 0.4f),
+                "a trailing [unk] the pattern never consumed must not change the verdict"
+            );
+            Assert.AreEqual(1.0f, parser.Parse("cease fire [unk]")[0].Command.Score, 0.001f);
+        }
+
         // ---------- HoldExtendable classification (issue #32) ----------
 
         [Test]


### PR DESCRIPTION
Closes symptom 2 of #65, and #42.

A grammar registering both `decelerate` and `decelerate by {burn_level}`, hearing *"decelerate hard burn"* with the "by" dropped, fired the **bare** command and discarded the burn level with nothing in the log to signal it. No threshold reached this: the bare pattern matched perfectly at `1.0`, and nothing normalised to `1.0` can be beaten.

Coverage now charges a candidate for the in-grammar tokens it leaves unexplained **on either side**, computed **before** candidates are compared rather than applied to the winner afterwards. That relocation is the feature — the leading skipped-word term (#31) sat after selection precisely so it could not reorder, and symptom 2 cannot be fixed without reordering. Bare `decelerate` now scores `1/(1+2) = 0.333` against the slot-filled `2/3 = 0.667`, so the command fires **with** its argument.

```
score = rawScore / (denominator + (skippedBefore + orphanedAfter) × coverageWeight)
```

A trailing token is orphaned if it follows the candidate's `ConsumedEndIdx` and no active pattern could begin a match at it; counting stops at the first token that could. That test is what keeps sequential extraction intact — *"cease fire launch missiles target hotel one"* still scores `2/2`, not `2/7`. `[unk]` is never charged and is transparent rather than a run terminator, so one noise token cannot shield every real orphan behind it.

## Reading this diff

It is two separable concerns that interleave inside `VoxrCommandParser.cs`, which is why they share a commit:

- **The behaviour change** — the pattern-start caches (built in the constructor), the three per-utterance coverage tables, the coverage term in `TryMatchScored`, and the deletion of the post-selection block in `ParseInternal`.
- **The DR-4 rename** — `skippedWordPenalty` → `coverageWeight` across eleven sites, `[FormerlySerializedAs]` on the serialized field. `VoxrCommandRecogniser.cs` and `VoxrBatchTestRunner.cs` are *entirely* rename.

## A design amendment the build forced

Phase 7's A/B found the locked §5.2 rule **fires the wrong command**, and it needed a G1 re-lock (Amendment A3) before this could ship.

The orphan predicate asks *"could a pattern **begin** a match here?"*, but the matcher can begin a pattern at any token by missing its leading elements. So `["switch","to","navigation"]` heard against *"switch to weapons target hotel"* **misses** its final element, stops short of "weapons" — which begins `["weapons","mode"]` and so terminates its orphan run at zero for a tidy `2/3` — and beats the correct `["switch","to","weapons"]`, which **matched** that element, moved its origin past the very token that would have terminated its own run, and pays `3/(3+2) = 0.600`.

**A candidate was rewarded for matching less.** A3 charges the mis-predicted token instead of testing it. Measured threshold: safe at one leftover token, flips at two.

The suite was green throughout. Only a purpose-built corpus caught it.

## Measurement

699 utterances in five generation families, judged at the `minScore` gate. The committed 16 transcripts cannot exercise this feature at all — every one begins at the first recognised token and consumes to the end — so insertion and concatenation were added to the inherited ablation.

| | count |
|---|---|
| newly-firing | 0 |
| slots-gained | 0 |
| intent-change | 11 |
| count-change | 1 |
| slots-lost | 0 |
| newly-silent | 17 |
| score-only | 116 |

All 16 baselines unchanged; the grammar pin still emits 133 entries identical to `expectations.json`, so the native harness does not re-baseline. **No wrong command fires anywhere in the corpus.**

| | `main` | after |
|---|---|---|
| bytes/utterance | **343.0** | **343.0** |
| µs/utterance | 12.22 – 12.65 | 12.34 – 12.81 |

## Known limitations, measured and accepted

Bound for `KNOWN_LIMITATIONS.md` after acceptance, not silently absorbed:

- Where a **second** command in one utterance loses its own leading word, the first is still charged for the second's tokens and can fall below `minScore`. Loses a command; never fires a wrong one.
- Only the literal `[unk]` token is exempt, so `freeSpeechMode`, `InjectText` and `VoxrBatchTestRunner` — which deliver real tokens — charge trailing filler: *"cease fire please"* drops `1.0 → 0.667`.
- A bare pattern demoted to `0.333` fires nothing when **no sibling exists**.
- A slot-initial pattern over a permissive slot can zero trailing coverage grammar-wide.

## Breaking change

`VoxrBatchTestRunner`'s two public constructors renamed a parameter, so **named-argument** callers must update. Positional callers are unaffected. Inspector values survive via `[FormerlySerializedAs]` — but note that attribute governs a field's own deserialization and does **not** reach prefab-instance overrides; nothing shipped here is affected, and one prefab-override round-trip is on the human-verification list.

## Verification

EditMode **116/116**, PlayMode **399/399**. No on-device check required (design §7.5). A prior `review-cycle` (11 angles, 5 adversarial verifiers, 21 findings) is applied in `60a064e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsetkJVeu9sRguysZZj1oS
