### PR TITLE
Move the completeness tests off the gate value so they witness their claim (#76)

### DIFF
--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -912,6 +912,14 @@ namespace VoXR.Commands
         internal bool TestGrammarRebuildDeferred => _grammar.GrammarRebuildDeferred;
         internal float TestEffectiveBufferWindow => EffectiveBufferWindow;
 
+        // Read-only, and read by the completeness tests (issue #76) rather than copied as a
+        // literal. Those tests assert that a candidate CLEARS this gate, so that the refusal
+        // they then observe can only have come from the completeness term. Against a hard-coded
+        // 0.60 that assertion cannot fail: raising the serialized default would drop the
+        // candidates below the gate, reject them on score, and leave the tests passing without
+        // ever reaching the branch they exist to pin.
+        internal float MinScore => minScore;
+
         internal void TestForceTimeoutNow()
         {
             if (!_pending.HasPending) return;

--- a/Tests~/Editor/VoxrBatchTestRunnerTests.cs
+++ b/Tests~/Editor/VoxrBatchTestRunnerTests.cs
@@ -204,6 +204,103 @@ namespace VoXR.Tests.Editor
             Assert.IsTrue(result.Passed, result.FailureReason);
         }
 
+        // ─── Flush-path completeness (issues #73, #76) ──────────────────
+        //
+        // PassesThresholds refuses a command with an unfilled required slot independently of
+        // score, in step with the recogniser's own Step 7 gate — without it the harness would
+        // report PASS for an utterance the runtime refuses, certifying a grammar against
+        // behaviour the user will never see. That branch shipped in PR #75 with no coverage.
+        //
+        // The grammar is local rather than the shared fixture because on the shared
+        // five-element pattern a single stranded slot scores exactly 0.60, and a case pinned to
+        // the gate value cannot distinguish "rejected as incomplete" from "rejected on score"
+        // if the denominator ever moves (issue #76). Eight required elements — nothing optional,
+        // so the denominator is the pattern length outright — with seven matched and {target}
+        // stranded gives (7 x 1 - 1) / 8 = 0.75 instead.
+        const string IncompleteAboveGate = "launch all missiles from tube three at";
+
+        static VoxrBatchTestRunner CreateLongFormRunner() =>
+            new VoxrBatchTestRunner(
+                new[]
+                {
+                    new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+                    new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two" }),
+                    new VoxrSlotDefinition("quantity", new[] { "all", "one", "two" }),
+                    new VoxrSlotDefinition("tube", new[] { "one", "two", "three" }),
+                },
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "launch_weapon",
+                        new[]
+                        {
+                            new[]
+                            {
+                                "launch",
+                                "{quantity}",
+                                "{weapon}",
+                                "from",
+                                "tube",
+                                "{tube}",
+                                "at",
+                                "{target}",
+                            },
+                        }
+                    ),
+                }
+            );
+
+        [Test]
+        public void Run_IncompleteCommandAboveGate_RejectedAsIncomplete()
+        {
+            var runner = CreateLongFormRunner();
+            var result = runner.Run(
+                new VoxrTestCase
+                {
+                    input = IncompleteAboveGate,
+                    expectedIntent = "launch_weapon",
+                    description = "Clears minScore but leaves {target} unfilled",
+                }
+            );
+
+            Assert.AreEqual(
+                6f / 8f,
+                result.Score,
+                0.001f,
+                "the hand-derived score no longer holds — re-derive it and argue the new value, "
+                    + "because a candidate that fell below minScore would be rejected for a "
+                    + "reason that has nothing to do with completeness"
+            );
+            Assert.IsFalse(result.Passed, "an incomplete command must not be certified");
+            StringAssert.Contains("required slot unfilled", result.FailureReason);
+            StringAssert.DoesNotContain(
+                "minScore",
+                result.FailureReason,
+                "and the reported reason must be the one that actually rejected it"
+            );
+        }
+
+        [Test]
+        public void Run_ExpectedRejection_IncompleteCommandAboveGate_Passes()
+        {
+            // The other side of the same branch: a grammar author pinning the runtime's refusal
+            // as the expected outcome gets a PASS, so the harness can be used to hold the
+            // behaviour in place rather than only to notice it.
+            var runner = CreateLongFormRunner();
+            var result = runner.Run(
+                new VoxrTestCase
+                {
+                    input = IncompleteAboveGate,
+                    expectedIntent = null,
+                    description = "Incomplete above the gate is expected to be refused",
+                }
+            );
+
+            Assert.IsTrue(result.Passed, result.FailureReason);
+            Assert.IsNull(result.ActualIntent, "nothing may be accepted");
+            Assert.AreEqual(6f / 8f, result.Score, 0.001f, "and it really did clear minScore");
+        }
+
         [Test]
         public void Run_ExpectedAcceptance_ButConfidenceRejects_Fails()
         {

--- a/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
+++ b/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
@@ -888,23 +888,61 @@ namespace VoXR.Tests.Runtime
         // TryEagerCommit has refused a command with an unfilled required slot since #66. The
         // ordinary flush path — the one on by default — had no such condition, so a slot-missing
         // candidate that cleared minScore fired with its argument simply absent.
+        //
+        // The claim is "an incomplete command does not fire AT ANY SCORE", so the cases below
+        // are spread across the range instead of clustered on the gate value (issue #76). A case
+        // pinned to 0.60 witnesses only "does not fire at 0.60", which the suite would keep
+        // reporting green if the completeness term were deleted and the gate loosened to
+        // `> minScore` — the exact regression these tests exist to catch.
 
-        [Test]
-        public void SlotMissing_AboveGate_DoesNotFire()
+        // Pins the candidate's score against the caller's hand-derived expectation, then asserts
+        // the recogniser refuses to fire it.
+        //
+        // The pin is the point. Without it a does-not-fire assertion FAILS OPEN: any change to
+        // the score denominator that pushed the candidate below minScore would leave the test
+        // green for the wrong reason — rejected on score, never reaching the completeness branch
+        // — with nothing to signal that it had gone vacuous. Per the #65 §7.3 discipline the
+        // expected scores are hand-derived and argued at each call site, never updated to
+        // whatever the code happens to emit.
+        void AssertIncompleteDoesNotFire(
+            VoxrSlotDefinition[] slots,
+            VoxrCommandDefinition[] commands,
+            string utterance,
+            float expectedScore,
+            string strandedSlot
+        )
         {
-            // #73's repro, and the deliberate counterpart to the boundary test above: both land
-            // on exactly 0.60 and both clear the >= gate, so score cannot be what separates them.
-            // "launch all missiles target" matches launch, {?quantity}, {weapon} and target, then
-            // strands {target}: (1 + 1 + 1 + 1 - 1) / 5 = 0.60. Firing it hands the handler a
-            // launch order with nothing to launch at.
-            ConfigureWithSyncDefaults();
+            var probe = new VoxrCommandParser(slots, commands).Parse(utterance);
+            Assert.AreEqual(1, probe.Length, "the utterance must yield exactly one candidate");
+            Assert.IsTrue(probe[0].IsMatch, "and that candidate must be a match");
+            Assert.AreEqual(
+                expectedScore,
+                probe[0].Command.Score,
+                0.001f,
+                "the hand-derived score no longer holds — re-derive it and argue the new value "
+                    + "before touching anything else, because everything below rests on it"
+            );
+            Assert.GreaterOrEqual(
+                probe[0].Command.Score,
+                0.6f,
+                "the candidate must clear the default minScore, or the refusal below proves "
+                    + "nothing about completeness"
+            );
+            Assert.IsFalse(
+                probe[0].Command.HasSlot(strandedSlot),
+                $"'{strandedSlot}' must really be unfilled — that is what the recogniser rejects on"
+            );
+
+            _recogniser.Configure(slots, commands);
+            _recogniser.BufferWindow = 0f;
+            _recogniser.CommandCooldown = 0f;
 
             int recognisedCount = 0;
             string unrecognised = null;
             _recogniser.OnCommandRecognised += _ => recognisedCount++;
             _recogniser.OnUnrecognisedSpeech += text => unrecognised = text;
 
-            _recogniser.InjectText("launch all missiles target");
+            _recogniser.InjectText(utterance);
 
             Assert.AreEqual(
                 0,
@@ -912,9 +950,132 @@ namespace VoXR.Tests.Runtime
                 "a command missing a required argument must not fire, whatever it scores"
             );
             Assert.AreEqual(
-                "launch all missiles target",
+                utterance,
                 unrecognised,
                 "and the utterance is reported unrecognised rather than dropped in silence"
+            );
+        }
+
+        [Test]
+        public void SlotMissing_OnTheGate_DoesNotFire()
+        {
+            // #73's own repro, kept because it is the shape that was actually reported, and the
+            // deliberate counterpart to the boundary test above: both land on exactly 0.60 and
+            // both clear the >= gate, so score cannot be what separates them. "launch all
+            // missiles target" matches launch, {?quantity}, {weapon} and target, then strands
+            // {target}: (1 + 1 + 1 + 1 - 1) / 5 = 0.60. Firing it hands the handler a launch
+            // order with nothing to launch at.
+            //
+            // Sitting on the boundary is precisely what the helper's score pin protects: nothing
+            // else would notice this candidate sliding underneath the gate.
+            AssertIncompleteDoesNotFire(
+                MakeSlots(),
+                MakeCommands(),
+                "launch all missiles target",
+                3f / 5f,
+                "target"
+            );
+        }
+
+        [Test]
+        public void SlotMissing_AboveGate_DoesNotFire()
+        {
+            // Clear of the boundary, so the completeness branch is the only condition in Step 7
+            // that can reject this. Eight required elements — nothing optional, so the
+            // denominator is the pattern length outright — with seven matched and the trailing
+            // {target} stranded: (7 x 1 - 1) / 8 = 0.75.
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two", "alpha one" }),
+                new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+                new VoxrSlotDefinition("quantity", new[] { "all", "one", "two" }),
+                new VoxrSlotDefinition("tube", new[] { "one", "two", "three" }),
+            };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition(
+                    "launch_weapon",
+                    new[]
+                    {
+                        new[]
+                        {
+                            "launch",
+                            "{quantity}",
+                            "{weapon}",
+                            "from",
+                            "tube",
+                            "{tube}",
+                            "at",
+                            "{target}",
+                        },
+                    }
+                ),
+                new VoxrCommandDefinition("cease_fire", new[] { new[] { "cease", "fire" } }),
+            };
+
+            AssertIncompleteDoesNotFire(
+                slots,
+                commands,
+                "launch all missiles from tube three at",
+                6f / 8f,
+                "target"
+            );
+        }
+
+        [Test]
+        public void SlotMissing_FarAboveGate_DoesNotFire()
+        {
+            // The witness for "at ANY score" (issue #76). One stranded slot on a fourteen-element
+            // pattern: (13 x 1 - 1) / 14 = 0.857 — a full 0.257 above the gate, which no
+            // plausible drift in the denominator moves under it. Concretely, coverage would have
+            // to charge more than six whole tokens' worth of unexplained speech — 12 / (14 + c)
+            // < 0.60 needs c > 6 — against an utterance the pattern consumes end to end.
+            //
+            // The pattern is deliberately long: with every element required and exactly one slot
+            // stranded the score is (N - 2) / N, so headroom above the gate is bought only with
+            // length. {target} is stranded mid-pattern and the tail still matches, which is also
+            // what keeps the coverage term at zero here — "on my mark" consumes the rest, so
+            // nothing is left orphaned after the last match.
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two", "alpha one" }),
+                new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+                new VoxrSlotDefinition("quantity", new[] { "all", "one", "two" }),
+                new VoxrSlotDefinition("tube", new[] { "one", "two", "three" }),
+            };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition(
+                    "launch_weapon",
+                    new[]
+                    {
+                        new[]
+                        {
+                            "weapons",
+                            "free",
+                            "launch",
+                            "{quantity}",
+                            "{weapon}",
+                            "from",
+                            "tube",
+                            "{tube}",
+                            "at",
+                            "target",
+                            "{target}",
+                            "on",
+                            "my",
+                            "mark",
+                        },
+                    }
+                ),
+            };
+
+            AssertIncompleteDoesNotFire(
+                slots,
+                commands,
+                "weapons free launch all missiles from tube three at target on my mark",
+                12f / 14f,
+                "target"
             );
         }
 

--- a/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
+++ b/Tests~/Runtime/VoxrCommandRecogniserInjectionTests.cs
@@ -898,12 +898,16 @@ namespace VoXR.Tests.Runtime
         // Pins the candidate's score against the caller's hand-derived expectation, then asserts
         // the recogniser refuses to fire it.
         //
-        // The pin is the point. Without it a does-not-fire assertion FAILS OPEN: any change to
-        // the score denominator that pushed the candidate below minScore would leave the test
-        // green for the wrong reason — rejected on score, never reaching the completeness branch
-        // — with nothing to signal that it had gone vacuous. Per the #65 §7.3 discipline the
-        // expected scores are hand-derived and argued at each call site, never updated to
-        // whatever the code happens to emit.
+        // The two guards are the point, and they close different doors. Without them a
+        // does-not-fire assertion FAILS OPEN: a candidate that ended up below the gate would
+        // leave the test green for the wrong reason — rejected on score, never reaching the
+        // completeness branch — with nothing to signal that it had gone vacuous. The score pin
+        // catches the candidate moving (a change to the denominator); reading MinScore off the
+        // recogniser catches the gate moving underneath a candidate that did not. A hard-coded
+        // 0.60 would catch neither, being implied by the pin directly above it.
+        //
+        // Per the #65 §7.3 discipline the expected scores are hand-derived and argued at each
+        // call site, never updated to whatever the code happens to emit.
         void AssertIncompleteDoesNotFire(
             VoxrSlotDefinition[] slots,
             VoxrCommandDefinition[] commands,
@@ -924,9 +928,9 @@ namespace VoXR.Tests.Runtime
             );
             Assert.GreaterOrEqual(
                 probe[0].Command.Score,
-                0.6f,
-                "the candidate must clear the default minScore, or the refusal below proves "
-                    + "nothing about completeness"
+                _recogniser.MinScore,
+                "the candidate must clear the gate the recogniser is actually running, or the "
+                    + "refusal below proves nothing about completeness"
             );
             Assert.IsFalse(
                 probe[0].Command.HasSlot(strandedSlot),

--- a/Tests~/Runtime/VoxrPendingCommandTests.cs
+++ b/Tests~/Runtime/VoxrPendingCommandTests.cs
@@ -112,13 +112,20 @@ namespace VoXR.Tests.Runtime
             // Issue #73's routing half. The pending path is entered from BELOW minScore, so a
             // slot-missing candidate that cleared the gate never reached it — allowPartialMatch
             // was silently inapplicable to exactly the commands that scored well enough to fire
-            // incomplete. This one scores (1 + 1 + 1 + 1 - 1) / 5 = 0.60, right on the gate.
+            // incomplete.
+            //
+            // The candidate sits clear of the gate rather than on it (issue #76): eight required
+            // elements, seven matched and the trailing {target} stranded, so (7 x 1 - 1) / 8 =
+            // 0.75. On the gate value itself the routing assertion would fail open — a scoring
+            // change that dropped the candidate below minScore would still route it to pending,
+            // for the ordinary below-gate reason, and prove nothing about completeness.
             _recogniser.Configure(
                 new[]
                 {
                     new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two" }),
                     new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
                     new VoxrSlotDefinition("quantity", new[] { "all", "one", "two" }),
+                    new VoxrSlotDefinition("tube", new[] { "one", "two", "three" }),
                 },
                 new[]
                 {
@@ -126,7 +133,17 @@ namespace VoXR.Tests.Runtime
                         "launch_weapon",
                         new[]
                         {
-                            new[] { "launch", "{?quantity}", "{weapon}", "target", "{target}" },
+                            new[]
+                            {
+                                "launch",
+                                "{quantity}",
+                                "{weapon}",
+                                "from",
+                                "tube",
+                                "{tube}",
+                                "at",
+                                "{target}",
+                            },
                         },
                         allowPartialMatch: true
                     ),
@@ -141,7 +158,7 @@ namespace VoXR.Tests.Runtime
             VoxrCommand? recognised = null;
             _recogniser.OnCommandRecognised += cmd => recognised = cmd;
 
-            _recogniser.InjectText("launch all missiles target");
+            _recogniser.InjectText("launch all missiles from tube three at");
 
             Assert.IsFalse(
                 recognised.HasValue,
@@ -151,7 +168,21 @@ namespace VoXR.Tests.Runtime
                 pending.HasValue,
                 "it goes to slot-fill, which is where it always belonged"
             );
+            // The pending command carries the parse score through untouched, so this pins the
+            // hand-derived 0.75 without a second parser: it is the candidate that was routed.
+            Assert.AreEqual(
+                6f / 8f,
+                pending.Value.Score,
+                0.001f,
+                "the hand-derived score no longer holds — re-derive it and argue the new value"
+            );
+            Assert.GreaterOrEqual(
+                pending.Value.Score,
+                0.6f,
+                "and it must clear the default minScore, or completeness is not what routed it"
+            );
             Assert.AreEqual("missiles", pending.Value.GetSlot("weapon"));
+            Assert.AreEqual("three", pending.Value.GetSlot("tube"));
             Assert.IsTrue(_recogniser.HasPendingCommand);
 
             _recogniser.InjectText("hotel one");
@@ -171,26 +202,50 @@ namespace VoXR.Tests.Runtime
             // set_burn deliberately does NOT opt into partial matching, so the incomplete second
             // utterance is rejected rather than entering pending itself — which is what isolates
             // this to the cancellation and keeps it from passing for the wrong reason.
-            _recogniser.Configure(
-                new[]
-                {
-                    new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two" }),
-                    new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
-                    new VoxrSlotDefinition("burn_level", new[] { "coast", "hard burn" }),
-                },
-                new[]
-                {
-                    new VoxrCommandDefinition(
-                        "launch_weapon",
-                        new[] { new[] { "launch", "{weapon}", "target", "{target}" } },
-                        allowPartialMatch: true
-                    ),
-                    new VoxrCommandDefinition(
-                        "set_burn",
-                        new[] { new[] { "set", "burn", "to", "{burn_level}", "now" } }
-                    ),
-                }
+            //
+            // Its pattern is eight elements rather than five (issue #76) so the incomplete
+            // candidate lands clear of the gate at (7 x 1 - 1) / 8 = 0.75. On the gate value
+            // itself this test fails open: a scoring change that pushed the candidate below
+            // minScore would still leave the pending command alive — rejected on score, never
+            // reaching the completeness term that Step 4 exists to apply.
+            var slots = new[]
+            {
+                new VoxrSlotDefinition("target", new[] { "hotel one", "hotel two" }),
+                new VoxrSlotDefinition("weapon", new[] { "missiles", "torpedoes" }),
+                new VoxrSlotDefinition("burn_level", new[] { "coast", "hard burn" }),
+            };
+            var commands = new[]
+            {
+                new VoxrCommandDefinition(
+                    "launch_weapon",
+                    new[] { new[] { "launch", "{weapon}", "target", "{target}" } },
+                    allowPartialMatch: true
+                ),
+                new VoxrCommandDefinition(
+                    "set_burn",
+                    new[]
+                    {
+                        new[] { "helm", "set", "burn", "to", "{burn_level}", "on", "my", "mark" },
+                    }
+                ),
+            };
+
+            // Nothing fires and nothing pends for set_burn, so no event carries its score —
+            // pin it against the same grammar directly, or the assertions below cannot tell
+            // "refused as incomplete" from "never cleared the gate".
+            var probe = new VoxrCommandParser(slots, commands).Parse("helm set burn to on my mark");
+            Assert.AreEqual(1, probe.Length);
+            Assert.AreEqual("set_burn", probe[0].Command.Intent);
+            Assert.AreEqual(
+                6f / 8f,
+                probe[0].Command.Score,
+                0.001f,
+                "the hand-derived score no longer holds — re-derive it and argue the new value"
             );
+            Assert.GreaterOrEqual(probe[0].Command.Score, 0.6f, "and it must clear minScore");
+            Assert.IsFalse(probe[0].Command.HasSlot("burn_level"), "with {burn_level} stranded");
+
+            _recogniser.Configure(slots, commands);
             _recogniser.BufferWindow = 0f;
             _recogniser.CommandCooldown = 0f;
             _recogniser.PendingTimeout = 30f;
@@ -203,8 +258,7 @@ namespace VoXR.Tests.Runtime
             _recogniser.OnCommandCancelled += _ => cancelledCount++;
             _recogniser.OnCommandRecognised += cmd => recognised = cmd;
 
-            // Scores (1 + 1 + 1 - 1 + 1) / 5 = 0.60 with {burn_level} stranded.
-            _recogniser.InjectText("set burn to now");
+            _recogniser.InjectText("helm set burn to on my mark");
 
             Assert.IsFalse(recognised.HasValue, "the incomplete command must not fire");
             Assert.AreEqual(

--- a/Tests~/Runtime/VoxrPendingCommandTests.cs
+++ b/Tests~/Runtime/VoxrPendingCommandTests.cs
@@ -178,8 +178,9 @@ namespace VoXR.Tests.Runtime
             );
             Assert.GreaterOrEqual(
                 pending.Value.Score,
-                0.6f,
-                "and it must clear the default minScore, or completeness is not what routed it"
+                _recogniser.MinScore,
+                "and it must clear the gate the recogniser is running, or completeness is not "
+                    + "what routed it"
             );
             Assert.AreEqual("missiles", pending.Value.GetSlot("weapon"));
             Assert.AreEqual("three", pending.Value.GetSlot("tube"));
@@ -242,7 +243,11 @@ namespace VoXR.Tests.Runtime
                 0.001f,
                 "the hand-derived score no longer holds — re-derive it and argue the new value"
             );
-            Assert.GreaterOrEqual(probe[0].Command.Score, 0.6f, "and it must clear minScore");
+            Assert.GreaterOrEqual(
+                probe[0].Command.Score,
+                _recogniser.MinScore,
+                "and it must clear the gate the recogniser is running"
+            );
             Assert.IsFalse(probe[0].Command.HasSlot("burn_level"), "with {burn_level} stranded");
 
             _recogniser.Configure(slots, commands);


### PR DESCRIPTION
Closes #76

## What

Almost entirely test-only. The one production change is a single `internal` test-only accessor added in review (see *Review fixes applied* below); the #73 behaviour is untouched, and what changes is whether the suite can tell that behaviour from a plausible impostor.

| Test | Before | After | Shape |
|---|---|---|---|
| `SlotMissing_AboveGate_DoesNotFire` | 0.60 | **0.75** | 8 required elements, trailing `{target}` stranded |
| `SlotMissing_OnTheGate_DoesNotFire` | — | **0.60** | #73's own repro, retained, now score-pinned |
| `SlotMissing_FarAboveGate_DoesNotFire` | — | **0.857** | 14-element pattern — the "at any score" witness |
| `PartialMatch_AboveGateButIncomplete_EntersPendingInsteadOfFiring` | 0.60 | **0.75** | same 8-element shape, `allowPartialMatch` |
| `IncompleteNewCommand_DoesNotCancelALivePending` | 0.60 | **0.75** | 8 elements, **medial** `{burn_level}` stranded |
| `Run_IncompleteCommandAboveGate_RejectedAsIncomplete` | — | **0.75** | new — `VoxrBatchTestRunner` |
| `Run_ExpectedRejection_IncompleteCommandAboveGate_Passes` | — | **0.75** | new — other side of that branch |

`SlotMissing_OptionalSlotOmitted_StillFires` (the over-correction guard: an omitted OPTIONAL slot is not a missing argument) is unchanged by this PR but was verified alongside the seven above, since the re-derivations move grammars around it.

## Why

With every element required and exactly one slot stranded the score is `(N − 2) / N`, so headroom above the gate is bought only with pattern length: 5 elements gives the 0.60 the issue objects to, 8 gives 0.75, 14 gives 0.857.

**Every case now pins its score, and every recogniser case reads the live gate off the recogniser.** This is the part the issue's suggested fix doesn't spell out but its fail-open argument demands: a bare does-not-fire assertion cannot distinguish *"refused as incomplete"* from *"never cleared the gate"*. The two guards close different doors — the pin catches the candidate moving, `MinScore` catches the gate moving underneath a candidate that didn't. With both, drift fails loudly instead of going vacuous, which is also what lets #73's original 0.60 repro stay in the suite honestly rather than being deleted for sitting on the boundary.

The suite now fails on both mutations it is meant to catch:

- **Delete `IsIncomplete`** (gate becomes score-only) → all five recogniser cases fire/cancel and fail; the batch-runner case starts passing where it asserts failure.
- **Move the denominator** so a candidate drops below the gate → the score pin fails, rather than the refusal quietly passing for the wrong reason.

### The issue's time-pressure premise has expired — the weakness has not

`feat-coverage-in-selection` has already merged; coverage is in the denominator at `Runtime/Commands/VoxrCommandParser.cs:1291-1297`. I verified against the real parser that all three tests **still sit at exactly 0.60** on `main`: coverage is zero for an utterance the pattern consumes end to end, so the collision the issue anticipated did not fire and nothing went silently vacuous. The structural weakness the issue identifies is unaffected by that, and is what this PR fixes.

Concretely, for the 0.857 witness the coverage term would have to charge more than six whole tokens of unexplained speech (`12 / (14 + c) < 0.60` needs `c > 6`) before the completeness branch stopped being the only possible rejector.

### Second unapplied #75 finding, folded in as the issue asked

`VoxrBatchTestRunner.PassesThresholds`'s completeness branch (`Runtime/Testing/VoxrBatchTestRunner.cs:199-206`) had **zero** tests reaching it. Two now do — one asserting the rejection (including that the reported reason is `required slot unfilled` and *not* the score wording), one asserting a grammar author can pin the refusal as the expected outcome. Both use a local grammar rather than the file's shared fixture, for the same reason the **two re-derived** recogniser tests moved off it — `SlotMissing_OnTheGate_DoesNotFire` deliberately stays on the shared fixture, being #73's reported shape.

## Review fixes applied

`review-pr` (slim profile) ran on this PR and confirmed four findings; all four are fixed here, and the review comment above records the six it refuted.

1. **`Assert.GreaterOrEqual(score, 0.6f)` could not fail** — it duplicated a private `minScore` the tests cannot read, *and* was implied by the exact score pin two lines above it. Fixed by adding `internal float MinScore => minScore;` to `VoxrCommandRecogniser`'s existing test-only accessor block, and reading it at all three guard sites. The guard now genuinely fails if the serialized default rises above a pinned candidate — the fail-open route the review identified. **This is the one production line in the diff**: `internal`, read-only, no behaviour.
2. Dropped an inaccurate ordering claim ("pins its score **before** asserting the refusal" / "the score pin **fails first**") — true for five of seven cases, but `PartialMatch_…` reads the pin off `pending.Value` and so cannot assert it before `pending.HasValue`.
3. Corrected "the recogniser tests moved off it" to "the two re-derived recogniser tests".
4. Named the eighth verified test rather than leaving an unnamed count.

## Validation

- [x] **Unity EditMode 118/118** and **PlayMode 410/410** green, `failed="0"`, zero `error CS` in either log (Unity 6000.4.7f1, host project `VoXR TestGround`, both platforms run separately). Verified per-`test-case` rather than on the root attribute alone, and all eight tests named in this description confirmed **discovered and passed** — not phantom-green. **Re-run after the review fixes**, since those touched production code; see the re-run comment below for the second run's counts.
- [x] Every expected score **hand-derived and argued in the test comment first**, then independently checked against the real parser via the `Planning~/` A/B rig staged from this worktree. All nine numbers matched, including the 0.60 baseline the issue describes. Per #65 §7.3 no expectation was read off the code. Two independent review angles later re-derived all nine by hand and agree.
- [x] No `CHANGELOG.md` entry: nothing user-facing changed. The sole production line is an `internal` accessor invisible outside the assembly — no public API, no behaviour.
- [ ] On-device (Quest) verification **not run** (WSL cannot). Not implicated: no runtime behaviour changed, and the only production line is a test-only property.

## Adjacent, deliberately left alone

The #75 review's finding 9 also noted the **recogniser's** `"required slot unfilled"` diagnostic reject string is asserted nowhere, unlike the four other rejection classes in `Tests~/Editor/VoxrCommandRecogniserDiagnosticTests.cs`. Issue #76 names only the batch-runner half, so I left it; it is a clean follow-up issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsetkJVeu9sRguysZZj1oS
