### PR TITLE
Measure the poll-path allocation tests with a live instrument (#105)

### DIFF
--- a/Tests~/Runtime/VoxrCommandParserTests.cs
+++ b/Tests~/Runtime/VoxrCommandParserTests.cs
@@ -4664,18 +4664,15 @@ namespace VoXR.Tests.Runtime
             // the first null), and nothing checked.
             //
             // Measured with Unity's own AllocatingGCMemory constraint and NOT with
-            // GC.GetAllocatedBytesForCurrentThread, which is what ZeroAllocPollPathTests uses.
-            // That counter is INERT here — measured at 0 B moved after a deliberate 1 MB
-            // allocation, this Unity version's collector not being one that maintains it — so
-            // an assertion written against it reads zero whatever the code does. This test was
-            // written that way first and was blind: deleting the memo guard in
-            // EnsureSiblingLookup makes this very scan rebuild the whole lookup (a Dictionary,
-            // per-bucket lists and four jagged arrays) on all 100 calls, and the counter-based
-            // version still reported 0 B and passed. The constraint below fails on it.
-            //
-            // ZeroAllocPollPathTests is blind for the same reason and is left alone here — it
-            // is a different hot path, and its partial-JSON test asserts a BUDGET, which no
-            // constraint expresses. Reported on the PR rather than fixed in passing.
+            // GC.GetAllocatedBytesForCurrentThread. That counter is INERT here — measured at
+            // 0 B moved after a deliberate 1 MB allocation, this Unity version's collector not
+            // being one that maintains it — so an assertion written against it reads zero
+            // whatever the code does. This test was written that way first and was blind:
+            // deleting the memo guard in EnsureSiblingLookup makes this very scan rebuild the
+            // whole lookup (a Dictionary, per-bucket lists and four jagged arrays) on all 100
+            // calls, and the counter-based version still reported 0 B and passed. The
+            // constraint below fails on it. ZeroAllocPollPathTests was blind for the same
+            // reason and was moved off that counter in issue #105.
             //
             // Measured over TryEagerCommit rather than Parse, because Parse necessarily
             // allocates the results it returns and so can never be pinned at zero. The eager

--- a/Tests~/Runtime/ZeroAllocPollPathTests.cs
+++ b/Tests~/Runtime/ZeroAllocPollPathTests.cs
@@ -19,9 +19,16 @@ namespace VoXR.Tests.Runtime
     // measured at 0 B moved after a deliberate 1 MB allocation — so the byte-delta
     // assertions this file was written with read zero whatever the code does, and both
     // passed unconditionally from the day they were written (issue #105).
+    //
+    // TheAllocationInstrumentsSeeADeliberateAllocation is the positive control against a
+    // repeat of that. Read it before trusting a green run of the other two.
     public class ZeroAllocPollPathTests
     {
         const int Iterations = 100;
+
+        // Not private: a private field only ever assigned is a CS0414 warning. Written by
+        // the positive control so its allocations cannot be optimised away as dead.
+        internal static byte[] Sink;
 
         [Test]
         public void ParsingPartialJson_AllocatesOnlyTheReturnedString()
@@ -41,6 +48,10 @@ namespace VoXR.Tests.Runtime
             // exactly that one allocation. Anything beyond it — an inadvertent Substring,
             // a boxed value type, a freshly built key array — shows up as a second
             // allocation per call and fails here.
+            //
+            // Deliberately an equality, not a ceiling: a count BELOW one-per-call would
+            // mean the returned string had stopped being freshly allocated, which is also
+            // a change worth failing on.
             Assert.AreEqual(
                 Iterations,
                 allocations,
@@ -57,7 +68,9 @@ namespace VoXR.Tests.Runtime
             VoxrJsonParser.ParseErrorCode(json);  // warm up
 
             // Returns an enum (value type), so nothing at all is permitted and Unity's
-            // zero-or-fail constraint expresses it exactly.
+            // zero-or-fail constraint expresses it exactly. Looped rather than called once
+            // so that an allocation appearing only on a repeat call — a lazy init that
+            // re-fires, a cache that rebuilds — is caught too.
             Assert.That(
                 () =>
                 {
@@ -68,22 +81,64 @@ namespace VoXR.Tests.Runtime
             );
         }
 
+        // The failure mode this file exists to prevent is not a parser regression — it is an
+        // instrument that silently reads zero. That is what GC.GetAllocatedBytesForCurrentThread
+        // did here while both tests above "passed" for four months, and neither test can detect
+        // it alone: a zero-or-fail constraint passes when the recorder is dead, and an
+        // expected-zero byte delta passes when the counter is dead. So assert the converse —
+        // both instruments must SEE a deliberate allocation. If this test goes red, the other
+        // two in this file are not measuring anything and their greens mean nothing.
+        [Test]
+        public void TheAllocationInstrumentsSeeADeliberateAllocation()
+        {
+            int observed = GCAllocationsDuring(() =>
+            {
+                Sink = new byte[64];
+            });
+
+            Assert.Greater(
+                observed,
+                0,
+                "GCAllocationsDuring saw 0 allocations for a deliberate 64 B array. The GC.Alloc "
+                    + "recorder is not measuring on this runtime, so "
+                    + "ParsingPartialJson_AllocatesOnlyTheReturnedString proves nothing."
+            );
+
+            Assert.That(
+                () =>
+                {
+                    Sink = new byte[64];
+                },
+                Is.AllocatingGCMemory(),
+                "Unity's AllocatingGCMemory constraint did not observe a deliberate 64 B "
+                    + "allocation, so ParsingErrorCode_AllocatesNothing proves nothing."
+            );
+        }
+
         // Is.Not.AllocatingGCMemory() is zero-or-fail and expresses no budget, so the
         // partial-JSON test — which must permit the one string it returns — reads the same
-        // recorder that constraint is itself built on (AllocatingGCMemoryConstraint uses
-        // Recorder.Get("GC.Alloc") and sampleBlockCount) and asserts on the COUNT instead.
-        // A count is the stronger guard of the two available: the 20 KB byte budget this
-        // test used to carry would have admitted an extra Substring per call (~78 B × 100
-        // = ~7.8 KB) even on a runtime where the byte counter worked.
+        // recorder that constraint is itself built on and asserts on the COUNT instead.
+        // sampleBlockCount is a count of allocations, which is Unity's own documented
+        // reading of it: AllocatingGCMemoryConstraint reports "The provided delegate made
+        // {0} GC allocation(s)" from this very number, and only collapses it to a boolean
+        // for its own pass/fail.
+        //
+        // A count is also the stronger guard of the two available: the 20 KB byte budget
+        // this test used to carry would have admitted an extra Substring per call
+        // (~78 B x 100 = ~7.8 KB) even on a runtime where the byte counter worked.
         static int GCAllocationsDuring(Action action)
         {
             var recorder = Recorder.Get("GC.Alloc");
 
             // Disabling first flushes the samples Recorder.Get itself produced, so they are
-            // not counted against the delegate. Unity's constraint does the same, for the
-            // same reason. The delegate is allocated at the call site, outside this region.
+            // not counted against the delegate. The whole sequence mirrors
+            // AllocatingGCMemoryConstraint.ApplyTo, WebGL guards included, so that the count
+            // read here and the constraint's own verdict can never disagree about what was
+            // measured. The delegate is allocated at the call site, outside this region.
             recorder.enabled = false;
+#if !UNITY_WEBGL
             recorder.FilterToCurrentThread();
+#endif
             recorder.enabled = true;
             try
             {
@@ -92,7 +147,9 @@ namespace VoXR.Tests.Runtime
             finally
             {
                 recorder.enabled = false;
+#if !UNITY_WEBGL
                 recorder.CollectFromAllThreads();
+#endif
             }
 
             return recorder.sampleBlockCount;

--- a/Tests~/Runtime/ZeroAllocPollPathTests.cs
+++ b/Tests~/Runtime/ZeroAllocPollPathTests.cs
@@ -1,20 +1,27 @@
 using System;
 using System.Text;
 using NUnit.Framework;
+using UnityEngine.Profiling;
+using UnityEngine.TestTools.Constraints;
 using VoXR;
+// UnityEngine.TestTools.Constraints.Is derives from NUnit's and adds AllocatingGCMemory().
+// Aliased because both namespaces export the name.
+using Is = UnityEngine.TestTools.Constraints.Is;
 
 namespace VoXR.Tests.Runtime
 {
     // Regression guard for the zero-alloc parsing hot path. The poll loop should
     // allocate only the leaf string returned to consumers — anything else
     // (Substring, boxing, freshly allocated key arrays) is a regression.
+    //
+    // Both tests below measure through Unity's GC.Alloc profiler recorder, NOT through
+    // GC.GetAllocatedBytesForCurrentThread. That counter is INERT on this runtime —
+    // measured at 0 B moved after a deliberate 1 MB allocation — so the byte-delta
+    // assertions this file was written with read zero whatever the code does, and both
+    // passed unconditionally from the day they were written (issue #105).
     public class ZeroAllocPollPathTests
     {
-        // Sized for the fixed test input below ("hello world" = 11 chars). On Mono
-        // a managed string costs ~56 B header + 2*length bytes ≈ 78 B → ~7.8 KB / 100
-        // calls. 20 KB budget gives headroom for slightly longer inputs without
-        // becoming flaky from per-test JIT or static-init noise.
-        const long PartialBudget = 20_000;
+        const int Iterations = 100;
 
         [Test]
         public void ParsingPartialJson_AllocatesOnlyTheReturnedString()
@@ -24,15 +31,22 @@ namespace VoXR.Tests.Runtime
             // Warm up — first call may JIT/touch statics.
             VoxrJsonParser.ParseTextFromJson(json, isFinal: false);
 
-            long before = GC.GetAllocatedBytesForCurrentThread();
-            for (int i = 0; i < 100; i++)
-                VoxrJsonParser.ParseTextFromJson(json, isFinal: false);
-            long delta = GC.GetAllocatedBytesForCurrentThread() - before;
+            int allocations = GCAllocationsDuring(() =>
+            {
+                for (int i = 0; i < Iterations; i++)
+                    VoxrJsonParser.ParseTextFromJson(json, isFinal: false);
+            });
 
-            // Each call returns one managed string (the partial text). Anything beyond
-            // that is a regression — e.g. an inadvertent Substring or boxed value type.
-            Assert.Less(delta, PartialBudget,
-                $"Allocated {delta} B over 100 calls; expected < {PartialBudget} B.");
+            // Each call returns one managed string (the partial text) and is allowed
+            // exactly that one allocation. Anything beyond it — an inadvertent Substring,
+            // a boxed value type, a freshly built key array — shows up as a second
+            // allocation per call and fails here.
+            Assert.AreEqual(
+                Iterations,
+                allocations,
+                $"{allocations} GC allocation(s) over {Iterations} calls; expected exactly "
+                    + $"{Iterations} — one returned string per call and nothing else."
+            );
         }
 
         [Test]
@@ -42,13 +56,46 @@ namespace VoXR.Tests.Runtime
 
             VoxrJsonParser.ParseErrorCode(json);  // warm up
 
-            long before = GC.GetAllocatedBytesForCurrentThread();
-            for (int i = 0; i < 100; i++)
-                VoxrJsonParser.ParseErrorCode(json);
-            long delta = GC.GetAllocatedBytesForCurrentThread() - before;
+            // Returns an enum (value type), so nothing at all is permitted and Unity's
+            // zero-or-fail constraint expresses it exactly.
+            Assert.That(
+                () =>
+                {
+                    for (int i = 0; i < Iterations; i++)
+                        VoxrJsonParser.ParseErrorCode(json);
+                },
+                Is.Not.AllocatingGCMemory()
+            );
+        }
 
-            // Returns an enum (value type), no allocations expected at all.
-            Assert.AreEqual(0, delta, $"Allocated {delta} B; expected exactly 0.");
+        // Is.Not.AllocatingGCMemory() is zero-or-fail and expresses no budget, so the
+        // partial-JSON test — which must permit the one string it returns — reads the same
+        // recorder that constraint is itself built on (AllocatingGCMemoryConstraint uses
+        // Recorder.Get("GC.Alloc") and sampleBlockCount) and asserts on the COUNT instead.
+        // A count is the stronger guard of the two available: the 20 KB byte budget this
+        // test used to carry would have admitted an extra Substring per call (~78 B × 100
+        // = ~7.8 KB) even on a runtime where the byte counter worked.
+        static int GCAllocationsDuring(Action action)
+        {
+            var recorder = Recorder.Get("GC.Alloc");
+
+            // Disabling first flushes the samples Recorder.Get itself produced, so they are
+            // not counted against the delegate. Unity's constraint does the same, for the
+            // same reason. The delegate is allocated at the call site, outside this region.
+            recorder.enabled = false;
+            recorder.FilterToCurrentThread();
+            recorder.enabled = true;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                recorder.enabled = false;
+                recorder.CollectFromAllThreads();
+            }
+
+            return recorder.sampleBlockCount;
         }
     }
 }


### PR DESCRIPTION
Closes #105

## What

`Tests~/Runtime/ZeroAllocPollPathTests.cs` moves off `GC.GetAllocatedBytesForCurrentThread` and onto Unity's GC.Alloc profiler recorder.

- **`ParsingErrorCode_AllocatesNothing`** — the mechanical swap the issue specified. It returns an enum and should allocate nothing at all, so `Is.Not.AllocatingGCMemory()` expresses it exactly.
- **`ParsingPartialJson_AllocatesOnlyTheReturnedString`** — the half the issue left open. Took **option 3, allocation count rather than bytes**; rationale below.
- `PartialBudget` (the 20 KB byte budget) is deleted.
- A comment in `VoxrCommandParserTests.cs` (~:4676) said `ZeroAllocPollPathTests` "is left alone here… reported on the PR rather than fixed in passing." This PR makes that false, so it now points at #105 instead. That is the only reason that file is in the diff — no test in it changed.

No `CHANGELOG.md` entry: `Tests~/` is not shipped, so this is not user-facing.

## Why

The issue's premise is confirmed. Both assertions compared a number that was always `0`, and had since `44d364f` (2026-04-29).

**Why option 3 for the partial-JSON test.** The deciding fact came from reading Unity's own constraint source — `AllocatingGCMemoryConstraint.cs` is *itself* built on `Recorder.Get("GC.Alloc")` + `sampleBlockCount`, which is an allocation **count**. So the count-based assertion is not a new, unvalidated instrument; it is the exact mechanism already mutation-proven in this repo by #104's `EagerSelection_OverASiblingTie_AllocatesNothingPerCall`. That ruled out option 2 (hunting for a byte-reporting instrument) as strictly more risk for less.

A count also states the intent — "one string per call, nothing else" — more precisely than the budget did, and is the **stronger** guard: an inadvertent `Substring` per call costs ~78 B x 100 = ~7.8 KB, comfortably under the old 20 KB budget. That budget would have passed the very regression it was written to catch *even on a runtime where the byte counter worked*.

Option 1 was rejected because the only input that skips the string allocation is an empty partial value, which returns `string.Empty` before the slice — it would pin the key search but not the value extraction, where the regression the test names would live. Option 4 (delete) discards a guard that turns out to be cheap to make real.

## Validation

- [x] **Unity PlayMode 526/526, EditMode 132/132**, host `VoXR TestGround` (6000.4.7f1). Both suites green, `failed="0"` with nonzero totals. No compile errors.
- [x] **Mutation-verified — this is the part that matters.** A first-try green proves nothing here; it is the exact shape of the bug being fixed. Adding one throwaway allocation per call to `ParseErrorCode` and `ParseStringValue` (stored to a static so the JIT cannot elide it, behaviour-neutral) makes both tests fail:
  - `ParsingPartialJson_AllocatesOnlyTheReturnedString` → `Expected: 100 / But was: 200`
  - `ParsingErrorCode_AllocatesNothing` → `Expected: not allocates GC memory`
  - Blast radius was exactly those two of 526 — no other test guards this path.
  - Sensitivity is to a **single one-byte array per call**, so any realistic regression is caught. The mutation is reverted; `Runtime/VoxrJsonParser.cs` is unchanged in this diff.
- [x] Confirmed no other **test** reads `GC.GetAllocatedBytesForCurrentThread` (the issue's "also worth checking" item) — no call site remains in tracked test code. Scoped deliberately: the default `grep` here honours `.gitignore`, so it cannot see `Planning~/`, where the A/B rig still reads the counter at `ab-rig/Program.cs:196,202`. That is out of scope and harmless — the rig is a `net10.0` console app running on CoreCLR, where the counter works.
- [ ] Not covered: this proves the instrument fires under **PlayMode/Mono in batch mode**. It says nothing about IL2CPP or device builds, where allocation accounting can differ.

## For the reviewer

The open decision was mine to make and is the thing worth ruling on: **`Assert.AreEqual(100, allocations)` pins an exact count, so it fails if the parse path ever allocates fewer objects too**, not just more. That is deliberate — a drop would mean `Encoding.UTF8.GetString` stopped returning a fresh string, which is worth knowing — but if you would rather it were one-directional, `Assert.LessOrEqual` is a one-line change.
