### PR TITLE
Pin the HoldExtendable -> None transition the leading-miss bar introduces (#127)

### DIFF
--- a/Runtime/Commands/VoxrCommandParser.cs
+++ b/Runtime/Commands/VoxrCommandParser.cs
@@ -4462,6 +4462,13 @@ namespace VoXR.Commands
             // commit early anyway. There is nothing to refuse when nothing was being offered,
             // and a refusal must not lengthen a wait it is not responsible for. Here the only
             // transition it introduces is Commit -> None.
+            //
+            // That principle is not absolute, though: the leading-required-miss bar above does
+            // convert HoldExtendable into None, and that is a ruled exception (issue #127,
+            // accepted permanently). A barred candidate produces no result at any length of
+            // wait, so the only cost there is how soon the speaker is told — whereas a tied
+            // candidate may still fire after the wait, which is what makes lengthening it
+            // pointless here.
             if (bestTiedSiblingCommandIdx >= 0)
                 return EagerCommitVerdict.None;
 

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -969,6 +969,105 @@ namespace VoXR.Tests.Runtime
             );
         }
 
+        [Test]
+        public void TryEagerCommit_LeadingRequiredMiss_ExtendablePattern_StillReturnsNone()
+        {
+            // Pins the HoldExtendable -> None transition the bar introduces, at the second of
+            // the two hold returns: the extendable-pattern one (issue #32). The bar sits ABOVE
+            // both hold returns, so a barred winner that would otherwise have been HELD is
+            // refused outright instead — which lengthens the wait before OnUnrecognisedSpeech
+            // from prefixHoldSeconds to the full bufferWindow.
+            //
+            // That transition is deliberate and ruled (issue #127, accepted permanently). DR-5
+            // places the bar beside the #66/#70 completeness refusals — they are all refusals
+            // about the candidate itself — and moving it below the hold returns to preserve the
+            // shortened hold would be a design change, not a bug fix. The cost is latency only:
+            // a barred candidate produces no result at any length of wait, so the only thing the
+            // longer wait delays is how soon the speaker is told. At the shipped default
+            // prefixHoldSeconds = 0 there is no shortened hold to lose, so it is inert there.
+            //
+            // The fixture: "advance"'s only pattern is a proper prefix of "advance_more"'s, so
+            // CanCommitEarly reports false for it and the winner reaches the extendable hold
+            // return. Everything between the bar and that return is cleared deliberately —
+            // score (1 + 1) / 3 = 0.667 clears the 0.6 gate; there are no slots at all, so the
+            // issue #66 condition cannot bite; the miss is LEADING, so "bravo" and "charlie"
+            // match after it and no required TAIL remains (issue #70); and the match spans the
+            // whole buffer. "advance_more" cannot steal the win on the barred utterance — its
+            // unspoken "delta" drags it to (1 + 1) / 4 = 0.5, under the gate and under 0.667.
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(
+                    Cmd("advance", P("alpha", "bravo", "charlie")),
+                    Cmd("advance_more", P("alpha", "bravo", "charlie", "delta"))
+                )
+            );
+
+            Assert.AreEqual(
+                EagerCommitVerdict.None,
+                parser.TryEagerCommit(Tok("bravo charlie"), null, 0.6f, 0.4f),
+                "the bar outranks the extendable hold — a barred winner is refused, not held"
+            );
+
+            // Control, on the same grammar, and the whole point of the test: with the leading
+            // element present the very same winning pattern reaches the extendable hold return
+            // and answers HoldExtendable. Without this the assertion above could go green from
+            // any refusal at all, and would not show that the fixture reaches a HOLD — i.e.
+            // that the bar really is converting HoldExtendable into None, rather than sitting
+            // above a None that would have happened anyway.
+            Assert.AreEqual(
+                EagerCommitVerdict.HoldExtendable,
+                parser.TryEagerCommit(Tok("alpha bravo charlie"), null, 0.6f, 0.4f),
+                "unbarred, the same winner is held because its pattern is a prefix of a longer one"
+            );
+        }
+
+        [Test]
+        public void TryEagerCommit_LeadingRequiredMiss_UnanalysableGrammar_StillReturnsNone()
+        {
+            // The same HoldExtendable -> None transition, at the FIRST hold return: the
+            // un-analysable-grammar degrade (issue #44). Both tests are needed because the two
+            // hold returns are separate lines — an edit that moved the bar to sit BETWEEN them
+            // would leave one of these green and flip the other, so neither one pins the
+            // transition on its own.
+            //
+            // Deliberate and ruled exactly as in the test above (issue #127, accepted
+            // permanently): DR-5 places the bar beside the #66/#70 completeness refusals, and
+            // moving it below the hold returns would be a design change, not a bug fix. The cost
+            // is latency only — a barred candidate produces no result however long the wait, so
+            // only the moment the speaker is told moves — and it is inert at the shipped default
+            // prefixHoldSeconds = 0.
+            //
+            // OverLimitCommand carries one optional past MaxOptionalExpansion, so the
+            // eligibility analysis is abandoned for the whole parser and _canCommitEarly is
+            // null; that is what puts hold return A in play here rather than B. It matches
+            // nothing in either utterance ("noisy" is never spoken), so "advance" still wins.
+            // The construction warns at authoring time (issue #44), hence the expectation
+            // before it and the sweep at the end.
+            LogAssert.Expect(LogType.Warning, new Regex("more than the 12"));
+
+            var parser = new VoxrCommandParser(
+                Slots(),
+                Commands(OverLimitCommand(), Cmd("advance", P("alpha", "bravo", "charlie")))
+            );
+
+            Assert.AreEqual(
+                EagerCommitVerdict.None,
+                parser.TryEagerCommit(Tok("bravo charlie"), null, 0.6f, 0.4f),
+                "the bar outranks the un-analysable degrade — a barred winner is refused, not held"
+            );
+
+            // Control: the same grammar with the leading element present cannot commit either,
+            // because the analysis that would have vetted a commit was abandoned — so it
+            // degrades to the hold instead of None. That is what makes the barred utterance's
+            // None attributable to the bar, and not to the missing analysis.
+            Assert.AreEqual(
+                EagerCommitVerdict.HoldExtendable,
+                parser.TryEagerCommit(Tok("alpha bravo charlie"), null, 0.6f, 0.4f),
+                "unbarred, the un-analysable grammar degrades to the hold rather than None"
+            );
+            LogAssert.NoUnexpectedReceived();
+        }
+
         // ---------- Back to the unfilled required slot (issue #66) ----------
 
         [Test]

--- a/Tests~/Runtime/VoxrEagerCommitTests.cs
+++ b/Tests~/Runtime/VoxrEagerCommitTests.cs
@@ -988,12 +988,18 @@ namespace VoXR.Tests.Runtime
             //
             // The fixture: "advance"'s only pattern is a proper prefix of "advance_more"'s, so
             // CanCommitEarly reports false for it and the winner reaches the extendable hold
-            // return. Everything between the bar and that return is cleared deliberately —
-            // score (1 + 1) / 3 = 0.667 clears the 0.6 gate; there are no slots at all, so the
-            // issue #66 condition cannot bite; the miss is LEADING, so "bravo" and "charlie"
-            // match after it and no required TAIL remains (issue #70); and the match spans the
-            // whole buffer. "advance_more" cannot steal the win on the barred utterance — its
-            // unspoken "delta" drags it to (1 + 1) / 4 = 0.5, under the gate and under 0.667.
+            // return. Gates are cleared deliberately on BOTH sides of the bar, for two different
+            // reasons. Above it, so that the bar is the first refusal and not a late one standing
+            // behind an earlier verdict: score (1 + 1) / 3 = 0.667 clears the 0.6 gate; there are
+            // no slots at all, so the issue #66 condition cannot bite; and the miss is LEADING,
+            // so "bravo" and "charlie" match after it and no required TAIL remains (issue #70).
+            // Below it, so that the control at the end of this test reaches the hold rather than
+            // some other refusal: the match spans the whole buffer, and the confidence gate is
+            // inert because both calls pass a null wordConfidence, which makes ComputeConfidence
+            // return -1f.
+            //
+            // "advance_more" cannot steal the win on the barred utterance — its unspoken "delta"
+            // drags it to (1 + 1) / 4 = 0.5, under the gate and under 0.667.
             var parser = new VoxrCommandParser(
                 Slots(),
                 Commands(
@@ -1008,12 +1014,23 @@ namespace VoXR.Tests.Runtime
                 "the bar outranks the extendable hold — a barred winner is refused, not held"
             );
 
-            // Control, on the same grammar, and the whole point of the test: with the leading
-            // element present the very same winning pattern reaches the extendable hold return
-            // and answers HoldExtendable. Without this the assertion above could go green from
-            // any refusal at all, and would not show that the fixture reaches a HOLD — i.e.
-            // that the bar really is converting HoldExtendable into None, rather than sitting
-            // above a None that would have happened anyway.
+            // Control, on the same grammar: with the leading element present the very same
+            // winning pattern reaches the extendable hold return and answers HoldExtendable.
+            //
+            // Be exact about what this does and does not establish, because it is easy to credit
+            // it with more. It rules out "this grammar can never hold at all" — the case where a
+            // bar that refused everything would pass the assertion above, which is how the issue
+            // #125 pin words its own control. It does NOT establish that the BARRED utterance
+            // reached a hold. That is a different input, and the whole-buffer span gate sitting
+            // between the bar and the hold returns is input-dependent: a barred call refused
+            // THERE would also read None while this control still read HoldExtendable, and both
+            // assertions would pass with the bar deleted. TryEagerCommit_LeadingRecognisedLeftover_StillReturnsNone
+            // above is exactly that shape — a span-gate None on a grammar that can hold.
+            //
+            // What establishes the transition is mutation, recorded here because it lives
+            // nowhere else in the file: relocating the bar below both hold returns turns the
+            // assertion above red with "Expected: None / But was: HoldExtendable", and no other
+            // test in the suite moves.
             Assert.AreEqual(
                 EagerCommitVerdict.HoldExtendable,
                 parser.TryEagerCommit(Tok("alpha bravo charlie"), null, 0.6f, 0.4f),
@@ -1026,9 +1043,14 @@ namespace VoXR.Tests.Runtime
         {
             // The same HoldExtendable -> None transition, at the FIRST hold return: the
             // un-analysable-grammar degrade (issue #44). Both tests are needed because the two
-            // hold returns are separate lines — an edit that moved the bar to sit BETWEEN them
-            // would leave one of these green and flip the other, so neither one pins the
-            // transition on its own.
+            // hold returns are separate lines and each test guards only one — but it takes TWO
+            // mutations to show that, and one of them alone would mislead. Relocating the bar to
+            // sit BETWEEN the two returns reddens this test and leaves the extendable one green.
+            // Narrowing the bar to (bestLeadingRequiredMissed && _canCommitEarly == null) does
+            // the reverse: this test still refuses, and the extendable one falls through to its
+            // own hold return and goes red. Each test is blind to one of those two edits, which
+            // is what "neither pins the transition on its own" actually rests on — not on the
+            // first mutation alone, which reddens this test as well.
             //
             // Deliberate and ruled exactly as in the test above (issue #127, accepted
             // permanently): DR-5 places the bar beside the #66/#70 completeness refusals, and
@@ -1058,8 +1080,12 @@ namespace VoXR.Tests.Runtime
 
             // Control: the same grammar with the leading element present cannot commit either,
             // because the analysis that would have vetted a commit was abandoned — so it
-            // degrades to the hold instead of None. That is what makes the barred utterance's
-            // None attributable to the bar, and not to the missing analysis.
+            // degrades to the hold instead of None. The same precision as in the test above
+            // applies: this rules out "this grammar can never hold at all", but it does not by
+            // itself establish that the barred utterance reached the degrade, that being a
+            // different input. The mutation is what does — relocating the bar below both hold
+            // returns turns the assertion above red with
+            // "Expected: None / But was: HoldExtendable".
             Assert.AreEqual(
                 EagerCommitVerdict.HoldExtendable,
                 parser.TryEagerCommit(Tok("alpha bravo charlie"), null, 0.6f, 0.4f),


### PR DESCRIPTION
Closes #127

## What

Test-only, plus one comment. **No runtime behaviour changes.**

Two pin tests in `Tests~/Runtime/VoxrEagerCommitTests.cs`, both PlayMode, one per `HoldExtendable` return in `TryEagerCommit`:

- `TryEagerCommit_LeadingRequiredMiss_ExtendablePattern_StillReturnsNone` — guards hold return B (`!CanCommitEarly(...)`, issue #32)
- `TryEagerCommit_LeadingRequiredMiss_UnanalysableGrammar_StillReturnsNone` — guards hold return A (`_canCommitEarly == null`, issue #44)

Each pairs the barred assertion with a **control on the same grammar** whose leading element is present. The control rules out *"this grammar can never hold at all"* — the case where a bar refusing everything would pass the barred assertion. It does **not** by itself establish that the barred utterance reached a hold, since that is a different input and the whole-buffer span gate between the bar and the hold returns is input-dependent. What establishes the transition is the **mutation** recorded below, and each test's comment now carries that mutation and its observed values, so the evidence lives beside the assertion rather than only here.

One comment paragraph (two sentences) appended to the sibling-tie refusal's comment in `Runtime/Commands/VoxrCommandParser.cs`, noting that its principle — *"a refusal must not lengthen a wait it is not responsible for"* — is not absolute, that the leading-miss bar ~60 lines above is a ruled exception, and why the two cases differ.

## Why

#127 reports that the bar sits above both hold returns, so a barred winner that would have been *held* is refused outright, stretching the wait before `OnUnrecognisedSpeech` from `prefixHoldSeconds` to the full `bufferWindow`.

**That behaviour was already ruled and is deliberately left alone.** Option 1 — accept permanently — was ruled at item 3 of the #124 backlog (`Planning~/features/leading-miss-warning/requirements.md:125`, and recorded in #130). Options 2 and 3 are runtime timing changes needing a design amendment, and are not in scope here.

What was left unbuilt is the issue's **"Also unpinned"** section, which the same ruling explicitly kept open: *"#127's 'also unpinned' note — that no test covers the `HoldExtendable -> None` transition — stays open with the issue."*

The transition is also a **published** guarantee: the shipped `[Unreleased]` CHANGELOG entry for #124 states *"the eager gate refuses a leading-missed candidate before it can arm the shortened hold, so such an utterance now waits the full `bufferWindow`"*. Nothing tested it. This is the same family as #128's three published-but-unguarded guarantees.

Two tests rather than one because the two hold returns are separate lines and each test guards only one — which takes **two** mutations to demonstrate, since the between-returns relocation alone reddens the un-analysable test too.

## Validation

- [x] **Unity EditMode — 133/133 passed**, `failed="0"` (host project `VoXR TestGround`, Unity 6000.4.7f1, package referenced by local path)
- [x] **Unity PlayMode — 585/585 passed**, `failed="0"`; both new tests confirmed present by name in the results XML and `result="Passed"` (not merely absent from the failure list)
- [x] **Mutation-verified — the pins can be made red, and each guards a distinct return.** Moving the bar below *both* hold returns failed *both* tests, each reporting `Expected: None / But was: HoldExtendable`, with no other test in the 585 affected. Moving it *between* the two returns failed only the un-analysable-grammar test and left the extendable-pattern test passing.
- [ ] On-device (Quest) check: **not applicable.** The only `Runtime/` change is a comment; no parsing, scoring, firing, lifecycle or native-bridge behaviour moves.

Two limits worth stating rather than glossing:

- NUnit aborts a test method at its first failing assertion, so under the both-returns mutation each test stopped at its barred assertion and its *control* assertion did not execute in that run. The controls are observed green in the unmutated suite and under the between-returns mutation; they are not separately observed under the first mutation.
- The narrowing mutation now cited in the second test's comment — `bestLeadingRequiredMissed && _canCommitEarly == null`, which would spare that test and redden the extendable one — is **derived, not run**. The two mutations that were actually executed are the two reported above.

No CHANGELOG entry — the behaviour is already published there under #124 and is unchanged by this PR.

---

*Updated after the `review-pr` pass: four findings, all confirmed, all of them prose claims wider than their evidence rather than defects in the tests. Fixes in `acce4fa`.*
