### PR TITLE
Name the sibling-only rival family for what it restricts (#102)

### DIFF
--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -372,8 +372,8 @@ namespace VoXR.Commands
         // Parallel to _resultBuf: index i describes the result at index i. Rival detail lives in
         // flat preallocated arrays rather than inside the struct so nothing allocates per round.
         TiedSiblingRecord[] _tiedSiblingBuf;
-        TiedSiblingRival[] _tiedRivalBuf; // _resultBuf.Length * MaxDisambiguationRivals
-        VoxrSlotMatch[] _rivalSlotBuf; // ...that, times _maxSlotsPerPattern
+        TiedSiblingRival[] _tiedSiblingRivalBuf; // _resultBuf.Length * MaxDisambiguationRivals
+        VoxrSlotMatch[] _siblingRivalSlotBuf; // ...that, times _maxSlotsPerPattern
 
         // The cancel words the recogniser will actually match against, resolved once here so
         // the construction-time collision report tests the same array TryHandleConfirmCancel
@@ -606,7 +606,7 @@ namespace VoXR.Commands
             // allocate there.
             //
             // Left NULL when nothing will record, which is what DR-7's "costs a flag-off player
-            // nothing" asks for at the rebuild as well as at the parse. _rivalSlotBuf is
+            // nothing" asks for at the rebuild as well as at the parse. _siblingRivalSlotBuf is
             // commands x 4 x maxSlots VoxrSlotMatch — tens of KB on a large grammar, re-made on
             // every NotifySlotChanged() and never read. Every reader is downstream of
             // _recordSiblingTies (the recording branch tests it first, and the recogniser only
@@ -615,8 +615,10 @@ namespace VoXR.Commands
             if (_recordSiblingTies)
             {
                 _tiedSiblingBuf = new TiedSiblingRecord[_resultBuf.Length];
-                _tiedRivalBuf = new TiedSiblingRival[_resultBuf.Length * MaxDisambiguationRivals];
-                _rivalSlotBuf = new VoxrSlotMatch[
+                _tiedSiblingRivalBuf = new TiedSiblingRival[
+                    _resultBuf.Length * MaxDisambiguationRivals
+                ];
+                _siblingRivalSlotBuf = new VoxrSlotMatch[
                     _resultBuf.Length * MaxDisambiguationRivals * _maxSlotsPerPattern
                 ];
             }
@@ -2291,7 +2293,7 @@ namespace VoXR.Commands
                                         tiedTruncated = true;
                                     }
                                     else
-                                        RecordTiedRival(
+                                        RecordTiedSiblingRival(
                                             ci,
                                             pi,
                                             rivalSetId,
@@ -2411,7 +2413,7 @@ namespace VoXR.Commands
         //
         // matchResult is the RIVAL's match — its slots are in _matchSlotBuf right now, which is
         // why the capture has to happen here and not later.
-        void RecordTiedRival(
+        void RecordTiedSiblingRival(
             int ci,
             int pi,
             int rivalSetId,
@@ -2448,7 +2450,7 @@ namespace VoXR.Commands
             int firstRival = _resultCount * MaxDisambiguationRivals;
             for (int r = 0; r < tiedRivalCount; r++)
             {
-                var kept = _tiedRivalBuf[firstRival + r];
+                var kept = _tiedSiblingRivalBuf[firstRival + r];
                 if (
                     IsAnswerableRival(
                         kept.Value,
@@ -2488,7 +2490,7 @@ namespace VoXR.Commands
             }
 
             int slot = firstRival + tiedRivalCount;
-            _tiedRivalBuf[slot] = new TiedSiblingRival
+            _tiedSiblingRivalBuf[slot] = new TiedSiblingRival
             {
                 CommandIndex = ci,
                 PatternIndex = pi,
@@ -2507,7 +2509,7 @@ namespace VoXR.Commands
                 Array.Copy(
                     _matchSlotBuf,
                     0,
-                    _rivalSlotBuf,
+                    _siblingRivalSlotBuf,
                     slot * _maxSlotsPerPattern,
                     matchResult.SlotCount
                 );
@@ -2522,34 +2524,44 @@ namespace VoXR.Commands
         // recogniser already walks the result buffer by index in its Step 7 loop.
         internal TiedSiblingRecord[] TiedSiblingBuffer => _tiedSiblingBuf;
 
-        // Rival n of result i. Flat indexing rather than a jagged array so nothing allocates per
-        // round; the caller has already checked n against TiedSiblingBuffer[i].RivalCount.
-        internal TiedSiblingRival TiedRival(int resultIdx, int n) =>
-            _tiedRivalBuf[resultIdx * MaxDisambiguationRivals + n];
+        // Sibling rival n of result i. Flat indexing rather than a jagged array so nothing
+        // allocates per round; the caller has already checked n against
+        // TiedSiblingBuffer[i].RivalCount.
+        //
+        // Every member of this family says Sibling, and that is not decoration (issue #102):
+        // this buffer holds ONLY sibling rivals, because DR-4 makes the discriminating values
+        // the choice vocabulary and a non-sibling tie has none. VoxrMatchAttempt.TiedRival is
+        // the opposite — the Editor diagnostic that issue #95 widened to name a rival of ANY
+        // kind. One name for both contracts is what this family was renamed away from.
+        //
+        // The At suffix is only there because C# would otherwise have this method and the
+        // struct it returns share a name.
+        internal TiedSiblingRival TiedSiblingRivalAt(int resultIdx, int n) =>
+            _tiedSiblingRivalBuf[resultIdx * MaxDisambiguationRivals + n];
 
         // That rival's own slot matches, copied out fresh because they cross into a public
         // VoxrCommand the subscriber can retain — the PendingCommandHandler precedent that
         // anything reaching a public event is allocated, never pool-borrowed. Once per
         // ambiguity, never per candidate.
-        internal VoxrSlotMatch[] CopyRivalSlots(int resultIdx, int n)
+        internal VoxrSlotMatch[] CopySiblingRivalSlots(int resultIdx, int n)
         {
             int slot = resultIdx * MaxDisambiguationRivals + n;
-            int count = _tiedRivalBuf[slot].SlotCount;
+            int count = _tiedSiblingRivalBuf[slot].SlotCount;
             if (count <= 0)
                 return Array.Empty<VoxrSlotMatch>();
 
             var slots = new VoxrSlotMatch[count];
-            Array.Copy(_rivalSlotBuf, slot * _maxSlotsPerPattern, slots, 0, count);
+            Array.Copy(_siblingRivalSlotBuf, slot * _maxSlotsPerPattern, slots, 0, count);
             return slots;
         }
 
-        // Rival n's intent, so the recogniser can resolve its definition before offering it as
-        // a choice — and drop it from the list if that lookup fails.
-        internal string RivalIntent(int resultIdx, int n) =>
-            _commands[TiedRival(resultIdx, n).CommandIndex].Intent;
+        // Sibling rival n's intent, so the recogniser can resolve its definition before offering
+        // it as a choice — and drop it from the list if that lookup fails.
+        internal string SiblingRivalIntent(int resultIdx, int n) =>
+            _commands[TiedSiblingRivalAt(resultIdx, n).CommandIndex].Intent;
 
-        // The command that fires if the speaker picks rival n — built here rather than in the
-        // recogniser because _slotNames and the confidence span both live on this side.
+        // The command that fires if the speaker picks sibling rival n — built here rather than
+        // in the recogniser because _slotNames and the confidence span both live on this side.
         //
         // Confidence is computed over the RIVAL's own span. ComputeConfidence takes
         // (tokens, startIdx, endIdx): startIdx comes from the record, because CompareCandidate
@@ -2559,17 +2571,17 @@ namespace VoXR.Commands
         //
         // The score is the winner's, and that is not an approximation: reaching Tied means the
         // scores were equal.
-        internal VoxrCommand BuildRivalCommand(
+        internal VoxrCommand BuildSiblingRivalCommand(
             int resultIdx,
             int n,
             string[] tokens,
             Dictionary<string, float> wordConfidence
         )
         {
-            var rival = TiedRival(resultIdx, n);
+            var rival = TiedSiblingRivalAt(resultIdx, n);
             return new VoxrCommand(
                 _commands[rival.CommandIndex].Intent,
-                CopyRivalSlots(resultIdx, n),
+                CopySiblingRivalSlots(resultIdx, n),
                 ComputeConfidence(
                     tokens,
                     _tiedSiblingBuf[resultIdx].StartIdx,

--- a/Runtime/Commands/VoxrCommandRecogniser.cs
+++ b/Runtime/Commands/VoxrCommandRecogniser.cs
@@ -1103,7 +1103,9 @@ namespace VoXR.Commands
                 // registered the rival in an inactive set, which does not reach the shape —
                 // the parser is rebuilt from the ACTIVE commands, so it stops seeing the tie
                 // at all. The guard is what keeps that argument true if either end changes.
-                if (!_setManager.TryLookupCommand(parser.RivalIntent(i, n), out var rivalDef))
+                if (
+                    !_setManager.TryLookupCommand(parser.SiblingRivalIntent(i, n), out var rivalDef)
+                )
                 {
                     // Nameable in a prompt but not fireable, so not offered — and reported,
                     // because an answer the speaker could have given is going unoffered.
@@ -1111,8 +1113,8 @@ namespace VoXR.Commands
                     continue;
                 }
 
-                choiceBuf.Add(parser.BuildRivalCommand(i, n, tokens, wordConfidence));
-                valueBuf.Add(parser.TiedRival(i, n).Value);
+                choiceBuf.Add(parser.BuildSiblingRivalCommand(i, n, tokens, wordConfidence));
+                valueBuf.Add(parser.TiedSiblingRivalAt(i, n).Value);
                 defBuf.Add(rivalDef);
             }
 

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -4749,8 +4749,12 @@ namespace VoXR.Tests.Runtime
             Assert.AreEqual(1, record.RivalCount);
             Assert.AreEqual("mode", record.WinnerValue, "the winner's own discriminating value");
             Assert.IsFalse(record.Truncated);
-            Assert.AreEqual("level", parser.TiedRival(0, 0).Value, "what the speaker would say");
-            Assert.AreEqual("set_level", parser.RivalIntent(0, 0), "…to fire this instead");
+            Assert.AreEqual(
+                "level",
+                parser.TiedSiblingRivalAt(0, 0).Value,
+                "what the speaker would say"
+            );
+            Assert.AreEqual("set_level", parser.SiblingRivalIntent(0, 0), "…to fire this instead");
         }
 
         [Test]
@@ -4790,7 +4794,11 @@ namespace VoXR.Tests.Runtime
             Assert.IsFalse(record.Truncated);
             CollectionAssert.AreEqual(
                 new[] { "level", "standby" },
-                new[] { parser.TiedRival(0, 0).Value, parser.TiedRival(0, 1).Value },
+                new[]
+                {
+                    parser.TiedSiblingRivalAt(0, 0).Value,
+                    parser.TiedSiblingRivalAt(0, 1).Value,
+                },
                 "registration order, deterministically — an integrator's prompt must not "
                     + "reorder itself between sessions"
             );
@@ -4817,7 +4825,11 @@ namespace VoXR.Tests.Runtime
 
             var record = parser.TiedSiblingBuffer[0];
             Assert.AreEqual(1, record.RivalCount, "one offerable choice, not two spellings of it");
-            Assert.AreEqual("set_level_a", parser.RivalIntent(0, 0), "the first, as F8 does");
+            Assert.AreEqual(
+                "set_level_a",
+                parser.SiblingRivalIntent(0, 0),
+                "the first, as F8 does"
+            );
             Assert.IsFalse(
                 record.Truncated,
                 "a duplicate that was never offerable is not something that failed to fit"
@@ -4861,7 +4873,7 @@ namespace VoXR.Tests.Runtime
 
             parser.Parse("set alpha on", null);
 
-            var slots = parser.CopyRivalSlots(0, 0);
+            var slots = parser.CopySiblingRivalSlots(0, 0);
             Assert.AreEqual(1, slots.Length);
             Assert.AreEqual("ship", slots[0].Name);
             Assert.AreEqual("alpha", slots[0].Value);
@@ -4898,8 +4910,8 @@ namespace VoXR.Tests.Runtime
                     + "used to claim this while nothing asserted it"
             );
             Assert.AreEqual("mode", record.WinnerValue);
-            Assert.AreEqual("level", parser.TiedRival(0, 0).Value);
-            Assert.AreEqual("set_level_on", parser.RivalIntent(0, 0));
+            Assert.AreEqual("level", parser.TiedSiblingRivalAt(0, 0).Value);
+            Assert.AreEqual("set_level_on", parser.SiblingRivalIntent(0, 0));
         }
 
         [Test]
@@ -4968,7 +4980,7 @@ namespace VoXR.Tests.Runtime
 
             var record = parser.TiedSiblingBuffer[0];
             Assert.AreEqual(1, record.RivalCount, "only the nameable rival is offered");
-            Assert.AreEqual("standby", parser.TiedRival(0, 0).Value);
+            Assert.AreEqual("standby", parser.TiedSiblingRivalAt(0, 0).Value);
             Assert.IsTrue(
                 record.Truncated,
                 "and the integrator is told an answer is missing from the list"
@@ -5011,10 +5023,14 @@ namespace VoXR.Tests.Runtime
             );
             CollectionAssert.AreEqual(
                 new[] { "set_beta", "set_standby" },
-                new[] { parser.RivalIntent(0, 0), parser.RivalIntent(0, 1) },
+                new[] { parser.SiblingRivalIntent(0, 0), parser.SiblingRivalIntent(0, 1) },
                 "and the second intent still gets its slot"
             );
-            Assert.AreEqual("level", parser.TiedRival(0, 0).Value, "the first spelling wins");
+            Assert.AreEqual(
+                "level",
+                parser.TiedSiblingRivalAt(0, 0).Value,
+                "the first spelling wins"
+            );
         }
 
         [Test]


### PR DESCRIPTION
Closes #102

## What

`TiedRival` named two opposite contracts. `VoxrCommandParser.TiedRival(...)` indexed a buffer DR-4 restricts to **sibling** rivals; `VoxrMatchAttempt.TiedRival` is the diagnostic field issue #95 deliberately widened to name a rival of **any** kind. Both `internal` to `VoXR.Commands`, nothing at either call site saying which was in force.

This applies the rename rule #95 established — say `Sibling` where the sibling restriction applies — to the parser's whole choice-buffer family, leaving `TiedRival` to mean "a rival of any kind" consistently:

| before | after |
|---|---|
| `TiedRival(i, n)` | `TiedSiblingRivalAt(i, n)` |
| `RecordTiedRival(…)` | `RecordTiedSiblingRival(…)` |
| `_tiedRivalBuf` | `_tiedSiblingRivalBuf` |
| `RivalIntent(i, n)` | `SiblingRivalIntent(i, n)` |
| `CopyRivalSlots(i, n)` | `CopySiblingRivalSlots(i, n)` |
| `BuildRivalCommand(…)` | `BuildSiblingRivalCommand(…)` |
| `_rivalSlotBuf` | `_siblingRivalSlotBuf` |

`VoxrMatchAttempt.TiedRival` / `TiedRivalIsSibling` and their two Editor readers are untouched — that is the point.

## Why

Two judgement calls the reviewer should rule on rather than assume:

**The `At` suffix.** Inserting `Sibling` mechanically gives `TiedSiblingRival(i, n)` — a method sharing its name with the struct it returns. C# permits it, but it is a worse readability trap than the one being fixed, so the accessor takes `At`. The doc comment on it says why, and also states the sibling-only contract and its contrast with `VoxrMatchAttempt.TiedRival`.

**Three names beyond the issue's list.** The issue enumerates four members. `CopyRivalSlots`, `BuildRivalCommand`, and `_rivalSlotBuf` are sibling-only and drop the word by exactly the same criterion, and index the same flat buffer. Renaming four of the seven would reproduce the fault the issue itself names — applying a rename rule to one side of a boundary and not the other. Trim this back if you disagree; it is the only part of the diff not literally enumerated in #102.

Rename only. No behaviour change. Four are `internal` and three (`_tiedSiblingRivalBuf`, `_siblingRivalSlotBuf`, `RecordTiedSiblingRival`) are `private`, all inside an `internal class VoxrCommandParser` — **none is `public`**, so no public API change and no `CHANGELOG` entry. `Runtime/AssemblyInfo.cs` grants `InternalsVisibleTo` to `Jinwoo1601.VoXR.Editor` and both test assemblies, which is the full blast radius for the four `internal` ones. No `Documentation~/`, `Samples~/`, or root-markdown references existed.

## Validation

- [x] **Unity EditMode: 131/131 pass** (`failed="0"`, `inconclusive="0"`, `skipped="0"`) via host project `VoXR TestGround`, Unity 6000.4.7f1.
- [x] **Unity PlayMode: 522/522 pass** (`failed="0"`, `inconclusive="0"`, `skipped="0"`) — where the parser/command tests live; an EditMode-only run would have missed them.
- [x] **Zero compile errors across all four assemblies** (Runtime, Editor, Tests.Runtime, Tests.Editor). This is the load-bearing check for a rename of `internal` members: a missed call site is a compile error, and there were none.
- [x] Post-rename sweep for stale `_tiedRivalBuf` / `_rivalSlotBuf` / `RecordTiedRival` / `RivalIntent` / `CopyRivalSlots` / `BuildRivalCommand` / parser-side `TiedRival(` references. **Corrected after review** — as originally worded ("anywhere in the repo") this box was false. `grep` in this shell is a wrapper passing `--ignore-files`, so it honours `.gitignore` and silently skipped `Planning~/`, which contains compiled C# that stages and compiles these very Runtime sources. One stale call site was there (`ab-rig/PlayerCheck.cs:77`) and broke that rig's build. It is now fixed, but `Planning~/` is gitignored so **that fix is not in this diff**. Tracked content is confirmed clean via `command grep`.
- [x] **Grammar A/B rig green on the renamed parser** — `./stage.sh WORKTREE` then `PlayerCheck` **7/7, exit 0** and `DocCheck` **50/50 doc claims, exit 0**. `PlayerCheck` is the only build in this project that compiles *without* `UNITY_EDITOR` defined, so this is the one check that reaches the shipped player configuration — which all 653 Unity tests structurally cannot.
- [x] `Tests~` edited via `sed` rather than the editor tooling, to keep the CSharpier hook from reformatting the whole (not-currently-CSharpier-clean) file; only the four lines pushed past 100 chars were rewrapped by hand. Diff is 10 renamed call sites plus that rewrapping.

No on-device (Quest) check applies: nothing here changes runtime behaviour, and the rename is proven by compilation plus 653 passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsetkJVeu9sRguysZZj1oS
