### PR TITLE
Pin the sibling-set edge branches and lookup invariants (#93)

### DIFF
--- a/Tests~/Editor/VoxrCommandParserDiagnosticTests.cs
+++ b/Tests~/Editor/VoxrCommandParserDiagnosticTests.cs
@@ -493,5 +493,78 @@ namespace VoXR.Tests.Editor
                 "a tie we cannot phrase a question about is not one we ask about"
             );
         }
+
+        [Test]
+        public void LastParseDiagnostics_TieInRoundOne_DoesNotLeakIntoRoundTwo()
+        {
+            // The first multi-round test in which round 1 actually RECORDS a rival. The only
+            // multi-round diagnostic test before it parsed a grammar with no sibling sets, so
+            // nothing was ever recorded in either round and the hand-off between rounds went
+            // unexercised (issue #93).
+            //
+            // What this does NOT pin, said plainly because issue #93 asked for it and the
+            // premise did not survive contact: ParseInternal declares its tie locals inside the
+            // extraction loop, and hoisting them OUT is unobservable. The clear-on-adopt block
+            // in the Better branch resets all eight of them whenever a new incumbent is taken,
+            // and a round that appends a diagnostic entry has taken one by definition —
+            // bestScore starts at float.MinValue, so the first admissible candidate always
+            // adopts, and a round that adopts nothing breaks before appending. The per-round
+            // declaration is belt-and-braces over clear-on-adopt, not the rule enforcing it.
+            // Confirmed by hoisting the three exemplar locals out of the loop and re-running
+            // both suites green. So this test pins the BEHAVIOUR — round 2 reports the tie it
+            // had, which is none — and no test can pin the declaration site.
+            //
+            // Two rounds, and only the first is a coin flip. "set alpha on" drops the
+            // discriminator and ties set_mode against set_level; "cease fire" that follows it
+            // is unambiguous. The tied round comes FIRST, which is the order a leak would show
+            // in, and what puts it there is the start-index key: CompareCandidate returns on
+            // `startIdx != bestStartIdx` before it ever reads a score, so the sibling pair
+            // adopted at index 0 refuses "cease fire" at index 3 without the two scores being
+            // compared at all. Score enters only as the > 0 admission floor.
+            //
+            // Said precisely because the arithmetic invites the wrong reading: the pair does
+            // also outscore "cease fire" here (0.75 against 0.4, which pays coverage for the
+            // three tokens it skips to reach itself), and that is a coincidence this fixture
+            // does not rest on. A change that sank the pair below 0.4 would NOT reorder the
+            // rounds; one that pushed it to zero would, by dropping it from the round entirely.
+            var parser = new VoxrCommandParser(
+                ShipSlots(),
+                new[]
+                {
+                    new VoxrCommandDefinition(
+                        "set_mode",
+                        new[] { new[] { "set", "{ship}", "mode", "on" } }
+                    ),
+                    new VoxrCommandDefinition(
+                        "set_level",
+                        new[] { new[] { "set", "{ship}", "level", "on" } }
+                    ),
+                    new VoxrCommandDefinition("cease_fire", new[] { new[] { "cease", "fire" } }),
+                }
+            );
+
+            var results = parser.Parse("set alpha on cease fire", null);
+
+            Assert.AreEqual(2, results.Length, "two commands extracted, in two rounds");
+            Assert.AreEqual("set_mode", results[0].Command.Intent);
+            Assert.AreEqual("cease_fire", results[1].Command.Intent);
+
+            var diag = parser.LastParseDiagnostics;
+            Assert.AreEqual(2, diag.Length);
+            Assert.AreEqual(
+                "set_level",
+                diag[0].TiedRivalIntent,
+                "round 1 is the coin flip, and is still reported as one"
+            );
+
+            Assert.IsNull(
+                diag[1].TiedRivalIntent,
+                "round 2 had one candidate — a rival held over from round 1 would name a "
+                    + "pattern that never competed for this command"
+            );
+            Assert.AreEqual(-1, diag[1].TiedRivalPatternIndex);
+            Assert.IsFalse(diag[1].TiedRivalIsSibling);
+            Assert.IsNull(diag[1].DescribeTiedRival());
+        }
     }
 }

--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -3,8 +3,13 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine.TestTools;
+using UnityEngine.TestTools.Constraints;
 using VoXR;
 using VoXR.Commands;
+// UnityEngine.TestTools.Constraints.Is derives from NUnit's and adds AllocatingGCMemory().
+// Aliased rather than imported bare because both namespaces export the name; this file used
+// no `Is.` before, so the alias costs nothing and keeps the ambiguity from ever arising.
+using Is = UnityEngine.TestTools.Constraints.Is;
 
 namespace VoXR.Tests.Runtime
 {
@@ -3910,6 +3915,52 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
+        public void SiblingWarning_TwoPatternsSharingAValue_NameThatValueOnce()
+        {
+            // The VALUE list's dedup, the sibling of the pattern-text one above and added
+            // blind alongside it (issue #93). Both became reachable when issue #90 stopped
+            // dropping duplicate-valued members, and both collapse for the same reason the
+            // intent list does — except that here the reason is about the QUESTION: the choice
+            // the speaker faces is between distinct words, so ("mode", "mode" or "level")
+            // would be wrong about what is being asked, not merely repetitive.
+            //
+            // The duplicate-valued members render DIFFERENT pattern text here — set_a reaches
+            // the frame by omitting its optional — so the pattern-text dedup does nothing and
+            // the value list is the only thing under test.
+            //
+            // Not the only guard on this branch, and issue #93 said otherwise only because it
+            // was filed hours before the other one landed: SiblingWarning_SymmetricSetWith
+            // ABarePattern_NumbersEachPatternToo asserts a full message on a set that carries
+            // "mode" twice, so it too goes red without the dedup. It gets there incidentally,
+            // through a fixture built to pin per-pattern element numbering, and it would stop
+            // covering this the moment that fixture changed for its own reasons. This one is
+            // deliberate and isolated, which is what makes it the guard rather than a second
+            // accident.
+            LogAssert.Expect(
+                UnityEngine.LogType.Warning,
+                new Regex(
+                    "Intents 'set_a', 'set_b' and 'set_c' have patterns "
+                        + "\"set mode on \\?please\" \\(with its optional elements omitted\\), "
+                        + "\"set mode on\" and \"set level on\" that differ only at element 2 "
+                        + "\\(\"mode\" or \"level\"\\)"
+                )
+            );
+
+            var parser = new VoxrCommandParser(
+                Array.Empty<VoxrSlotDefinition>(),
+                new[]
+                {
+                    Sib("set_a", SibP("set", "mode", "on", "?please")),
+                    Sib("set_b", SibP("set", "mode", "on")),
+                    Sib("set_c", SibP("set", "level", "on")),
+                }
+            );
+
+            Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
         public void SiblingWarning_NamesARemedyThatActuallyRemovesTheTie()
         {
             // The message shipped saying "Diverge earlier", which does not work — and this
@@ -4314,6 +4365,45 @@ namespace VoXR.Tests.Runtime
         }
 
         [Test]
+        public void SiblingWarning_TwoPatternsCarryingOneCancelWord_ReportItOnce()
+        {
+            // The collision loop's per-VALUE dedup, the other branch issue #90 forced and the
+            // other one added blind (issue #93). Since a value can now be carried by several
+            // patterns, and the remedy — rename the literal — is the same advice however many
+            // patterns spell it, repeating it would be noise.
+            //
+            // This is the shape the test above deliberately is NOT: there the earlier member
+            // carrying "negative" was unanswerable, so suppressing against it would have lost
+            // a real collision, and the dedup had to let the later one through. Here BOTH
+            // members are answerable — each has 'ident_friendly' as a different-valued,
+            // different-intent co-member — so exactly one report is right, and the suppressed
+            // second one is what NoUnexpectedReceived catches. No fixture anywhere paired a
+            // duplicated value with cancel vocabulary before this, so the guard had no
+            // exercise at all.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("differ only at element 3"));
+            LogAssert.Expect(
+                UnityEngine.LogType.Warning,
+                new Regex(
+                    "Intent 'ident_hostile' carries the discriminating value \"negative\" at "
+                        + "element 3, which is also in the default cancel vocabulary"
+                )
+            );
+
+            var parser = new VoxrCommandParser(
+                Array.Empty<VoxrSlotDefinition>(),
+                new[]
+                {
+                    Sib("ident_hostile", SibP("mark", "contact", "negative")),
+                    Sib("ident_unknown", SibP("mark", "contact", "negative")),
+                    Sib("ident_friendly", SibP("mark", "contact", "friendly")),
+                }
+            );
+
+            Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
         public void SiblingWarning_CancelVocabularyOverridden_ReportsAgainstTheOverride()
         {
             // F12. The report is computed against the vocabulary that will actually run, so an
@@ -4548,6 +4638,131 @@ namespace VoXR.Tests.Runtime
             var parser = new VoxrCommandParser(BurnSlots(), DecelerateCommands("by"));
 
             Assert.IsNotNull(parser);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // ---------- Sibling selection cost invariants (issue #74 F13, design §7; issue #93) ----------
+        //
+        // Two claims the feature makes about what it costs rather than about what it decides.
+        // Both were argued in prose and measured with throwaway probes, and neither had an
+        // executable guard: deleting the code that makes them true left every suite green.
+
+        static VoxrCommandDefinition[] SetOnSiblings() =>
+            new[]
+            {
+                Sib("set_mode", SibP("set", "mode", "on")),
+                Sib("set_level", SibP("set", "level", "on")),
+            };
+
+        [Test]
+        public void EagerSelection_OverASiblingTie_AllocatesNothingPerCall()
+        {
+            // CompareCandidate and AreSiblingRivals sit in the innermost loop of both selection
+            // paths — (command x pattern x startIdx), per utterance — so an allocation
+            // introduced beside them is per-utterance GC pressure on the poll path. Both are
+            // written to allocate nothing (AreSiblingRivals reads prebuilt arrays and exits on
+            // the first null), and nothing checked.
+            //
+            // Measured with Unity's own AllocatingGCMemory constraint and NOT with
+            // GC.GetAllocatedBytesForCurrentThread, which is what ZeroAllocPollPathTests uses.
+            // That counter is INERT here — measured at 0 B moved after a deliberate 1 MB
+            // allocation, this Unity version's collector not being one that maintains it — so
+            // an assertion written against it reads zero whatever the code does. This test was
+            // written that way first and was blind: deleting the memo guard in
+            // EnsureSiblingLookup makes this very scan rebuild the whole lookup (a Dictionary,
+            // per-bucket lists and four jagged arrays) on all 100 calls, and the counter-based
+            // version still reported 0 B and passed. The constraint below fails on it.
+            //
+            // ZeroAllocPollPathTests is blind for the same reason and is left alone here — it
+            // is a different hot path, and its partial-JSON test asserts a BUDGET, which no
+            // constraint expresses. Reported on the PR rather than fixed in passing.
+            //
+            // Measured over TryEagerCommit rather than Parse, because Parse necessarily
+            // allocates the results it returns and so can never be pinned at zero. The eager
+            // scan mirrors ParseInternal's loop and shares the comparator and the rival test,
+            // which is the code this is about; it returns an enum, so anything the constraint
+            // sees is a regression.
+            //
+            // Literal-only grammar, because the constraint admits no budget: a matched slot
+            // allocates its own captured value, and there would be no threshold to put it under.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("differ only at element 2"));
+
+            var parser = new VoxrCommandParser(Array.Empty<VoxrSlotDefinition>(), SetOnSiblings());
+
+            // ONE array instance, hoisted OUT of the measured delegate below, because
+            // `new[] { "set", "on" }` inside it would be 100 array allocations inside the
+            // region the constraint watches — the test failing on its own garbage.
+            //
+            // Not for warm-up: a fresh two-element array per call would leave the steady state
+            // exactly as it is. BuildCoverageTables regrows only when tokens.Length exceeds
+            // the capacity it already has, and it rebinds _coverageTokens every call, so
+            // neither the tables nor the ReferenceEquals guard would notice.
+            var tokens = new[] { "set", "on" };
+
+            // The tie has to be REACHED, or this measures an empty loop: "set on" drops the
+            // discriminator, both patterns score identically, and the sibling refusal is what
+            // turns the verdict from Commit into None. This call is also the warm-up — the
+            // extendability analysis and the coverage tables are built lazily on the first
+            // eager check, and both are per-parser costs rather than per-call ones.
+            Assert.AreEqual(
+                EagerCommitVerdict.None,
+                parser.TryEagerCommit(tokens, null, 0.6f, 0f),
+                "the sibling refusal, which is the branch that calls AreSiblingRivals"
+            );
+
+            Assert.That(
+                () =>
+                {
+                    for (int i = 0; i < 100; i++)
+                        parser.TryEagerCommit(tokens, null, 0.6f, 0f);
+                },
+                Is.Not.AllocatingGCMemory()
+            );
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void SiblingLookup_IsBuiltOncePerParser_NotOncePerParse()
+        {
+            // F13's acceptance: parsing the same utterance N times calls FindSiblingSets once.
+            // The whole of what makes that true is the `if (_siblingLookupComputed) return;`
+            // guard at the top of EnsureSiblingLookup, and deleting it broke nothing in the
+            // suite as it stood — a rebuild produces an EQUAL lookup, so every behavioural test
+            // still passed while the parser re-ran an O(commands x forms) Dictionary build on
+            // every eager scan.
+            //
+            // Pinned on reference identity rather than a call count: a rebuild is exactly what
+            // replaces these arrays, and _siblingMemberships is the one the runtime reads (the
+            // set list beside it is Editor-only). Reflection for the reason SiblingScan_
+            // IsEditorOnly uses it — the private field IS the invariant, and widening its
+            // visibility for a test would be a larger change than the test.
+            LogAssert.Expect(UnityEngine.LogType.Warning, new Regex("differ only at element 2"));
+
+            var parser = new VoxrCommandParser(Array.Empty<VoxrSlotDefinition>(), SetOnSiblings());
+
+            var field = typeof(VoxrCommandParser).GetField(
+                "_siblingMemberships",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
+            );
+            Assert.IsNotNull(field, "VoxrCommandParser._siblingMemberships");
+
+            object built = field.GetValue(parser);
+            Assert.IsNotNull(built, "built at construction, before any utterance");
+
+            // The eager scan is the parse-time caller — ParseInternal reads the lookup but
+            // never builds it — so both are driven, three times each.
+            for (int i = 0; i < 3; i++)
+            {
+                parser.Parse("set on", null);
+                parser.TryEagerCommit(new[] { "set", "on" }, null, 0.6f, 0f);
+            }
+
+            Assert.AreSame(
+                built,
+                field.GetValue(parser),
+                "the same lookup instance throughout, so FindSiblingSets ran once for this "
+                    + "parser and not once per scan"
+            );
             LogAssert.NoUnexpectedReceived();
         }
 


### PR DESCRIPTION
Closes #93

> **Revised after review.** All four findings from the review below were confirmed and fixed in `dff809b` (force-push; the previous head `5c4005c` carried an overclaim in its commit message, so it was amended rather than followed up). This body is corrected too — see [Review fixes](#review-fixes) at the end for exactly what changed.

## What

Five tests, no production change. **Four** were verified by deleting the code they guard and watching them go red, with the failure message quoted below so you can check each failed for the right reason. The fifth guards something no test can witness; it is marked as such in the table rather than counted as a witness it is not.

| # | Gap | Test | Suite | Mutation-witnessed |
|---|---|---|---|---|
| 1 | `BuildSiblingWarning` value-list dedup | `SiblingWarning_TwoPatternsSharingAValue_NameThatValueOnce` | PlayMode | yes |
| 1 | cancel-collision `alreadyReported` guard | `SiblingWarning_TwoPatternsCarryingOneCancelWord_ReportItOnce` | PlayMode | yes |
| 2 | per-round tie reset | `LastParseDiagnostics_TieInRoundOne_DoesNotLeakIntoRoundTwo` | EditMode | **no — not observable, see Finding 2** |
| 3 | invariant 8, allocation-free selection | `EagerSelection_OverASiblingTie_AllocatesNothingPerCall` | PlayMode | yes |
| 3 | invariant 9, lookup built once (F13) | `SiblingLookup_IsBuiltOncePerParser_NotOncePerParse` | PlayMode | yes |

Fixture notes, since the issue asked for these two to match the pattern-text dedup test:

- The **value dedup** fixture gives its two duplicate-valued members *different* pattern text — `set_a` reaches the frame by omitting its optional — so the pattern-text dedup does nothing and the value list is the only thing under test.
- The **cancel dedup** fixture makes *both* `"negative"` members answerable, which is exactly what `SiblingWarning_CancelCollisionReachableOnlyThroughOnePair_StillReports` is not: there the dedup must let the later member through, here it must suppress it.

### One correction to the issue's premise

Issue #93 says all these branches are "nothing fails if this is deleted". That is right for three of the four, and was right for the fourth **when the issue was filed**. It is no longer: `SiblingWarning_SymmetricSetWithABarePattern_NumbersEachPatternToo` asserts a full message on a set carrying `"mode"` twice, so the **value-list dedup was already going red incidentally**. That test landed in `d6fa33c`, roughly five hours after #93 was opened.

The new test is still worth having — the incidental guard rides on a fixture built to pin per-pattern element numbering and would stop covering the dedup the moment that fixture changed for its own reasons — but it is a *deliberate, isolated* guard replacing an accidental one, not first coverage. The test comment says so.

## Why

The branches were untested and the invariants were argued in prose. Mutation-testing each one is what turned that from a claim into evidence — and it caught two of my own tests being as blind as the code they were meant to guard. Both are below.

## Two findings beyond the issue

**1. `GC.GetAllocatedBytesForCurrentThread()` is inert on this runtime.** A probe measured **0 B moved after a deliberate 1 MB allocation**. I wrote the allocation test against that counter first and it was blind: with `EnsureSiblingLookup`'s memo guard deleted, the eager scan rebuilds the entire lookup — a `Dictionary`, per-bucket lists and four jagged arrays — on all 100 calls, and the counter still read zero and the test still passed. It now uses Unity's `Is.Not.AllocatingGCMemory()` constraint, which fails on that mutation.

This means **`ZeroAllocPollPathTests.ParsingErrorCode_AllocatesNothing` has been vacuous since it was written** (`Assert.AreEqual(0, delta)` where `delta` is always 0), and `ParsingPartialJson_AllocatesOnlyTheReturnedString` likewise (`0 < 20_000`). I left that file alone: different hot path, and the partial-JSON one asserts a *budget*, which `AllocatingGCMemory` cannot express — converting it is a design call, not a mechanical swap. Worth its own issue.

**2. Gap 2's premise does not hold — the hoist is unobservable.** The issue asks for a test that fails if `ParseInternal`'s tie locals are hoisted out of the extraction loop. There cannot be one. The clear-on-adopt block in the `Better` branch resets all eight of them whenever a new incumbent is taken, and a round that appends a diagnostic entry has taken one by definition — `bestScore` starts at `float.MinValue`, so the first admissible candidate always adopts, and a round that adopts nothing `break`s before appending. Confirmed by hoisting the three exemplar locals and running both suites green.

The per-round declaration is belt-and-braces over clear-on-adopt, not the rule enforcing it. I kept the test, because it is still the first multi-round diagnostic test in which round 1 actually *records* a rival — coverage that was genuinely absent — but its comment states what it does and does not pin instead of claiming a guard it does not provide.

## Validation

**Mutation pass** — four guards deleted simultaneously, then re-run:

| Mutation | Witness | Verdict |
|---|---|---|
| value-list dedup removed | `SiblingWarning_TwoPatternsSharingAValue_...` | FAILED — `... ("mode", "mode" or "level")` |
| `alreadyReported` removed | `SiblingWarning_TwoPatternsCarryingOneCancelWord_...` | FAILED — second warning for `ident_unknown` |
| memo guard removed | `SiblingLookup_IsBuiltOncePerParser_...` | FAILED — `Expected: same as ...` reference identity |
| memo guard removed | `EagerSelection_OverASiblingTie_...` | FAILED — `Expected: not allocates GC memory` |
| tie locals hoisted | — | **no witness exists**, see Finding 2 |

`SiblingWarning_SymmetricSetWithABarePattern_NumbersEachPatternToo` also failed under mutation 1 — not collateral, but the pre-existing incidental guard described above.

**Clean run** on the exact commit under review (`dff809b`), `Runtime/Commands/VoxrCommandParser.cs` pristine, probe test deleted:

- [x] Unity EditMode — **132/132**, 0 failed
- [x] Unity PlayMode — **526/526**, 0 failed
- [x] Both suites compiled clean (no `CS####` diagnostics)
- [x] No regressions; working tree restored (`Tests~` renamed back, `.meta` orphans cleaned)
- [x] No production code changed — `git diff origin/main HEAD` touches only the two test files, 288 insertions, 0 deletions
- [x] No `CHANGELOG.md` entry: not user-facing, consistent with prior test-only issues (#68, #76)

Host project `VoXR TestGround`, Unity 6000.4.7f1. No `NativeBridge~` change, so no arm64 rebuild and no on-device check needed.

## Review fixes

The review below found no code defect. All four findings were false or unsupported *statements*; all four are fixed in `dff809b`:

1. **Overclaimed mutation coverage** — the "Each was verified…" sentence and the unmarked table row, in both this body and the commit message. Commit amended so the claim never reaches `main`; body scoped to four, table marks the fifth.
2. **Value dedup described as unguarded** — corrected above and in the test comment, with the timing that explains why the issue said otherwise.
3. **Wrong hoist rationale** in `EagerSelection_...` — the real reason is that `new[]` inside the delegate is 100 allocations inside the measured region, not a warm-up effect. `BuildCoverageTables` regrows on length, not identity.
4. **"Round 1 wins on score"** in the Editor test — it wins on the start-index key, which `CompareCandidate` tests two lines before score (`VoxrCommandParser.cs:2899` vs `:2901`), as the source itself states at `:2873`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsetkJVeu9sRguysZZj1oS
